### PR TITLE
fix: skill backup paths don't match actual written paths

### DIFF
--- a/src/writers/__tests__/get-files-to-write.test.ts
+++ b/src/writers/__tests__/get-files-to-write.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { getFilesToWrite } from '../index.js';
+
+describe('getFilesToWrite', () => {
+    it('returns skill paths matching the OpenSkills directory format', () => {
+        const files = getFilesToWrite({
+            targetAgent: ['claude'],
+            claude: {
+                claudeMd: '# Test',
+                skills: [
+                    { name: 'My Skill', description: 'desc', content: 'body' },
+                    { name: 'another-one', description: 'desc', content: 'body' },
+                ],
+            },
+        });
+
+        expect(files).toContain('.claude/skills/my-skill/SKILL.md');
+        expect(files).toContain('.claude/skills/another-one/SKILL.md');
+        expect(files).not.toContain('.claude/skills/my-skill.md');
+        expect(files).not.toContain('.claude/skills/another-one.md');
+    });
+});

--- a/src/writers/index.ts
+++ b/src/writers/index.ts
@@ -13,7 +13,7 @@ import {
   type ManifestEntry,
 } from './manifest.js';
 
-interface AgentSetup {
+export interface AgentSetup {
   targetAgent: ('claude' | 'cursor' | 'codex' | 'github-copilot')[];
   deletions?: Array<{ filePath: string; reason: string }>;
   claude?: Parameters<typeof writeClaudeConfig>[0];
@@ -112,7 +112,7 @@ export function undoSetup(): { restored: string[]; removed: string[] } {
   return { restored, removed };
 }
 
-function getFilesToWrite(setup: AgentSetup): string[] {
+export function getFilesToWrite(setup: AgentSetup): string[] {
   const files: string[] = [];
 
   if (setup.targetAgent.includes('claude') && setup.claude) {
@@ -120,7 +120,7 @@ function getFilesToWrite(setup: AgentSetup): string[] {
     if (setup.claude.mcpServers) files.push('.mcp.json');
     if (setup.claude.skills) {
       for (const s of setup.claude.skills) {
-        files.push(`.claude/skills/${s.name.replace(/[^a-z0-9-]/gi, '-').toLowerCase()}.md`);
+        files.push(`.claude/skills/${s.name.replace(/[^a-z0-9-]/gi, '-').toLowerCase()}/SKILL.md`);
       }
     }
   }


### PR DESCRIPTION
Fixes #37

The skill backup path in `getFilesToWrite` (src/writers/index.ts) used a flat `.md` file format (`.claude/skills/<name>.md`) that did not match the directory-based format actually written by the Claude writer (`.claude/skills/<name>/SKILL.md`). This mismatch caused backups to target nonexistent paths. Corrects the path template in `getFilesToWrite` and exports both it and `AgentSetup` to support the new test in `src/writers/__tests__/get-files-to-write.test.ts`.