### PR TITLE
fix: skip executable permission test on Windows

### DIFF
--- a/src/__tests__/claude-integration.test.ts
+++ b/src/__tests__/claude-integration.test.ts
@@ -308,7 +308,7 @@ describe('Hook script correctness', () => {
     expect(script).toContain('"decision":"block"');
   });
 
-  it('SessionStart hook is executable', async () => {
+  it.skipIf(process.platform === 'win32')('SessionStart hook is executable', async () => {
     const { installSessionStartHook } = await import('../lib/hooks.js');
     installSessionStartHook();
 


### PR DESCRIPTION
## Summary

- Skip the `SessionStart hook is executable` test on Windows — `chmod` is a no-op and `stat.mode` never has execute bits on win32

Fixes CI failure from #111.