### PR TITLE
ci: add next branch pre-release publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   pull_request:
-    branches: [master]
+    branches: [master, next]
   push:
-    branches: [master]
+    branches: [master, next]
 
 permissions:
   contents: read

--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -1,0 +1,69 @@
+name: Publish next to npm
+
+on:
+  push:
+    branches: [next]
+
+jobs:
+  publish-next:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - run: npm ci
+      - run: npm test
+      - run: npm run build
+
+      - name: Smoke test build
+        run: |
+          node dist/bin.js --version
+          node dist/bin.js --help
+
+      - name: Determine pre-release version
+        id: version
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 --match "v*" 2>/dev/null || echo "")
+
+          if [ -z "$LAST_TAG" ]; then
+            BASE_VERSION=$(node -p "require('./package.json').version")
+          else
+            COMMITS=$(git log "${LAST_TAG}..HEAD" --format="%s")
+
+            if [ -z "$COMMITS" ]; then
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+              echo "No new commits since ${LAST_TAG}"
+              exit 0
+            fi
+
+            BUMP="patch"
+            if echo "$COMMITS" | grep -qE "^.+!:|BREAKING CHANGE"; then
+              BUMP="major"
+            elif echo "$COMMITS" | grep -qE "^feat(\(.+\))?:"; then
+              BUMP="minor"
+            fi
+
+            npm version "$BUMP" --no-git-tag-version
+            BASE_VERSION=$(node -p "require('./package.json').version")
+          fi
+
+          TIMESTAMP=$(date +%s)
+          NEW_VERSION="${BASE_VERSION}-next.${TIMESTAMP}"
+
+          npm version "$NEW_VERSION" --no-git-tag-version
+          echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Publishing v${NEW_VERSION} to @next"
+
+      - name: Publish with next tag
+        if: steps.version.outputs.skip != 'true'
+        run: npm publish --access public --tag next
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,13 +40,36 @@ npm run build    # Compile
 - Tests live in `__tests__/` directories next to their source
 - Global LLM mocks are in `src/test/setup.ts`
 
+## Release channels
+
+Caliber has two release channels:
+
+| Branch | npm tag | Version format | Install |
+|--------|---------|----------------|---------|
+| `master` | `latest` | `1.20.0` | `npm i @rely-ai/caliber` |
+| `next` | `next` | `1.20.0-next.1742140800` | `npm i @rely-ai/caliber@next` |
+
+- **`master`** — stable releases. Merging here auto-publishes the official version.
+- **`next`** — pre-release channel for testing risky or in-progress changes. Pushing here auto-publishes a dev version that won't affect `latest`.
+
+### Testing with the next channel
+
+```bash
+# Install the latest pre-release
+npm i @rely-ai/caliber@next
+
+# Or run directly
+npx @rely-ai/caliber@next score
+```
+
 ## Pull requests
 
-1. Fork the repo and create a branch from `main`
+1. Fork the repo and create a branch from `master`
 2. Make your changes
 3. Add tests for new functionality
 4. Run `npm run test` and `npx tsc --noEmit`
 5. Use [conventional commits](https://www.conventionalcommits.org/): `feat:`, `fix:`, `refactor:`, `chore:`
+6. For risky changes, target the `next` branch instead of `master` to publish a pre-release first
 
 ## Reporting issues
 


### PR DESCRIPTION
## Summary
- Add `publish-next.yml` workflow: publishes pre-release versions with `@next` npm tag on push to the `next` branch (e.g. `1.20.0-next.1742140800`)
- Update `ci.yml` to run CI on the `next` branch (PRs and pushes)
- Update `CONTRIBUTING.md` with release channels documentation

## How it works
| Branch | npm tag | Version format | Install |
|--------|---------|----------------|---------|
| `master` | `latest` | `1.20.0` | `npm i @rely-ai/caliber` |
| `next` | `next` | `1.20.0-next.<timestamp>` | `npm i @rely-ai/caliber@next` |

Push risky changes to `next` → auto-publishes a dev version that never touches `latest`. Merge `next` → `master` when ready → publishes the official version as usual.

## Test plan
- [ ] Merge this PR to master
- [ ] Create `next` branch from master and push it
- [ ] Push a test commit to `next` and verify the workflow publishes a `-next.*` version with `--tag next`
- [ ] Verify `npm info @rely-ai/caliber` shows `latest` unchanged and `next` pointing to the pre-release