### PR TITLE
refactor: replace require() with ESM import in writers/index.ts

### DIFF
--- a/src/writers/index.ts
+++ b/src/writers/index.ts
@@ -5,6 +5,7 @@ import { writeCodexConfig } from './codex/index.js';
 import { writeGithubCopilotConfig } from './github-copilot/index.js';
 import { createBackup, restoreBackup } from './backup.js';
 import { ensureBuiltinSkills } from '../lib/builtin-skills.js';
+import { MANIFEST_FILE } from '../constants.js';
 import {
   readManifest,
   writeManifest,
@@ -104,7 +105,6 @@ export function undoSetup(): { restored: string[]; removed: string[] } {
     }
   }
 
-  const { MANIFEST_FILE } = require('../constants.js');
   if (fs.existsSync(MANIFEST_FILE)) {
     fs.unlinkSync(MANIFEST_FILE);
   }


### PR DESCRIPTION
Fixes #39

Removes a stale `require('../constants.js')` call inside `undoSetup()` in `src/writers/index.ts` that was inconsistent with the project's ES module conventions. Replaces it with a proper ESM `import { MANIFEST_FILE } from '../constants.js'` at the top of the file.