### PR TITLE
feat: replace pre-commit hooks with config-file instructions

### DIFF
--- a/src/commands/hooks.ts
+++ b/src/commands/hooks.ts
@@ -52,6 +52,11 @@ function printStatus() {
 // --- Interactive mode (default when running `caliber hooks`) ---
 
 export async function hooksCommand(options: { install?: boolean; remove?: boolean }) {
+  if (!options.install && !options.remove) {
+    console.log(chalk.dim('\n  Note: caliber now adds refresh instructions directly to config files.'));
+    console.log(chalk.dim('  These hooks are available for non-agent workflows (manual commits).\n'));
+  }
+
   if (options.install) {
     for (const hook of HOOKS) {
       const result = hook.install();

--- a/src/commands/init-prompts.ts
+++ b/src/commands/init-prompts.ts
@@ -12,7 +12,6 @@ import { promptReviewMethod, openReview } from '../utils/review.js';
 import type { StageResult } from '../writers/staging.js';
 
 export type TargetAgent = ('claude' | 'cursor' | 'codex' | 'github-copilot')[];
-export type HookChoice = 'claude' | 'precommit' | 'both' | 'skip';
 type ReviewAction = 'accept' | 'refine' | 'decline';
 
 export function detectAgents(dir: string): TargetAgent {
@@ -46,23 +45,6 @@ export async function promptAgent(detected?: TargetAgent): Promise<TargetAgent> 
     },
   });
   return selected;
-}
-
-export async function promptHookType(targetAgent: TargetAgent): Promise<HookChoice> {
-  const choices: Array<{ name: string; value: HookChoice }> = [];
-  const hasClaude = targetAgent.includes('claude');
-
-  choices.push({ name: 'Git pre-commit hook — refresh before each commit (recommended)', value: 'precommit' });
-  if (hasClaude) {
-    choices.push({ name: 'Claude Code hook — auto-refresh on session end', value: 'claude' });
-    choices.push({ name: 'Both (pre-commit + Claude Code)', value: 'both' });
-  }
-  choices.push({ name: 'Skip for now', value: 'skip' });
-
-  return select({
-    message: 'Keep your AI docs & skills in sync as your code evolves?',
-    choices,
-  });
 }
 
 export async function promptLearnInstall(targetAgent: TargetAgent): Promise<boolean> {

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -8,7 +8,6 @@ import { generateSetup, generateSkillsForSetup } from '../ai/generate.js';
 import { writeSetup, undoSetup } from '../writers/index.js';
 import { stageFiles, cleanupStaging } from '../writers/staging.js';
 import { collectSetupFiles } from './setup-files.js';
-import { installHook, installPreCommitHook } from '../lib/hooks.js';
 import { installLearningHooks, installCursorLearningHooks } from '../lib/learning-hooks.js';
 import { writeState, getCurrentHeadSha } from '../lib/state.js';
 import { promptInput } from '../utils/prompt.js';
@@ -41,8 +40,8 @@ import {
   trackInitLearnEnabled,
 } from '../telemetry/events.js';
 
-import { detectAgents, promptAgent, promptHookType, promptLearnInstall, promptReviewAction, refineLoop } from './init-prompts.js';
-import type { TargetAgent, HookChoice } from './init-prompts.js';
+import { detectAgents, promptAgent, promptLearnInstall, promptReviewAction, refineLoop } from './init-prompts.js';
+import type { TargetAgent } from './init-prompts.js';
 import { formatProjectPreview, formatWhatChanged, printSetupSummary, displayTokenUsage } from './init-display.js';
 import { isFirstRun, summarizeSetup, ensurePermissions, writeErrorLog, evaluateDismissals } from './init-helpers.js';
 
@@ -625,71 +624,10 @@ export async function initCommand(options: InitOptions) {
     }
   }
 
-  // Auto-sync hooks (smart defaults: auto-install pre-commit on first run)
+  // Docs auto-refresh is now handled via instructions in generated config files
   console.log('');
-  let hookChoice: HookChoice;
-  if (options.autoApprove) {
-    hookChoice = 'skip';
-    log(options.verbose, 'Auto-approve: skipping hook installation');
-  } else if (firstRun) {
-    // Auto-install pre-commit hook on first run
-    const precommitResult = installPreCommitHook();
-    if (precommitResult.installed) {
-      console.log(`  ${chalk.green('✓')} Pre-commit hook installed — docs refresh before each commit`);
-      console.log(chalk.dim('    Run ') + chalk.hex('#83D1EB')('caliber hooks --remove') + chalk.dim(' to disable'));
-      hookChoice = 'precommit';
-    } else if (precommitResult.alreadyInstalled) {
-      console.log(chalk.dim('  Pre-commit hook already installed'));
-      hookChoice = 'precommit';
-    } else {
-      hookChoice = 'skip';
-    }
-
-    // Ask about Claude hook only if Claude is a target
-    if (targetAgent.includes('claude')) {
-      const { default: select } = await import('@inquirer/select');
-      const wantsClaude = await select({
-        message: 'Also install Claude Code session hook? (auto-refresh on session end)',
-        choices: [
-          { name: 'Yes', value: true },
-          { name: 'No', value: false },
-        ],
-      });
-      if (wantsClaude) {
-        const hookResult = installHook();
-        if (hookResult.installed) {
-          console.log(`  ${chalk.green('✓')} Claude Code hook installed`);
-        }
-        hookChoice = hookChoice === 'precommit' ? 'both' : 'claude';
-      }
-    }
-  } else {
-    hookChoice = await promptHookType(targetAgent);
-    if (hookChoice === 'claude' || hookChoice === 'both') {
-      const hookResult = installHook();
-      if (hookResult.installed) {
-        console.log(`  ${chalk.green('✓')} Claude Code hook installed — docs update on session end`);
-        console.log(chalk.dim('    Run ') + chalk.hex('#83D1EB')('caliber hooks --remove') + chalk.dim(' to disable'));
-      } else if (hookResult.alreadyInstalled) {
-        console.log(chalk.dim('  Claude Code hook already installed'));
-      }
-    }
-    if (hookChoice === 'precommit' || hookChoice === 'both') {
-      const precommitResult = installPreCommitHook();
-      if (precommitResult.installed) {
-        console.log(`  ${chalk.green('✓')} Pre-commit hook installed — docs refresh before each commit`);
-        console.log(chalk.dim('    Run ') + chalk.hex('#83D1EB')('caliber hooks --remove') + chalk.dim(' to disable'));
-      } else if (precommitResult.alreadyInstalled) {
-        console.log(chalk.dim('  Pre-commit hook already installed'));
-      } else {
-        console.log(chalk.yellow('  Could not install pre-commit hook (not a git repository?)'));
-      }
-    }
-    if (hookChoice === 'skip') {
-      console.log(chalk.dim('  Skipped auto-sync hooks. Run ') + chalk.hex('#83D1EB')('caliber hooks --install') + chalk.dim(' later to enable.'));
-    }
-  }
-  trackInitHookSelected(hookChoice);
+  console.log(`  ${chalk.green('✓')} Docs auto-refresh          ${chalk.dim('agents run caliber refresh before commits')}`);
+  trackInitHookSelected('config-instructions');
 
   // Session Learning prompt
   const hasLearnableAgent = targetAgent.includes('claude') || targetAgent.includes('cursor');
@@ -731,14 +669,7 @@ export async function initCommand(options: InitOptions) {
   console.log(chalk.bold('  What was set up:\n'));
 
   console.log(`    ${done}  Config generated          ${title('caliber score')} ${chalk.dim('for full breakdown')}`);
-
-  const hooksInstalled = hookChoice !== 'skip';
-  if (hooksInstalled) {
-    const hookLabel = hookChoice === 'both' ? 'pre-commit + Claude Code' : hookChoice === 'precommit' ? 'pre-commit' : 'Claude Code';
-    console.log(`    ${done}  Auto-sync hooks           ${chalk.dim(hookLabel + ' — docs stay fresh automatically')}`);
-  } else {
-    console.log(`    ${skip}  Auto-sync hooks           ${title('caliber hooks --install')} to enable later`);
-  }
+  console.log(`    ${done}  Docs auto-refresh        ${chalk.dim('agents run caliber refresh before commits')}`);
 
   if (hasLearnableAgent) {
     if (enableLearn) {

--- a/src/scoring/checks/bonus.ts
+++ b/src/scoring/checks/bonus.ts
@@ -9,6 +9,7 @@ import {
   POINTS_LEARNED_CONTENT,
 } from '../constants.js';
 import { readFileOrNull } from '../utils.js';
+import { hasPreCommitBlock as checkPreCommitBlock } from '../../writers/pre-commit-block.js';
 
 function hasPreCommitHook(dir: string): boolean {
   try {
@@ -46,7 +47,13 @@ export function checkBonus(dir: string): Check[] {
     hookSources.push('git pre-commit');
   }
 
-  const hasHooks = hasClaudeHooks || hasPrecommit;
+  const claudeMd = readFileOrNull(join(dir, 'CLAUDE.md'));
+  const hasPreCommitBlock = claudeMd ? checkPreCommitBlock(claudeMd) : false;
+  if (hasPreCommitBlock) {
+    hookSources.push('config pre-commit instruction');
+  }
+
+  const hasHooks = hasClaudeHooks || hasPrecommit || hasPreCommitBlock;
   checks.push({
     id: 'hooks_configured',
     name: 'Hooks configured',
@@ -57,11 +64,11 @@ export function checkBonus(dir: string): Check[] {
     detail: hasHooks
       ? hookSources.join(', ')
       : 'No hooks configured',
-    suggestion: hasHooks ? undefined : 'Run `caliber hooks --install` for auto-refresh',
+    suggestion: hasHooks ? undefined : 'Run `caliber init` to add pre-commit instructions',
     fix: hasHooks ? undefined : {
       action: 'install_hooks',
       data: {},
-      instruction: 'Install caliber hooks for automatic config refresh on commits.',
+      instruction: 'Run caliber init to add pre-commit refresh instructions to config files.',
     },
   });
 

--- a/src/writers/__tests__/codex.test.ts
+++ b/src/writers/__tests__/codex.test.ts
@@ -16,7 +16,9 @@ describe('writeCodexConfig', () => {
     const written = writeCodexConfig({ agentsMd: '# Project\n\nInstructions here.' });
 
     expect(written).toEqual(['AGENTS.md']);
-    expect(fs.writeFileSync).toHaveBeenCalledWith('AGENTS.md', '# Project\n\nInstructions here.');
+    const content = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
+    expect(content).toContain('# Project\n\nInstructions here.');
+    expect(content).toContain('caliber:managed:pre-commit');
   });
 
   it('writes skills to .agents/skills/{name}/SKILL.md with frontmatter', () => {

--- a/src/writers/__tests__/cursor-skills.test.ts
+++ b/src/writers/__tests__/cursor-skills.test.ts
@@ -22,9 +22,9 @@ describe('writeCursorConfig — skills', () => {
 
     const written = writeCursorConfig(config);
 
-    expect(written).toHaveLength(2);
     expect(written).toContain(path.join('.cursor', 'skills', 'testing-guide', 'SKILL.md'));
     expect(written).toContain(path.join('.cursor', 'skills', 'deploy', 'SKILL.md'));
+    expect(written).toContain(path.join('.cursor', 'rules', 'caliber-pre-commit.mdc'));
 
     expect(fs.mkdirSync).toHaveBeenCalledWith(
       path.join('.cursor', 'skills', 'testing-guide'),
@@ -36,10 +36,10 @@ describe('writeCursorConfig — skills', () => {
     );
   });
 
-  it('returns empty array when no skills provided', () => {
+  it('writes pre-commit rule even when no skills provided', () => {
     const written = writeCursorConfig({});
-    expect(written).toHaveLength(0);
-    expect(fs.writeFileSync).not.toHaveBeenCalled();
+    expect(written).toHaveLength(1);
+    expect(written).toContain(path.join('.cursor', 'rules', 'caliber-pre-commit.mdc'));
   });
 
   it('writes both skills and legacy cursorrules when both are present', () => {
@@ -54,6 +54,7 @@ describe('writeCursorConfig — skills', () => {
 
     expect(written).toContain('.cursorrules');
     expect(written).toContain(path.join('.cursor', 'skills', 'my-skill', 'SKILL.md'));
-    expect(written).toHaveLength(2);
+    expect(written).toContain(path.join('.cursor', 'rules', 'caliber-pre-commit.mdc'));
+    expect(written).toHaveLength(3);
   });
 });

--- a/src/writers/__tests__/refresh.test.ts
+++ b/src/writers/__tests__/refresh.test.ts
@@ -18,7 +18,8 @@ describe('writeRefreshDocs', () => {
 
     expect(written).toContain('CLAUDE.md');
     const content = vi.mocked(fs.writeFileSync).mock.calls[0][1] as string;
-    expect(content).toBe('# Project\n\nUpdated content.\n');
+    expect(content).toContain('# Project\n\nUpdated content.');
+    expect(content).toContain('caliber:managed:pre-commit');
   });
 
   it('writes other doc types normally', () => {

--- a/src/writers/claude/index.ts
+++ b/src/writers/claude/index.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { appendPreCommitBlock } from '../pre-commit-block.js';
 
 interface ClaudeConfig {
   claudeMd: string;
@@ -10,7 +11,7 @@ interface ClaudeConfig {
 export function writeClaudeConfig(config: ClaudeConfig): string[] {
   const written: string[] = [];
 
-  fs.writeFileSync('CLAUDE.md', config.claudeMd);
+  fs.writeFileSync('CLAUDE.md', appendPreCommitBlock(config.claudeMd));
   written.push('CLAUDE.md');
 
   if (config.skills?.length) {

--- a/src/writers/codex/index.ts
+++ b/src/writers/codex/index.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { appendPreCommitBlock } from '../pre-commit-block.js';
 
 interface CodexConfig {
   agentsMd: string;
@@ -9,7 +10,7 @@ interface CodexConfig {
 export function writeCodexConfig(config: CodexConfig): string[] {
   const written: string[] = [];
 
-  fs.writeFileSync('AGENTS.md', config.agentsMd);
+  fs.writeFileSync('AGENTS.md', appendPreCommitBlock(config.agentsMd));
   written.push('AGENTS.md');
 
   if (config.skills?.length) {

--- a/src/writers/cursor/index.ts
+++ b/src/writers/cursor/index.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { getCursorPreCommitRule } from '../pre-commit-block.js';
 
 interface CursorConfig {
   cursorrules?: string;
@@ -16,15 +17,15 @@ export function writeCursorConfig(config: CursorConfig): string[] {
     written.push('.cursorrules');
   }
 
-  if (config.rules?.length) {
-    const rulesDir = path.join('.cursor', 'rules');
-    if (!fs.existsSync(rulesDir)) fs.mkdirSync(rulesDir, { recursive: true });
+  const preCommitRule = getCursorPreCommitRule();
+  const allRules = [...(config.rules || []), preCommitRule];
+  const rulesDir = path.join('.cursor', 'rules');
+  if (!fs.existsSync(rulesDir)) fs.mkdirSync(rulesDir, { recursive: true });
 
-    for (const rule of config.rules) {
-      const rulePath = path.join(rulesDir, rule.filename);
-      fs.writeFileSync(rulePath, rule.content);
-      written.push(rulePath);
-    }
+  for (const rule of allRules) {
+    const rulePath = path.join(rulesDir, rule.filename);
+    fs.writeFileSync(rulePath, rule.content);
+    written.push(rulePath);
   }
 
   if (config.skills?.length) {

--- a/src/writers/github-copilot/__tests__/index.test.ts
+++ b/src/writers/github-copilot/__tests__/index.test.ts
@@ -25,9 +25,9 @@ describe('writeGithubCopilotConfig', () => {
     });
 
     expect(written).toEqual(['.github/copilot-instructions.md']);
-    expect(fs.readFileSync('.github/copilot-instructions.md', 'utf-8')).toBe(
-      '# Project\n\nBuild with `npm run build`.',
-    );
+    const content = fs.readFileSync('.github/copilot-instructions.md', 'utf-8');
+    expect(content).toContain('# Project\n\nBuild with `npm run build`.');
+    expect(content).toContain('caliber:managed:pre-commit');
   });
 
   it('skips writing when instructions is empty', () => {

--- a/src/writers/github-copilot/index.ts
+++ b/src/writers/github-copilot/index.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { appendPreCommitBlock } from '../pre-commit-block.js';
 
 interface CopilotConfig {
   instructions: string;
@@ -11,7 +12,7 @@ export function writeGithubCopilotConfig(config: CopilotConfig): string[] {
 
   if (config.instructions) {
     fs.mkdirSync('.github', { recursive: true });
-    fs.writeFileSync(path.join('.github', 'copilot-instructions.md'), config.instructions);
+    fs.writeFileSync(path.join('.github', 'copilot-instructions.md'), appendPreCommitBlock(config.instructions));
     written.push('.github/copilot-instructions.md');
   }
 

--- a/src/writers/pre-commit-block.ts
+++ b/src/writers/pre-commit-block.ts
@@ -1,0 +1,39 @@
+const BLOCK_START = '<!-- caliber:managed:pre-commit -->';
+const BLOCK_END = '<!-- /caliber:managed:pre-commit -->';
+
+const MANAGED_DOC_PATHS = 'CLAUDE.md .claude/ .cursor/ .github/copilot-instructions.md AGENTS.md CALIBER_LEARNINGS.md';
+
+const PRE_COMMIT_BLOCK = `${BLOCK_START}
+## Before Committing
+
+Run \`caliber refresh\` before creating git commits to keep docs in sync with code changes.
+After it completes, stage any modified doc files before committing:
+
+\`\`\`bash
+caliber refresh && git add ${MANAGED_DOC_PATHS} 2>/dev/null
+\`\`\`
+${BLOCK_END}`;
+
+const CURSOR_RULE_FILENAME = 'caliber-pre-commit.mdc';
+
+const CURSOR_RULE_CONTENT = `---
+description: Run caliber refresh before git commits to keep docs in sync
+alwaysApply: true
+---
+Before creating git commits, run \`caliber refresh\` to update docs based on code changes,
+then stage modified doc files (${MANAGED_DOC_PATHS}).
+`;
+
+export function hasPreCommitBlock(content: string): boolean {
+  return content.includes(BLOCK_START);
+}
+
+export function appendPreCommitBlock(content: string): string {
+  if (hasPreCommitBlock(content)) return content;
+  const trimmed = content.trimEnd();
+  return trimmed + '\n\n' + PRE_COMMIT_BLOCK + '\n';
+}
+
+export function getCursorPreCommitRule(): { filename: string; content: string } {
+  return { filename: CURSOR_RULE_FILENAME, content: CURSOR_RULE_CONTENT };
+}

--- a/src/writers/refresh.ts
+++ b/src/writers/refresh.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import { appendPreCommitBlock } from './pre-commit-block.js';
 
 interface RefreshDocs {
   claudeMd?: string | null;
@@ -15,7 +16,7 @@ export function writeRefreshDocs(docs: RefreshDocs): string[] {
   const written: string[] = [];
 
   if (docs.claudeMd) {
-    fs.writeFileSync('CLAUDE.md', docs.claudeMd);
+    fs.writeFileSync('CLAUDE.md', appendPreCommitBlock(docs.claudeMd));
     written.push('CLAUDE.md');
   }
 
@@ -49,7 +50,7 @@ export function writeRefreshDocs(docs: RefreshDocs): string[] {
 
   if (docs.copilotInstructions) {
     fs.mkdirSync('.github', { recursive: true });
-    fs.writeFileSync(path.join('.github', 'copilot-instructions.md'), docs.copilotInstructions);
+    fs.writeFileSync(path.join('.github', 'copilot-instructions.md'), appendPreCommitBlock(docs.copilotInstructions));
     written.push('.github/copilot-instructions.md');
   }
 


### PR DESCRIPTION
## Summary

- Replace git pre-commit hooks and Claude SessionEnd hooks with config-file instructions
- All 4 writers (Claude, Cursor, Codex, Copilot) now inject a "Before Committing" section telling agents to run `caliber refresh`
- Remove hook selection prompt from `caliber init` flow
- Scoring check recognizes managed block as hook alternative
- Learning event capture hooks unchanged

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All 621 tests pass
- [x] Build succeeds