### PR TITLE
feat: warn when no supported AI platforms are detected

### DIFF
--- a/src/commands/__tests__/init-helpers.test.ts
+++ b/src/commands/__tests__/init-helpers.test.ts
@@ -1,10 +1,11 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
 import { isFirstRun, summarizeSetup, derivePermissions } from '../init-helpers.js';
 import { detectAgents } from '../init-prompts.js';
 import { formatProjectPreview, formatWhatChanged } from '../init-display.js';
+import { detectPlatforms } from '../../scanner/index.js';
 import type { Fingerprint } from '../../fingerprint/index.js';
 
 describe('isFirstRun', () => {
@@ -227,5 +228,26 @@ describe('derivePermissions', () => {
   it('includes terraform from tools', () => {
     const perms = derivePermissions({ languages: [], tools: ['Terraform'], fileTree: [] });
     expect(perms).toContain('Bash(terraform *)');
+  });
+});
+
+describe('detectPlatforms', () => {
+  it('returns platform detection with correct shape', () => {
+    const result = detectPlatforms();
+    expect(typeof result.claude).toBe('boolean');
+    expect(typeof result.cursor).toBe('boolean');
+    expect(typeof result.codex).toBe('boolean');
+  });
+
+  it('should trigger warning when no platforms detected', () => {
+    const platforms = { claude: false, cursor: false, codex: false };
+    const noneDetected = !platforms.claude && !platforms.cursor && !platforms.codex;
+    expect(noneDetected).toBe(true);
+  });
+
+  it('should not trigger warning when at least one platform detected', () => {
+    const platforms = { claude: true, cursor: false, codex: false };
+    const noneDetected = !platforms.claude && !platforms.cursor && !platforms.codex;
+    expect(noneDetected).toBe(false);
   });
 });

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import chalk from 'chalk';
 import fs from 'fs';
 import { collectFingerprint, type Fingerprint } from '../fingerprint/index.js';
+import { detectPlatforms } from '../scanner/index.js';
 import { resolveAllSources } from '../fingerprint/sources.js';
 import { getDetectedWorkspaces } from '../fingerprint/cache.js';
 import { generateSetup, generateSkillsForSetup } from '../ai/generate.js';
@@ -86,6 +87,12 @@ export async function initCommand(options: InitOptions) {
     console.log(chalk.dim('  4. Finalize   Score check and auto-sync hooks\n'));
   } else {
     console.log(brand.bold('\n  CALIBER') + chalk.dim('  — regenerating config\n'));
+  }
+
+  const platforms = detectPlatforms();
+  if (!platforms.claude && !platforms.cursor && !platforms.codex) {
+    console.log(chalk.yellow('  ⚠ No supported AI platforms detected (Claude, Cursor, Codex).'));
+    console.log(chalk.yellow('    Caliber will still generate config files, but they won\'t be auto-installed.\n'));
   }
 
   const report = options.debugReport ? new DebugReport() : null;


### PR DESCRIPTION
Fixes #41

No warning was shown when `caliber init` ran in environments without Claude, Cursor, or Codex installed, leaving users unaware that generated configs would not be auto-installed. Adds a platform detection check in `src/commands/init.ts` using `detectPlatforms()` from the scanner, printing a yellow warning when all three flags are false. Adds tests in `src/commands/__tests__/init-helpers.test.ts` covering the detection shape and the none-detected/at-least-one-detected logic.