### PR TITLE
ci: add caliber score regression check on PRs

### DIFF
--- a/.github/workflows/caliber-score.yml
+++ b/.github/workflows/caliber-score.yml
@@ -31,12 +31,12 @@ jobs:
         id: score
         run: |
           set +e
-          RESULT=$(npx --yes @rely-ai/caliber@latest score --json --compare "origin/${{ github.base_ref }}" --agent claude 2>/dev/null)
+          RESULT=$(npx --yes @rely-ai/caliber@latest score --json --compare "origin/${{ github.base_ref }}" 2>/dev/null)
           EXIT_CODE=$?
           set -e
 
           if [ $EXIT_CODE -ne 0 ] || ! echo "$RESULT" | jq empty 2>/dev/null; then
-            RESULT=$(npx @rely-ai/caliber@latest score --json --agent claude 2>/dev/null)
+            RESULT=$(npx @rely-ai/caliber@latest score --json 2>/dev/null)
           fi
 
           SCORE=$(echo "$RESULT" | jq -r '.current.score // .score // 0')


### PR DESCRIPTION
## Summary

- Adds a CI workflow that runs `caliber score --compare` on every PR
- Builds from source (dogfooding) rather than pulling from npm
- Posts a PR comment with score + delta from base branch
- Fails the check if the score regresses (delta < 0)

Dogfooding the scoring feature on our own repo to prevent context regression.

## Test plan

- [ ] Open a PR that doesn't change configs → score should stay the same, check passes
- [ ] Open a PR that breaks a config reference → score should drop, check fails
- [ ] PR comment shows score and delta