### PR TITLE
fix: surface scanner warnings when local config scans fail

### DIFF
--- a/src/scanner/index.ts
+++ b/src/scanner/index.ts
@@ -72,7 +72,9 @@ export function scanLocalState(dir: string): LocalItem[] {
           });
         }
       }
-    } catch { /* ignore */ }
+    } catch (error) {
+      warnScanIssue(mcpJsonPath, 'MCP server definitions', error);
+    }
   }
 
   // Codex: AGENTS.md (when used as primary instructions)
@@ -103,7 +105,9 @@ export function scanLocalState(dir: string): LocalItem[] {
           });
         }
       }
-    } catch { /* ignore */ }
+    } catch (error) {
+      warnScanIssue(codexSkillsDir, 'Codex skills directory scan', error);
+    }
   }
 
   // Cursor: .cursorrules
@@ -149,7 +153,9 @@ export function scanLocalState(dir: string): LocalItem[] {
           });
         }
       }
-    } catch { /* ignore */ }
+    } catch (error) {
+      warnScanIssue(cursorSkillsDir, 'Cursor skills directory scan', error);
+    }
   }
 
   // Cursor: .cursor/mcp.json mcpServers
@@ -168,7 +174,9 @@ export function scanLocalState(dir: string): LocalItem[] {
           });
         }
       }
-    } catch { /* ignore */ }
+    } catch (error) {
+      warnScanIssue(cursorMcpPath, 'Cursor MCP server definitions', error);
+    }
   }
 
   return items;
@@ -236,4 +244,11 @@ function getCursorConfigDir(): string {
     return path.join(home, 'AppData', 'Roaming', 'Cursor');
   }
   return path.join(home, '.config', 'Cursor');
+}
+
+function warnScanIssue(targetPath: string, context: string, error: unknown): void {
+  const message = error instanceof Error ? error.message : String(error);
+  process.stderr.write(
+    `Warning: unable to read ${context} at ${targetPath} (${message}) — skipping\n`
+  );
 }


### PR DESCRIPTION
## Bug
Fixes https://github.com/caliber-ai-org/ai-setup/issues/38 — scanner catch blocks silently swallowed parse/read errors, so users saw missing config items with no explanation.

## Fix
- Replaced silent catch blocks in local scanner paths with explicit warnings to stderr.
- Added contextual warnings for:
  - .mcp.json parse/read failures
  - Codex skills directory scan failures
  - Cursor skills directory scan failures
  - Cursor MCP config parse/read failures
- Each warning includes what failed, where it failed, and that the scan path was skipped.

## Testing
Verified the scanner logic change in src/scanner/index.ts and confirmed all previously silent catch blocks now emit warnings through one helper.

Happy to address any feedback.

Greetings, saschabuehrle
