### PR TITLE
feat: add scanLocalState tests (#40), heuristic grounding (#59), model pinning (#75)

### DIFF
--- a/src/scanner/__tests__/scan-local-state.test.ts
+++ b/src/scanner/__tests__/scan-local-state.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+
+vi.mock('fs');
+
+import { scanLocalState } from '../index.js';
+
+describe('scanLocalState — comprehensive coverage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    vi.mocked(fs.existsSync).mockReturnValue(false);
+  });
+
+  describe('Claude MCP from .mcp.json', () => {
+    it('parses .mcp.json and lists MCP servers', () => {
+      const dir = '/project';
+      vi.mocked(fs.existsSync).mockImplementation((p) => String(p) === path.join(dir, '.mcp.json'));
+
+      const mcpContent = JSON.stringify({
+        mcpServers: {
+          slack: { command: 'npx', args: ['-y', '@anthropic/mcp-slack'] },
+          figma: { url: 'http://localhost:3000' },
+        },
+      });
+      vi.mocked(fs.readFileSync).mockImplementation((p: unknown) => {
+        if (String(p).includes('.mcp.json')) return mcpContent;
+        return '{}';
+      });
+
+      const items = scanLocalState(dir);
+      const mcpItems = items.filter((i) => i.type === 'mcp' && i.platform === 'claude');
+
+      expect(mcpItems).toHaveLength(2);
+      expect(mcpItems.map((i) => i.name).sort()).toEqual(['figma', 'slack']);
+      expect(mcpItems[0].path).toBe(path.join(dir, '.mcp.json'));
+      expect(mcpItems[0].contentHash).toMatch(/^[a-f0-9]{64}$/);
+    });
+  });
+
+  describe('Codex AGENTS.md', () => {
+    it('detects AGENTS.md when present', () => {
+      const dir = '/project';
+      vi.mocked(fs.existsSync).mockImplementation(
+        (p) => String(p) === path.join(dir, 'AGENTS.md')
+      );
+      vi.mocked(fs.readFileSync).mockReturnValue('# AGENTS.md\nProject context' as never);
+
+      const items = scanLocalState(dir);
+      const agents = items.filter((i) => i.name === 'AGENTS.md' && i.platform === 'codex');
+
+      expect(agents).toHaveLength(1);
+      expect(agents[0].type).toBe('rule');
+      expect(agents[0].path).toBe(path.join(dir, 'AGENTS.md'));
+    });
+  });
+
+  describe('Cursor .cursor/rules/*.mdc', () => {
+    it('scans .cursor/rules for .mdc files', () => {
+      const dir = '/project';
+      vi.mocked(fs.existsSync).mockImplementation((p) => {
+        const s = String(p);
+        return (
+          s === path.join(dir, '.cursor', 'rules') ||
+          s === path.join(dir, '.cursor', 'rules', 'testing.mdc') ||
+          s === path.join(dir, '.cursor', 'rules', 'lint.mdc')
+        );
+      });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      vi.mocked(fs.readdirSync).mockImplementation(((p: unknown) => {
+        const s = String(p);
+        if (s === path.join(dir, '.cursor', 'rules')) {
+          return ['testing.mdc', 'lint.mdc'];
+        }
+        return [];
+      }) as any);
+      vi.mocked(fs.readFileSync).mockReturnValue('---\ndescription: test\n---\nContent' as never);
+
+      const items = scanLocalState(dir);
+      const rules = items.filter((i) => i.type === 'rule' && i.platform === 'cursor');
+
+      expect(rules).toHaveLength(2);
+      expect(rules.map((r) => r.name).sort()).toEqual(['lint.mdc', 'testing.mdc']);
+    });
+  });
+
+  describe('Edge cases', () => {
+    it('returns empty results when directories do not exist', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(false);
+      const items = scanLocalState('/empty-project');
+      expect(items).toHaveLength(0);
+    });
+
+    it('does not throw when .mcp.json has malformed JSON', () => {
+      const dir = '/project';
+      vi.mocked(fs.existsSync).mockImplementation((p) => String(p) === path.join(dir, '.mcp.json'));
+      vi.mocked(fs.readFileSync).mockReturnValue('{invalid-json' as never);
+
+      const items = scanLocalState(dir);
+
+      expect(items).toHaveLength(0);
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('Warning: .mcp.json scan skipped')
+      );
+    });
+
+    it('handles empty .mcp.json with no mcpServers', () => {
+      const dir = '/project';
+      vi.mocked(fs.existsSync).mockImplementation((p) => String(p) === path.join(dir, '.mcp.json'));
+      vi.mocked(fs.readFileSync).mockReturnValue('{}' as never);
+
+      const items = scanLocalState(dir);
+      const mcpItems = items.filter((i) => i.type === 'mcp');
+
+      expect(mcpItems).toHaveLength(0);
+    });
+
+    it('handles CLAUDE.md only', () => {
+      const dir = '/project';
+      vi.mocked(fs.existsSync).mockImplementation(
+        (p) => String(p) === path.join(dir, 'CLAUDE.md')
+      );
+      vi.mocked(fs.readFileSync).mockReturnValue('# CLAUDE' as never);
+
+      const items = scanLocalState(dir);
+
+      expect(items).toHaveLength(1);
+      expect(items[0].name).toBe('CLAUDE.md');
+      expect(items[0].platform).toBe('claude');
+    });
+  });
+
+  describe('Content hashing', () => {
+    it('produces deterministic content hashes for files', () => {
+      const dir = '/project';
+      const content = 'same content';
+      vi.mocked(fs.existsSync).mockImplementation(
+        (p) => String(p) === path.join(dir, 'CLAUDE.md')
+      );
+      vi.mocked(fs.readFileSync).mockImplementation(() => content);
+
+      const run1 = scanLocalState(dir);
+      const run2 = scanLocalState(dir);
+
+      expect(run1[0].contentHash).toBe(run2[0].contentHash);
+    });
+  });
+});

--- a/src/scoring/checks/bonus.ts
+++ b/src/scoring/checks/bonus.ts
@@ -7,6 +7,7 @@ import {
   POINTS_AGENTS_MD,
   POINTS_OPEN_SKILLS_FORMAT,
   POINTS_LEARNED_CONTENT,
+  POINTS_MODEL_PINNED,
 } from '../constants.js';
 import { readFileOrNull } from '../utils.js';
 import { hasPreCommitBlock as checkPreCommitBlock } from '../../writers/pre-commit-block.js';
@@ -152,6 +153,53 @@ export function checkBonus(dir: string): Check[] {
     passed: hasLearned,
     detail: hasLearned ? 'Session learnings found in CALIBER_LEARNINGS.md' : 'No learned content',
     suggestion: hasLearned ? undefined : 'Install learning hooks: `caliber learn install`',
+  });
+
+  // 5. Model and effort level pinned
+  const configContent = (() => {
+    const parts: string[] = [];
+    const p = join(dir, 'CLAUDE.md');
+    const c = readFileOrNull(p);
+    if (c) parts.push(c);
+    try {
+      const rulesDir = join(dir, '.cursor', 'rules');
+      for (const f of readdirSync(rulesDir).filter((x) => x.endsWith('.mdc'))) {
+        const content = readFileOrNull(join(rulesDir, f));
+        if (content) parts.push(content);
+      }
+    } catch { /* dir missing */ }
+    return parts.join('\n').toLowerCase();
+  })();
+
+  const hasModelRef =
+    /\bcaliber_model\b/.test(configContent) ||
+    /\/(model|set model)\b/.test(configContent) ||
+    /\b(model|effort)\s*[:=]/.test(configContent) ||
+    /claude-(sonnet|opus|haiku)[-\d.]+/i.test(configContent) ||
+    /gpt-4[o.-]?\d*|gpt-5/i.test(configContent) ||
+    /\bhigh\s+effort|\bmedium\s+effort|\blow\s+effort/.test(configContent);
+
+  checks.push({
+    id: 'model_pinned',
+    name: 'Model & effort pinned',
+    category: 'bonus',
+    maxPoints: POINTS_MODEL_PINNED,
+    earnedPoints: hasModelRef ? POINTS_MODEL_PINNED : 0,
+    passed: hasModelRef,
+    detail: hasModelRef
+      ? 'Model or effort level explicitly set in config'
+      : "Config doesn't pin model or effort level — behavior may change when defaults are updated",
+    suggestion: hasModelRef
+      ? undefined
+      : 'Add model/effort to config: CALIBER_MODEL env var, or /model in Claude Code, or a Model Configuration section in CLAUDE.md',
+    fix: hasModelRef
+      ? undefined
+      : {
+          action: 'pin_model',
+          data: {},
+          instruction:
+            'Add a Model Configuration section to CLAUDE.md with recommended model and effort. Set via CALIBER_MODEL env var or /model in Claude Code.',
+        },
   });
 
   return checks;

--- a/src/scoring/checks/grounding.ts
+++ b/src/scoring/checks/grounding.ts
@@ -8,6 +8,7 @@ import {
   collectAllConfigContent,
   collectProjectStructure,
   isEntryMentioned,
+  getEntryWeight,
   extractReferences,
   analyzeMarkdownStructure,
   calculateDensityPoints,
@@ -30,18 +31,25 @@ export function checkGrounding(dir: string): Check[] {
 
   const mentioned: string[] = [];
   const notMentioned: string[] = [];
+  let weightedMentioned = 0;
+  let weightedTotal = 0;
 
   for (const entry of meaningfulEntries) {
+    const w = getEntryWeight(entry);
+    weightedTotal += w;
     if (isEntryMentioned(entry, configLower)) {
       mentioned.push(entry);
+      weightedMentioned += w;
     } else {
       notMentioned.push(entry);
     }
   }
 
-  const groundingRatio = meaningfulEntries.length > 0
-    ? mentioned.length / meaningfulEntries.length
-    : 0;
+  const groundingRatio = weightedTotal > 0
+    ? weightedMentioned / weightedTotal
+    : meaningfulEntries.length > 0
+      ? mentioned.length / meaningfulEntries.length
+      : 0;
 
   const groundingThreshold = GROUNDING_THRESHOLDS.find(t => groundingRatio >= t.minRatio);
   const groundingPoints = meaningfulEntries.length === 0

--- a/src/scoring/constants.ts
+++ b/src/scoring/constants.ts
@@ -13,7 +13,7 @@ export const CATEGORY_MAX = {
   grounding: 20,
   accuracy: 15,
   freshness: 10,
-  bonus: 7,
+  bonus: 9,
 } as const;
 
 // ── Existence checks (25 pts) ─────────────────────────────────────────
@@ -59,6 +59,8 @@ export const POINTS_PERMISSIONS = 2;
 
 // ── Bonus checks (5 pts + conditional source pts) ───────────────────
 export const POINTS_HOOKS = 2;
+/** Model/effort explicitly pinned to prevent silent provider regressions */
+export const POINTS_MODEL_PINNED = 2;
 export const POINTS_AGENTS_MD = 1;
 export const POINTS_OPEN_SKILLS_FORMAT = 2;
 export const POINTS_LEARNED_CONTENT = 2;

--- a/src/scoring/utils.ts
+++ b/src/scoring/utils.ts
@@ -392,6 +392,33 @@ export function calculateDensityPoints(density: number, maxPoints: number): numb
 }
 
 /**
+ * Heuristic weight for project entries — high-signal architectural files count more.
+ * Tier 1 (3.0): Core dependency/architectural boundaries.
+ * Tier 2 (2.0): Framework entry points and routing.
+ * Tier 3 (1.0): Standard source files and utilities.
+ */
+export function getEntryWeight(entry: string): number {
+  const base = entry.split('/').pop()?.toLowerCase() ?? entry.toLowerCase();
+  const tier1 = [
+    'package.json', 'package-lock.json', 'yarn.lock', 'pnpm-lock.yaml', 'bun.lockb',
+    'requirements.txt', 'pyproject.toml', 'Pipfile', 'go.mod', 'Cargo.toml',
+    'schema.prisma', 'docker-compose.yml', 'docker-compose.yaml', 'Dockerfile',
+    'openapi.yaml', 'openapi.json', 'swagger.yaml', 'tsconfig.json',
+  ];
+  const tier2 = [
+    'main.py', 'app.py', 'index.ts', 'index.js', 'main.ts', 'main.go',
+    'next.config.js', 'next.config.mjs', 'next.config.ts',
+    'App.tsx', 'App.jsx', 'app.tsx', 'app.jsx', 'main.tsx', 'main.jsx',
+    'vite.config.ts', 'vite.config.js', 'config.ts', 'config.js',
+  ];
+  if (tier1.includes(base)) return 3.0;
+  if (tier2.includes(base)) return 2.0;
+  if (/^(schema|migrations?)\//i.test(entry) || entry.endsWith('.prisma')) return 3.0;
+  if (/^(src|app)\//i.test(entry) && /\.(tsx?|jsx?|py|go)$/i.test(entry)) return 2.0;
+  return 1.0;
+}
+
+/**
  * Check if a project entry (directory or file) is mentioned in content.
  * Uses word-boundary matching with variants to avoid false positives.
  */

--- a/src/writers/claude/index.ts
+++ b/src/writers/claude/index.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { appendPreCommitBlock, appendLearningsBlock } from '../pre-commit-block.js';
+import { appendPreCommitBlock, appendLearningsBlock, appendModelBlock } from '../pre-commit-block.js';
 
 interface ClaudeConfig {
   claudeMd: string;
@@ -11,7 +11,10 @@ interface ClaudeConfig {
 export function writeClaudeConfig(config: ClaudeConfig): string[] {
   const written: string[] = [];
 
-  fs.writeFileSync('CLAUDE.md', appendLearningsBlock(appendPreCommitBlock(config.claudeMd)));
+  fs.writeFileSync(
+    'CLAUDE.md',
+    appendLearningsBlock(appendModelBlock(appendPreCommitBlock(config.claudeMd)))
+  );
   written.push('CLAUDE.md');
 
   if (config.skills?.length) {

--- a/src/writers/pre-commit-block.ts
+++ b/src/writers/pre-commit-block.ts
@@ -73,3 +73,25 @@ export function appendLearningsBlock(content: string): string {
 export function getCursorLearningsRule(): { filename: string; content: string } {
   return { filename: CURSOR_LEARNINGS_FILENAME, content: CURSOR_LEARNINGS_CONTENT };
 }
+
+// ── Model configuration block ────────────────────────────────────────
+
+const MODEL_BLOCK_START = '<!-- caliber:managed:model-config -->';
+const MODEL_BLOCK_END = '<!-- /caliber:managed:model-config -->';
+
+const MODEL_BLOCK = `${MODEL_BLOCK_START}
+## Model Configuration
+
+Recommended: \`claude-sonnet-4-6\` with high effort.
+Set via: \`/model\` in Claude Code, or \`CALIBER_MODEL\` env var.
+${MODEL_BLOCK_END}`;
+
+export function hasModelBlock(content: string): boolean {
+  return content.includes(MODEL_BLOCK_START);
+}
+
+export function appendModelBlock(content: string): string {
+  if (hasModelBlock(content)) return content;
+  const trimmed = content.trimEnd();
+  return trimmed + '\n\n' + MODEL_BLOCK + '\n';
+}

--- a/src/writers/refresh.ts
+++ b/src/writers/refresh.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { appendPreCommitBlock, appendLearningsBlock } from './pre-commit-block.js';
+import { appendPreCommitBlock, appendLearningsBlock, appendModelBlock } from './pre-commit-block.js';
 
 interface RefreshDocs {
   claudeMd?: string | null;
@@ -16,7 +16,10 @@ export function writeRefreshDocs(docs: RefreshDocs): string[] {
   const written: string[] = [];
 
   if (docs.claudeMd) {
-    fs.writeFileSync('CLAUDE.md', appendLearningsBlock(appendPreCommitBlock(docs.claudeMd)));
+    fs.writeFileSync(
+      'CLAUDE.md',
+      appendLearningsBlock(appendModelBlock(appendPreCommitBlock(docs.claudeMd)))
+    );
     written.push('CLAUDE.md');
   }
 


### PR DESCRIPTION
Closes #40, #59, #75

- **#40**: Add comprehensive test coverage for `scanLocalState()` — Claude MCP, AGENTS.md, Cursor rules, malformed JSON, empty config
- **#59**: Heuristic file weighting in grounding (Tier 1/2/3 multipliers for high-signal architectural files)
- **#75**: Model & effort pinning scoring check + Model Configuration block appended to CLAUDE.md on init/refresh

Made with [Cursor](https://cursor.com)