### PR TITLE
fix(ci): use @dev npm dist-tag for pre-releases

### DIFF
--- a/.github/workflows/publish-next.yml
+++ b/.github/workflows/publish-next.yml
@@ -56,14 +56,14 @@ jobs:
           fi
 
           TIMESTAMP=$(date +%s)
-          NEW_VERSION="${BASE_VERSION}-next.${TIMESTAMP}"
+          NEW_VERSION="${BASE_VERSION}-dev.${TIMESTAMP}"
 
           npm version "$NEW_VERSION" --no-git-tag-version
           echo "version=${NEW_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "Publishing v${NEW_VERSION} to @next"
+          echo "Publishing v${NEW_VERSION} to @dev"
 
-      - name: Publish with next tag
+      - name: Publish with dev tag
         if: steps.version.outputs.skip != 'true'
-        run: npm publish --access public --tag next
+        run: npm publish --access public --tag dev
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,19 +47,19 @@ Caliber has two release channels:
 | Branch | npm tag | Version format | Install |
 |--------|---------|----------------|---------|
 | `master` | `latest` | `1.20.0` | `npm i @rely-ai/caliber` |
-| `next` | `next` | `1.20.0-next.1742140800` | `npm i @rely-ai/caliber@next` |
+| `next` | `dev` | `1.20.0-dev.1742140800` | `npm i @rely-ai/caliber@dev` |
 
 - **`master`** — stable releases. Merging here auto-publishes the official version.
 - **`next`** — pre-release channel for testing risky or in-progress changes. Pushing here auto-publishes a dev version that won't affect `latest`.
 
-### Testing with the next channel
+### Testing with the dev channel
 
 ```bash
 # Install the latest pre-release
-npm i @rely-ai/caliber@next
+npm i @rely-ai/caliber@dev
 
 # Or run directly
-npx @rely-ai/caliber@next score
+npx @rely-ai/caliber@dev score
 ```
 
 ## Pull requests


### PR DESCRIPTION
## Summary
- Change npm dist-tag from `@next` to `@dev` for pre-release versions published from the `next` branch
- Update version format from `-next.<ts>` to `-dev.<ts>`
- Update CONTRIBUTING.md to reflect `@dev` install commands