### PR TITLE
fix: harden command injection, path traversal, and telemetry hashing

### DIFF
--- a/github-action/index.js
+++ b/github-action/index.js
@@ -1,5 +1,7 @@
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const https = require('https');
+
+const VALID_AGENTS = new Set(['claude', 'cursor', 'codex', 'github-copilot']);
 
 // --- GitHub Actions helpers (no @actions/core dependency) ---
 
@@ -109,6 +111,10 @@ function buildComment(result, baseResult, agent) {
 
 async function run() {
   const agent = getInput('agent') || 'claude';
+  if (!VALID_AGENTS.has(agent)) {
+    setFailed(`Invalid agent "${agent}". Must be one of: ${[...VALID_AGENTS].join(', ')}`);
+    return;
+  }
   const failBelow = parseInt(getInput('fail-below') || '0', 10);
   const shouldComment = getInput('comment') !== 'false';
   const autoRefresh = getInput('auto-refresh') === 'true';
@@ -117,7 +123,7 @@ async function run() {
   // Run caliber score
   let resultJson;
   try {
-    const output = execSync(`npx --yes @rely-ai/caliber@latest score --json --quiet --agent ${agent}`, {
+    const output = execFileSync('npx', ['--yes', '@rely-ai/caliber@latest', 'score', '--json', '--quiet', '--agent', agent], {
       encoding: 'utf-8',
       timeout: 120000,
       env: { ...process.env, CALIBER_SKIP_UPDATE_CHECK: '1' },
@@ -151,8 +157,9 @@ async function run() {
         const baseBranch = event.pull_request?.base?.ref;
         if (baseBranch) {
           try {
-            const baseOutput = execSync(
-              `npx --yes @rely-ai/caliber@latest score --json --quiet --agent ${agent} --compare origin/${baseBranch}`,
+            if (!/^[\w\.\-\/]+$/.test(baseBranch)) throw new Error('Invalid base branch name');
+            const baseOutput = execFileSync(
+              'npx', ['--yes', '@rely-ai/caliber@latest', 'score', '--json', '--quiet', '--agent', agent, '--compare', `origin/${baseBranch}`],
               { encoding: 'utf-8', timeout: 120000, env: { ...process.env, CALIBER_SKIP_UPDATE_CHECK: '1' } },
             );
             const parsed = JSON.parse(baseOutput.trim());
@@ -199,19 +206,21 @@ async function run() {
   // Auto-refresh
   if (autoRefresh) {
     try {
-      execSync('npx --yes @rely-ai/caliber@latest refresh --quiet', {
+      execFileSync('npx', ['--yes', '@rely-ai/caliber@latest', 'refresh', '--quiet'], {
         encoding: 'utf-8',
         timeout: 300000,
         env: { ...process.env, CALIBER_SKIP_UPDATE_CHECK: '1' },
       });
 
-      const changes = execSync('git diff --name-only', { encoding: 'utf-8' }).trim();
+      const changes = execFileSync('git', ['diff', '--name-only'], { encoding: 'utf-8' }).trim();
       if (changes) {
-        execSync('git config user.name "caliber[bot]"');
-        execSync('git config user.email "caliber-bot@users.noreply.github.com"');
-        execSync('git add CLAUDE.md AGENTS.md .cursorrules .cursor/ .claude/ CALIBER_LEARNINGS.md 2>/dev/null || true');
-        execSync('git commit -m "[caliber] auto-refresh agent configs"');
-        execSync('git push');
+        execFileSync('git', ['config', 'user.name', 'caliber[bot]']);
+        execFileSync('git', ['config', 'user.email', 'caliber-bot@users.noreply.github.com']);
+        try {
+          execFileSync('git', ['add', 'CLAUDE.md', 'AGENTS.md', '.cursorrules', '.cursor/', '.claude/', 'CALIBER_LEARNINGS.md'], { stdio: 'pipe' });
+        } catch { /* some files may not exist */ }
+        execFileSync('git', ['commit', '-m', '[caliber] auto-refresh agent configs']);
+        execFileSync('git', ['push']);
         console.log('Auto-refreshed and committed config changes.');
       } else {
         console.log('No config changes to commit.');

--- a/src/commands/recommend.ts
+++ b/src/commands/recommend.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import ora from 'ora';
 import select from '@inquirer/select';
 import { mkdirSync, readFileSync, readdirSync, existsSync, writeFileSync } from 'fs';
-import { join, dirname } from 'path';
+import { join, dirname, resolve } from 'path';
 import { collectFingerprint, Fingerprint } from '../fingerprint/index.js';
 import { scanLocalState } from '../scanner/index.js';
 import { llmJsonCall } from '../llm/index.js';
@@ -37,14 +37,25 @@ function detectLocalPlatforms(): Platform[] {
   return platforms.size > 0 ? Array.from(platforms) : ['claude'];
 }
 
+function sanitizeSlug(slug: string): string {
+  return slug.replace(/[^a-zA-Z0-9_\-]/g, '-').replace(/^-+|-+$/g, '');
+}
+
 function getSkillPath(platform: Platform, slug: string): string {
-  if (platform === 'cursor') {
-    return join('.cursor', 'skills', slug, 'SKILL.md');
+  const safe = sanitizeSlug(slug);
+  if (!safe) throw new Error(`Invalid skill slug: "${slug}"`);
+
+  const baseDir = platform === 'cursor' ? join('.cursor', 'skills')
+    : platform === 'codex' ? join('.agents', 'skills')
+    : join('.claude', 'skills');
+
+  const cwd = process.cwd();
+  const fullPath = resolve(cwd, baseDir, safe, 'SKILL.md');
+  if (!fullPath.startsWith(resolve(cwd, baseDir) + '/')) {
+    throw new Error(`Skill path escapes base directory: "${slug}"`);
   }
-  if (platform === 'codex') {
-    return join('.agents', 'skills', slug, 'SKILL.md');
-  }
-  return join('.claude', 'skills', slug, 'SKILL.md');
+
+  return join(baseDir, safe, 'SKILL.md');
 }
 
 function getSkillDir(platform: Platform): string {

--- a/src/telemetry/__tests__/telemetry.test.ts
+++ b/src/telemetry/__tests__/telemetry.test.ts
@@ -60,10 +60,10 @@ describe('telemetry', () => {
       expect(id).toMatch(/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/);
     });
 
-    it('getGitEmailHash returns SHA-256 hash', async () => {
+    it('getGitEmailHash returns HMAC-SHA256 hash', async () => {
       const { getGitEmailHash } = await import('../config.js');
       const hash = getGitEmailHash();
-      const expected = crypto.createHash('sha256').update('test@example.com').digest('hex');
+      const expected = crypto.createHmac('sha256', 'caliber-telemetry-v1').update('test@example.com').digest('hex');
       expect(hash).toBe(expected);
     });
 

--- a/src/telemetry/config.ts
+++ b/src/telemetry/config.ts
@@ -40,11 +40,13 @@ export function getMachineId(): string {
   return machineId;
 }
 
+const EMAIL_HASH_KEY = 'caliber-telemetry-v1';
+
 export function getGitEmailHash(): string | undefined {
   try {
     const email = execSync('git config user.email', { encoding: 'utf-8' }).trim();
     if (!email) return undefined;
-    return crypto.createHash('sha256').update(email).digest('hex');
+    return crypto.createHmac('sha256', EMAIL_HASH_KEY).update(email).digest('hex');
   } catch {
     return undefined;
   }

--- a/src/utils/version-check.ts
+++ b/src/utils/version-check.ts
@@ -1,7 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import chalk from 'chalk';
 import ora from 'ora';
 import confirm from '@inquirer/confirm';
@@ -89,9 +89,10 @@ export async function checkForUpdates(): Promise<void> {
     }
 
     const tag = channel === 'latest' ? latest : channel;
+    if (!/^[\w.\-]+$/.test(tag)) return;
     const spinner = ora('Updating caliber...').start();
     try {
-      execSync(`npm install -g @rely-ai/caliber@${tag}`, {
+      execFileSync('npm', ['install', '-g', `@rely-ai/caliber@${tag}`], {
         stdio: 'pipe',
         timeout: 120_000,
         env: { ...process.env, npm_config_fund: 'false', npm_config_audit: 'false' },
@@ -108,7 +109,7 @@ export async function checkForUpdates(): Promise<void> {
 
       const args = process.argv.slice(2);
       console.log(chalk.dim(`\nRestarting: caliber ${args.join(' ')}\n`));
-      execSync(`caliber ${args.map((a) => JSON.stringify(a)).join(' ')}`, {
+      execFileSync('caliber', args, {
         stdio: 'inherit',
         env: { ...process.env, CALIBER_SKIP_UPDATE_CHECK: '1' },
       });


### PR DESCRIPTION
## Summary
- Replace `execSync` string interpolation with `execFileSync` + argument arrays in GitHub Action and version-check to prevent command injection (CWE-78)
- Validate GitHub Action `agent` input against allowlist
- Add slug sanitization and path boundary check in skill installation to prevent path traversal writes (CWE-22)
- Switch telemetry email hash from bare SHA-256 to HMAC-SHA256 (CWE-328)

Addresses GHSA-pwpc-952p-fvr3 and GHSA-gvcg-ghf7-jww4.

## Test plan
- [x] All 641 tests pass
- [x] Build succeeds