### PR TITLE
fix: skip version check when no subcommand is provided

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -10,7 +10,9 @@ if (process.env.CALIBER_LOCAL) {
   process.env.CALIBER_SKIP_UPDATE_CHECK = '1';
 }
 
-const isQuickExit = ['--version', '-V', '--help', '-h'].some(f => process.argv.includes(f));
+const userArgs = process.argv.slice(2);
+const hasCommand = userArgs.some(a => !a.startsWith('-'));
+const isQuickExit = !hasCommand || ['--version', '-V', '--help', '-h'].some(f => userArgs.includes(f));
 if (!isQuickExit) {
   await checkForUpdates();
 }


### PR DESCRIPTION
## Summary

- Fixes UV_HANDLE_CLOSING assertion failure on Windows when running `caliber` with no arguments
- Expands quick-exit detection to skip `checkForUpdates()` when no positional command argument is present (e.g. `caliber`, `caliber --no-traces`)
- Previously only `--version`, `-V`, `--help`, `-h` flags were detected as quick exits

## Root Cause

When `caliber` is run without a subcommand, Commander.js auto-displays help and exits. The `checkForUpdates()` fetch creates async handles that are still pending at exit time, causing `libuv` to throw an assertion error on Windows.

## Test plan

- [x] All 313 existing tests pass
- [ ] Verify `caliber` (no args) no longer crashes on Windows
- [ ] Verify `caliber --no-traces` (no subcommand) also skips the check
- [ ] Verify `caliber init` still runs the update check normally

Closes #14