### PR TITLE
fix: surface scanner warnings when local scans fail

### DIFF
--- a/src/scanner/__tests__/scan-warnings.test.ts
+++ b/src/scanner/__tests__/scan-warnings.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+vi.mock('fs');
+
+import { scanLocalState } from '../index.js';
+
+describe('scanLocalState warnings', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+  });
+
+  it('warns when .mcp.json cannot be parsed', () => {
+    const dir = '/project';
+    vi.mocked(fs.existsSync).mockImplementation((p) => String(p) === path.join(dir, '.mcp.json'));
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    vi.mocked(fs.readFileSync).mockReturnValue('{invalid-json' as any);
+
+    const items = scanLocalState(dir);
+
+    expect(items).toHaveLength(0);
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Warning: .mcp.json scan skipped'));
+  });
+
+  it('warns when cursor skills directory cannot be read', () => {
+    const dir = '/project';
+    vi.mocked(fs.existsSync).mockImplementation((p) => String(p) === path.join(dir, '.cursor', 'skills'));
+    vi.mocked(fs.readdirSync).mockImplementation(() => {
+      throw new Error('EACCES');
+    });
+
+    scanLocalState(dir);
+
+    expect(console.warn).toHaveBeenCalledWith(expect.stringContaining('Warning: .cursor/skills scan skipped'));
+  });
+});

--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -72,7 +72,9 @@ export function scanLocalState(dir: string): LocalItem[] {
           });
         }
       }
-    } catch { /* ignore */ }
+    } catch (error) {
+      warnScanSkip('.mcp.json', error);
+    }
   }
 
   // Codex: AGENTS.md (when used as primary instructions)
@@ -103,7 +105,9 @@ export function scanLocalState(dir: string): LocalItem[] {
           });
         }
       }
-    } catch { /* ignore */ }
+    } catch (error) {
+      warnScanSkip('.agents/skills', error);
+    }
   }
 
   // Cursor: .cursorrules
@@ -149,7 +153,9 @@ export function scanLocalState(dir: string): LocalItem[] {
           });
         }
       }
-    } catch { /* ignore */ }
+    } catch (error) {
+      warnScanSkip('.cursor/skills', error);
+    }
   }
 
   // Cursor: .cursor/mcp.json mcpServers
@@ -168,7 +174,9 @@ export function scanLocalState(dir: string): LocalItem[] {
           });
         }
       }
-    } catch { /* ignore */ }
+    } catch (error) {
+      warnScanSkip('.cursor/mcp.json', error);
+    }
   }
 
   return items;
@@ -225,6 +233,11 @@ function hashFile(filePath: string): string {
 
 function hashJson(obj: unknown): string {
   return crypto.createHash('sha256').update(JSON.stringify(obj)).digest('hex');
+}
+
+function warnScanSkip(target: string, error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  console.warn(`Warning: ${target} scan skipped (${message})`);
 }
 
 function getCursorConfigDir(): string {


### PR DESCRIPTION
## Bug
Fixes https://github.com/rely-ai-org/caliber/issues/38 — scanner catch blocks silently ignored parse/read errors, so users only saw missing items with no explanation.

## Fix
- Replaced silent catch blocks with targeted warnings for failing scan targets (`.mcp.json`, `.agents/skills`, `.cursor/skills`, `.cursor/mcp.json`).
- Added focused regression tests for malformed JSON and unreadable cursor skills directories.

## Testing
- `npm test -- src/scanner/__tests__/scan-warnings.test.ts src/scanner/__tests__/cursor-skills-scan.test.ts src/scanner/__tests__/compare-state.test.ts`

Happy to address any feedback.

Greetings, saschabuehrle
