### PR TITLE
fix: improve onboarding UX for Windows users and clarify scoring suggestions

### DIFF
--- a/.claude/rules/llm-patterns.md
+++ b/.claude/rules/llm-patterns.md
@@ -1,0 +1,16 @@
+---
+paths:
+  - src/llm/**
+---
+
+# LLM Provider Patterns
+
+- Providers implement `LLMProvider` from `src/llm/types.ts`: `call()`, `stream()`, optional `listModels()`
+- Config: env vars → `~/.caliber/config.json` via `src/llm/config.ts`
+- Seat-based: `isSeatBased()` in `src/llm/types.ts` — `cursor` and `claude-cli` skip `validateModel()`
+- Cursor: `agent --print --trust --workspace /tmp` in `src/llm/cursor-acp.ts`
+- Fast model: `getFastModel()` in `src/llm/config.ts` — `ANTHROPIC_SMALL_FAST_MODEL` scoped to anthropic/vertex/claude-cli
+- Model recovery: `src/llm/model-recovery.ts` handles not-found with interactive fallback
+- Usage: `trackUsage()` from `src/llm/usage.ts`
+- Errors: `src/llm/seat-based-errors.ts` parses stderr from CLI providers
+- JSON: `extractJson()`, `parseJsonResponse()` in `src/llm/utils.ts`

--- a/.claude/rules/scoring-patterns.md
+++ b/.claude/rules/scoring-patterns.md
@@ -1,0 +1,15 @@
+---
+paths:
+  - src/scoring/**
+---
+
+# Scoring Check Patterns
+
+- All checks are deterministic — no LLM calls, no network I/O, no randomness
+- Check functions return `Check[]` from `src/scoring/index.ts`
+- Point constants in `src/scoring/constants.ts` — never hardcode values
+- `filterChecksForTarget()` uses sets: `CLAUDE_ONLY_CHECKS`, `CURSOR_ONLY_CHECKS`, `CODEX_ONLY_CHECKS`, `COPILOT_ONLY_CHECKS` in `src/scoring/constants.ts`
+- Helpers: `readFileOrNull()`, `collectPrimaryConfigContent()`, `estimateTokens()` in `src/scoring/utils.ts`
+- Display: `src/scoring/display.ts` · History: `src/scoring/history.ts` · Dismissed: `src/scoring/dismissed.ts`
+- Grade thresholds in `GRADE_THRESHOLDS`, category max in `CATEGORY_MAX`
+- Test: `npx vitest run src/scoring/__tests__/accuracy.test.ts`

--- a/.claude/rules/testing-patterns.md
+++ b/.claude/rules/testing-patterns.md
@@ -1,0 +1,15 @@
+---
+paths:
+  - src/**/__tests__/**
+---
+
+# Testing Patterns
+
+- Config: `vitest.config.ts` · Setup: `src/test/setup.ts` (auto-loaded)
+- Run all: `npm run test` · Single: `npx vitest run src/scoring/__tests__/accuracy.test.ts`
+- LLM calls globally mocked in `src/test/setup.ts` — never mock `@anthropic-ai/sdk`, `openai`, `@anthropic-ai/vertex-sdk` in individual tests
+- Use `vi.mock()` for `fs`, `child_process` · `vi.mocked()` for type-safe assertions
+- Colocated: `src/llm/__tests__/config.test.ts` tests `src/llm/config.ts`
+- Pattern: `describe` → `beforeEach(vi.clearAllMocks)` → `it` with `expect`
+- Env vars: save `process.env` in `beforeEach`, restore in `afterEach`
+- Coverage: `npm run test:coverage` (v8 provider, thresholds in `vitest.config.ts`)

--- a/.claude/skills/adding-a-command/SKILL.md
+++ b/.claude/skills/adding-a-command/SKILL.md
@@ -1,147 +1,184 @@
 ---
 name: adding-a-command
-description: Creates a new CLI command following the Commander.js pattern in src/commands/. Handles command registration in src/cli.ts, telemetry tracking via tracked() wrapper, and option parsing. Use when user says 'add command', 'new CLI command', 'create subcommand', or adds files to src/commands/. Do NOT use for modifying existing commands or fixing bugs in existing commands.
+description: Creates a new CLI command following the Commander.js pattern in src/commands/. Handles command registration in src/cli.ts, telemetry tracking via tracked() wrapper, and option parsing. Use when user says add command, new CLI command, create subcommand, or adds files to src/commands/. Do NOT use for modifying existing commands or fixing bugs in existing commands.
+paths:
+  - src/commands/**/*.ts
+  - src/cli.ts
 ---
 # Adding a Command
 
 ## Critical
 
-- **All commands must be wrapped in `tracked()`** from `src/telemetry/index.ts`. This is non-negotiable — every command logs its execution for metrics.
-- **Commands are exported as default functions** from `src/commands/{name}.ts`. The function signature must match: `export default function commandName(program: Command): void`.
-- **Register the command in `src/cli.ts`** in the main CLI builder. Import the command function and call it, passing the program instance.
-- **Test the command exists** before merging: `npm run build && npx caliber {command-name} --help` should return the help text without errors.
+- **Export pattern**: Command must export a named async function: `export async function myCommand(options?: OptionType)`. Never use default exports.
+- **Registration in cli.ts**: Every command must be imported and registered with `.command()` chain in `src/cli.ts`, wrapped with `tracked()` for telemetry.
+- **Error signaling**: Use `throw new Error('__exit__')` to exit gracefully without printing the error message. Use chalk for user-facing messages.
+- **Options typing**: Commands receiving options must define a TypeScript interface for those options. Pass options as a destructured object parameter.
 
 ## Instructions
 
-1. **Create the command file** at `src/commands/{command-name}.ts`.
-   - Use kebab-case for file names (`src/commands/my-command.ts`).
-   - Export a default async function that receives `program: Command` parameter.
-   - The function builds and registers the command via `program.command('name')`.
-   - Verify: File exists and exports a default function with the correct signature.
+1. **Create the command file** at `src/commands/{commandName}.ts` with named async export.
+   - Signature: `export async function {commandName}Command(options?: { optionName?: optionType }) { ... }`
+   - Import only what you need (avoid kitchen-sink imports).
+   - Return void (handle all output via console.log or chalk).
+   - Verify the file follows the naming convention: camelCase function + "Command" suffix.
 
-2. **Define the command using Commander.js**.
-   - Chain `.description()`, `.option()`, `.action()` on the command object.
-   - Use `command.command('name').description('...')` for the command definition.
-   - Store the returned command object and call `.action()` on it.
-   - Verify: The action callback receives correct parameters (e.g., options object, command instance).
+2. **Handle errors consistently**: Wrap error-prone operations in try/catch. Distinguish between user errors and system errors:
+   - User error (bad input): `console.error(chalk.red('message')); throw new Error('__exit__');`
+   - System error (missing dependency): `throw new Error('Detailed error message');` — this will print and exit with code 1.
+   - Parse-like errors: Use ora spinner with `.fail()` before throwing.
+   - This step prevents double error printing in bin.ts.
 
-3. **Wrap the action handler in `tracked()`**.
-   - Import `tracked` from `src/telemetry/index.ts`.
-   - Call `tracked('command-name', async (context) => { ... })` inside `.action()`.
-   - The callback receives `context` parameter (telemetry context); use it to report custom metrics if needed.
-   - Return the Promise from the tracked wrapper.
-   - Verify: The command runs and completes without telemetry errors (check console output).
+3. **Import and register in src/cli.ts** in the correct location:
+   - Add import at the top: `import { {commandName}Command } from './commands/{commandName}.js';`
+   - Register the command in the appropriate section (main commands, or nested under a group like `sources`).
+   - For main commands: `.command('{kebab-name}').description('...').option(...).action(tracked('{kebab-name}', {commandName}Command))`
+   - For subcommands (like `sources add`): `sources.command('add').description(...).action(tracked('sources:add', sourcesAddCommand))`
+   - Key: Wrap handler with `tracked('{command-name}', handler)` for automatic telemetry.
+   - Verify the command name in tracked() uses kebab-case for main commands and colon-separated for subcommands.
 
-4. **Parse and validate options**.
-   - Extract options from the options object passed to the action callback.
-   - Use destructuring: `const { optionName, flag } = options`.
-   - For required options, validate they exist and throw an error if missing.
-   - Verify: Running the command without required options produces a clear error message.
+4. **Define options (if needed)**:
+   - Add `.option()` chains before `.action()`: `.option('--flag', 'Description')` or `.option('--opt <value>', 'Description')`
+   - For parsed options (like comma-separated agents), add a parse function: `.option('--opt <value>', 'Description', parseFunction)`
+   - Pass options to handler: `.action(tracked('name', (opts) => command(opts)))`
+   - Define TypeScript interface for the options object.
+   - Verify option names use camelCase (Commander converts kebab-case flags to camelCase).
 
-5. **Register the command in `src/cli.ts`**.
-   - Import the command function at the top: `import myCommand from './commands/my-command.js'`.
-   - Call it in the buildCli function: `myCommand(program)`.
-   - Commands are registered in the order they appear in the function.
-   - Verify: `npx caliber --help` lists your command in the available commands.
-
-6. **Write a test** in `src/commands/__tests__/{command-name}.test.ts`.
-   - Use Vitest patterns from existing tests (e.g., `src/commands/__tests__/status.test.ts`).
-   - Mock external dependencies (filesystem, LLM calls, telemetry).
-   - Test: command registration, option parsing, success path, error handling.
-   - Verify: `npm run test -- src/commands/__tests__/{command-name}.test.ts` passes.
+5. **Verify before proceeding**:
+   - Function exports correctly and is imported in cli.ts.
+   - Command is registered with tracked() wrapper.
+   - Output uses chalk for colors, not plain console.log.
+   - Error paths throw `new Error('__exit__')` for user errors.
 
 ## Examples
 
-### Example: User requests "add a greet command that takes a --name option"
+### Example 1: Simple command (status)
 
-**Action 1: Create `src/commands/greet.ts`**
+User says: "Add a command to show config status"
+
+**Actions taken**:
+1. Create src/commands/status.ts with statusCommand() export
+2. Import and register in src/cli.ts with tracked() wrapper
+
+**Result**: `caliber status` displays config status; `caliber status --json` outputs JSON.
+
+Code example:
 ```typescript
-import { Command } from 'commander';
-import { tracked } from '../telemetry/index.js';
+import chalk from 'chalk';
+import { loadConfig } from '../llm/config.js';
 
-export default function greetCommand(program: Command): void {
-  const cmd = program
-    .command('greet')
-    .description('Greet a user by name')
-    .option('--name <string>', 'Name to greet', 'World')
-    .action(async (options) => {
-      return tracked('greet', async (context) => {
-        const { name } = options;
-        console.log(`Hello, ${name}!`);
-      });
-    });
+export async function statusCommand(options?: { json?: boolean }) {
+  const config = loadConfig();
+  
+  if (options?.json) {
+    console.log(JSON.stringify({ configured: !!config }, null, 2));
+    return;
+  }
+  
+  console.log(chalk.bold('Status'));
+  console.log(`  LLM: ${chalk.green(config?.provider || 'Not configured')}`);
 }
 ```
 
-**Action 2: Register in `src/cli.ts`**
-- Add import: `import greetCommand from './commands/greet.js'`
-- Call in buildCli: `greetCommand(program)`
-
-**Action 3: Test in `src/commands/__tests__/greet.test.ts`**
+Registration in src/cli.ts:
 ```typescript
-import { describe, it, expect, vi } from 'vitest';
-import { Command } from 'commander';
-import greetCommand from '../greet.js';
-
-describe('greet', () => {
-  it('registers the command', () => {
-    const program = new Command();
-    greetCommand(program);
-    const cmd = program.commands.find((c) => c.name() === 'greet');
-    expect(cmd).toBeDefined();
-  });
-
-  it('greets with default name', async () => {
-    const program = new Command();
-    greetCommand(program);
-    const consoleSpy = vi.spyOn(console, 'log');
-    await program.parseAsync(['node', 'caliber', 'greet']);
-    expect(consoleSpy).toHaveBeenCalledWith('Hello, World!');
-  });
-
-  it('greets with custom name', async () => {
-    const program = new Command();
-    greetCommand(program);
-    const consoleSpy = vi.spyOn(console, 'log');
-    await program.parseAsync(['node', 'caliber', 'greet', '--name', 'Alice']);
-    expect(consoleSpy).toHaveBeenCalledWith('Hello, Alice!');
-  });
-});
+import { statusCommand } from './commands/status.js';
+program
+  .command('status')
+  .description('Show config status')
+  .option('--json', 'Output as JSON')
+  .action(tracked('status', statusCommand));
 ```
 
-**Action 4: Verify**
-```bash
-npm run build
-npx caliber greet --help          # Shows help text
-npx caliber greet                 # Output: Hello, World!
-npx caliber greet --name Alice    # Output: Hello, Alice!
-npm run test -- src/commands/__tests__/greet.test.ts  # All tests pass
+---
+
+### Example 2: Subcommand with arguments
+
+User says: "Add a sources add subcommand"
+
+**Actions taken**:
+1. Create src/commands/sources.ts with sourcesAddCommand() export
+2. Register under sources group with tracked('sources:add', ...)
+
+**Result**: `caliber sources add ../lib` adds a source.
+
+Code example:
+```typescript
+export async function sourcesAddCommand(sourcePath: string) {
+  if (!fs.existsSync(sourcePath)) {
+    console.log(chalk.red(`Path not found: ${sourcePath}`));
+    throw new Error('__exit__');
+  }
+  const existing = loadSourcesConfig(process.cwd());
+  existing.push({ type: 'repo', path: sourcePath });
+  writeSourcesConfig(process.cwd(), existing);
+  console.log(chalk.green(`Added ${sourcePath}`));
+}
+```
+
+Registration:
+```typescript
+const sources = program.command('sources');
+sources
+  .command('add')
+  .argument('<path>', 'Path to add')
+  .action(tracked('sources:add', sourcesAddCommand));
+```
+
+---
+
+### Example 3: Command with option parsing
+
+User says: "Add init with --agent flag supporting comma-separated values"
+
+**Actions taken**:
+1. Create parseAgentOption() parser in src/cli.ts
+2. Create src/commands/init.ts with initCommand(options)
+3. Register with custom parser
+
+**Result**: `caliber init --agent claude,cursor` passes parsed array to handler.
+
+Parser code:
+```typescript
+function parseAgentOption(value: string) {
+  const agents = value.split(',').map(s => s.trim().toLowerCase());
+  if (agents.length === 0) {
+    console.error('Invalid agent');
+    process.exit(1);
+  }
+  return agents;
+}
+
+program.command('init')
+  .option('--agent <type>', 'Agents (comma-separated)', parseAgentOption)
+  .action(tracked('init', initCommand));
 ```
 
 ## Common Issues
 
-**Error: "Command 'mycommand' is not a valid command"**
-- Verify the command function was called in `src/cli.ts` inside `buildCli()`: look for `myCommand(program)`.
-- Verify the import path is correct: `import myCommand from './commands/my-command.js'` (note `.js` extension for ESM).
-- Run `npm run build` to regenerate dist/ and try again.
+**Issue**: "SyntaxError: The requested module does not provide an export named 'myCommand'"
+- **Cause**: Function not exported or exported as default instead of named.
+- **Fix**: Use `export async function myCommand(...)` (not `export default`).
 
-**Error: "tracked is not a function"**
-- Verify import: `import { tracked } from '../telemetry/index.js'` at the top of the command file.
-- Verify the tracked call is async: `.action(async (options) => { return tracked(...); })`.
-- Verify the tracked callback returns or awaits a value; the action must return the Promise.
+**Issue**: Command appears in help but crashes when run
+- **Cause**: Handler not wrapped with `tracked()` or function import mismatch.
+- **Fix**: Verify import name matches function export. Wrap with `tracked('command-name', handler)`.
 
-**Error: "Option parsing failed" or options are undefined**
-- Verify options are defined via `.option()` before `.action()`.
-- Verify the action callback destructures options correctly: `const { optionName } = options`.
-- If testing, ensure the command is parsed with `await program.parseAsync([...])` including the command name and options.
+**Issue**: "Error: __exit__" appears in output for user errors
+- **Cause**: Throwing generic error instead of using error exit pattern.
+- **Fix**: Use `console.error(chalk.red('message')); throw new Error('__exit__');` for user-facing errors.
 
-**Command appears in --help but fails when run**
-- Verify the tracked wrapper is present and the action callback is async.
-- Check for console errors: the action may throw before telemetry completes.
-- Verify external dependencies (file reads, LLM calls) are mocked in tests.
-- Run in dev mode: `npm run dev` and test locally before committing.
+**Issue**: --dry-run flag not recognized
+- **Cause**: Option not declared with `.option()` or wrong camelCase in interface.
+- **Fix**: Add `.option('--dry-run', 'Description')` and ensure options interface has `dryRun?: boolean`.
 
-**Test fails with "Command is not registered"**
-- Verify the test calls `greetCommand(program)` to register it.
-- Verify the command name in the test matches the `.command('name')` call.
-- Use `program.commands.find((c) => c.name() === 'name')` to debug if the command exists.
+**Issue**: Subcommand crashes but parent command works
+- **Cause**: Using `program.command()` instead of `groupVar.command()` for subcommands.
+- **Fix**: Register on group: `const sources = program.command('sources'); sources.command('add')...`
+
+**Issue**: Telemetry not appearing
+- **Cause**: Handler not wrapped with `tracked()` or wrong command name.
+- **Fix**: Ensure `.action(tracked('{kebab-case}', handler))` wraps handler. Use colon for subcommands like 'sources:add'.
+
+**Issue**: "Cannot find module" with relative imports
+- **Cause**: Using `.ts` extension in imports.
+- **Fix**: Always use `.js` extension: `import { x } from '../lib/file.js'` (required for ESM).

--- a/.claude/skills/caliber-testing/SKILL.md
+++ b/.claude/skills/caliber-testing/SKILL.md
@@ -1,209 +1,370 @@
 ---
 name: caliber-testing
-description: Writes Vitest tests following project patterns: __tests__/ directories, vi.mock() for module mocking, global LLM mock from src/test/setup.ts, environment variable save/restore, and test file organization. Use when user says 'write tests', 'add test coverage', 'test this', creates *.test.ts files, or when test failures appear in CI. Do NOT use for non-test code or for debugging without writing tests.
+description: Writes Vitest tests following project patterns: __tests__/ directories, vi.mock() for module mocking with vi.hoisted() for test-time factories, global LLM mock from src/test/setup.ts, environment variable save/restore in beforeEach/afterEach, vi.clearAllMocks() lifecycle, and test file organization. Use when user says 'write tests', 'add test coverage', 'test this', creates *.test.ts files, or when test failures appear in CI. Do NOT use for non-test code or for debugging without writing tests.
+paths:
+  - src/**/__tests__/*.test.ts
 ---
-# caliber-testing
+# Caliber Testing
 
 ## Critical
 
-- **Test file location**: Always place tests in `__tests__/` subdirectory of the module being tested. File name: `module-name.test.ts`. Example: `src/llm/__tests__/anthropic.test.ts` for `src/llm/anthropic.ts`.
-- **Global LLM mock**: Use the mock from `src/test/setup.ts`. It is auto-loaded by Vitest. Do NOT create duplicate LLM mocks in individual test files.
-- **Avoid over-mocking**: Mock only external dependencies (HTTP, file I/O, LLM calls). Never mock internal modules or pure logic.
-- **Environment cleanup**: Always save and restore `process.env` between tests to prevent cross-test pollution. Use the pattern in Step 4.
-- **No hardcoded test data**: Use `beforeEach` to set up fresh mocks and env state for each test.
+- All test files MUST be placed in `__tests__/` directories parallel to source files: `src/[module]/__tests__/[module].test.ts`
+- Register any new `__tests__/` directories in `vitest.config.ts`'s `include` glob (already configured: `src/**/*.test.ts`)
+- NEVER mock `src/test/setup.ts` — it is the global LLM provider mock already applied to all tests
+- Environment variable tests MUST save `process.env` in `beforeEach`, restore in `afterEach`, and explicitly delete env vars to test absence
+- Temporary file/directory cleanup MUST happen in `afterEach`, not in individual test cleanup. Use `fs.rmSync(dir, { recursive: true, force: true })`
+- When a test requires unmocking modules mocked in global setup, call `vi.unmock('../module.js')` BEFORE the import statement
+- Run `pnpm test` locally and `pnpm test:coverage` before committing to verify coverage thresholds (lines: 50, functions: 50, branches: 50, statements: 50)
 
 ## Instructions
 
-### Step 1: Set up the test file structure
-Create `src/<module>/__tests__/<module-name>.test.ts`. Import `describe`, `it`, `expect`, `beforeEach`, `afterEach` from `vitest`, and import the module under test.
+### Step 1: Create the test file in the correct directory
+Create `src/[module]/__tests__/[module].test.ts`. The parent source file is `src/[module]/[module].ts`.
 
+**Verify**: The `__tests__` directory exists at the same level as the source file being tested.
+
+### Step 2: Import test framework
+At the top of every test file, import from `vitest`:
 ```typescript
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { functionToTest } from '../module-name.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 ```
 
-Verify: The test file is in the correct `__tests__/` directory parallel to the module it tests.
+Add additional imports based on what you're testing:
+- File system: `import fs from 'fs'; import path from 'path'; import os from 'os';`
+- Temporary files: Use `fs.mkdtempSync(path.join(os.tmpdir(), 'caliber-prefix-'))`
+- Exec: `import { execSync } from 'child_process';`
 
-### Step 2: Mock external dependencies with vi.mock()
-At the top of the test file, before `describe`, mock external modules using `vi.mock()`. This applies to:
-- HTTP calls (use `vi.mock()` to intercept fetch or axios)
-- File I/O (use `vi.mock('fs')` or similar)
-- LLM providers (already mocked globally via `src/test/setup.ts`, but document the assumption)
+**Verify**: All required test utilities are imported before test definitions.
 
-Example:
+### Step 3: Set up module mocking (if needed)
+If testing a module that imports other modules you want to mock:
+
 ```typescript
-vi.mock('fs', () => ({
-  readFileSync: vi.fn(() => 'mock content'),
+vi.mock('../config.js', () => ({
+  loadConfig: vi.fn(),
+  writeConfigFile: vi.fn(),
 }));
 ```
 
-Verify: All external dependencies are mocked. Internal module calls are NOT mocked.
-
-### Step 3: Use beforeEach and afterEach for setup and cleanup
-For each test suite, create `beforeEach` to reset mocks and set up test state. Create `afterEach` to clean up.
-
+For complex mocks with test-time factory functions (hoisted):
 ```typescript
-describe('module-name', () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-  });
+const { mockLoadConfig } = vi.hoisted(() => ({
+  mockLoadConfig: vi.fn(),
+}));
 
-  afterEach(() => {
-    vi.resetAllMocks();
-  });
+vi.mock('../config.js', () => ({
+  loadConfig: () => mockLoadConfig(),
+}));
+```
 
-  it('should do something', () => {
+For unmocking global setup mocks (e.g., to test llm/index.js itself):
+```typescript
+vi.unmock('../index.js');
+```
+
+Place all `vi.mock()` and `vi.unmock()` calls BEFORE importing the module under test.
+
+**Verify**: Mock declarations appear before the import of the module being tested.
+
+### Step 4: Organize tests in describe blocks
+Group related tests with `describe()`:
+```typescript
+describe('functionName', () => {
+  it('returns X when Y', () => {
     // test body
   });
 });
 ```
 
-Verify: `vi.clearAllMocks()` is called in `beforeEach` to reset mock call counts.
+**Verify**: Each `it()` test has a clear, complete assertion.
 
-### Step 4: Save and restore process.env for env-dependent tests
-If a test modifies `process.env`, save the original state and restore it. Use this pattern:
+### Step 5: Manage environment and process state
+For tests that modify `process.env` or `process.argv`:
 
 ```typescript
-describe('env-dependent module', () => {
+describe('config tests', () => {
   const originalEnv = process.env;
+  const originalArgv = process.argv;
 
   beforeEach(() => {
-    process.env = { ...originalEnv };
-    vi.clearAllMocks();
+    process.env = { ...originalEnv }; // Copy, not reference
+    process.argv = [...originalArgv];
+    delete process.env.SPECIFIC_VAR; // Explicitly remove vars to test absence
   });
 
   afterEach(() => {
     process.env = originalEnv;
-    vi.resetAllMocks();
+    process.argv = originalArgv;
   });
 
-  it('should read from process.env.VARIABLE', () => {
-    process.env.VARIABLE = 'test-value';
-    // test assertion
+  it('tests env var behavior', () => {
+    process.env.MY_VAR = 'test';
+    // test code
   });
 });
 ```
 
-Verify: `process.env` is restored to its original state after each test.
+**Verify**: `beforeEach` creates a copy of env/argv; `afterEach` restores originals; unused env vars are explicitly deleted with `delete process.env.VAR`.
 
-### Step 5: Write assertions that match project conventions
-Use `expect()` with clear matchers. For async functions, use `await` or `.resolves`.
+### Step 6: Manage temporary files and directories
+For file system tests, create temporary directories and clean them up:
 
 ```typescript
-it('should return the expected value', async () => {
-  const result = await functionToTest('input');
-  expect(result).toEqual({ key: 'value' });
+describe('file tree', () => {
+  const dirs: string[] = [];
+  
+  afterEach(() => {
+    for (const d of dirs) {
+      try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
+    }
+    dirs.length = 0;
+  });
+
+  it('processes files', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'caliber-test-'));
+    dirs.push(tmp);
+    // use tmp directory
+  });
+});
+```
+
+**Verify**: All temporary directories are pushed to a cleanup array and removed in `afterEach`.
+
+### Step 7: Handle mock state cleanup
+Before each test, clear mock call history to avoid pollution between tests:
+
+```typescript
+beforeEach(() => {
+  vi.clearAllMocks(); // Reset all mock call counts and return values
 });
 
-it('should throw on invalid input', async () => {
-  await expect(functionToTest(null)).rejects.toThrow('Invalid input');
+afterEach(() => {
+  vi.restoreAllMocks(); // Restore original implementations
+  vi.resetModules(); // Reset cached module imports (if you reload modules)
 });
 ```
 
-Verify: Assertions are specific (not just checking truthiness) and async functions use `await` or `.resolves`.
+**Verify**: `beforeEach` calls `vi.clearAllMocks()` for providers and `afterEach` calls `vi.restoreAllMocks()`.
 
-### Step 6: Run and verify the tests
-Run the specific test file to ensure it passes:
-```bash
-npm run test -- src/<module>/__tests__/<module-name>.test.ts
+### Step 8: Test assertions
+Write assertions using `expect()`. Match the patterns from existing tests:
+
+```typescript
+// Simple checks
+expect(value).toBe(expected);
+expect(array).toContain(item);
+expect(fn).toThrow('error message');
+
+// Instance checks
+expect(obj).toBeInstanceOf(ClassName);
+
+// Mock checks
+expect(mockFn).toHaveBeenCalledTimes(1);
+expect(mockFn).toHaveBeenCalledWith(arg);
+
+// File system checks
+expect(fs.existsSync(path)).toBe(true);
 ```
 
-Or run all tests:
+**Verify**: Each test has at least one assertion and uses appropriate `expect()` matchers.
+
+### Step 9: Run tests
+Run tests locally before committing:
 ```bash
-npm run test
+pnpm test                # Run all tests in watch mode
+pnpm test:coverage       # Check coverage thresholds
+pnpm test -- src/my/path/__tests__/my.test.ts  # Run single test file
 ```
 
-Verify: All tests pass. Check test coverage with `npm run test -- --coverage`.
+**Verify**: All tests pass and coverage thresholds are met (lines: 50%, functions: 50%, branches: 50%).
 
 ## Examples
 
-### Example: Testing an LLM provider module
+### Example 1: Testing a module with environment variables (config.test.ts pattern)
 
-User says: "Write tests for src/llm/anthropic.ts"
+**User asks**: "Write tests for my config loader that reads from env vars and a config file."
 
-**Actions:**
-1. Create `src/llm/__tests__/anthropic.test.ts`
-2. Import `describe`, `it`, `expect`, `beforeEach`, `afterEach`, `vi` from vitest
-3. Mock external HTTP calls (fetch is mocked globally via setup)
-4. Write tests for `call()` and `stream()` methods
-5. Save/restore `process.env` for API key tests
-6. Run: `npm run test -- src/llm/__tests__/anthropic.test.ts`
+**Actions taken**:
+1. Create `src/lib/__tests__/config.test.ts`
+2. Import test framework and fs module
+3. Mock `fs` and `os`
+4. Save/restore `process.env` in beforeEach/afterEach
+5. Delete specific env vars to test absence
+6. Test each branch: env vars set, file exists, both, neither
 
-**Result:**
+**Result**:
 ```typescript
-import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { AnthropicProvider } from '../anthropic.js';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
 
-describe('AnthropicProvider', () => {
+vi.mock('fs');
+vi.mock('os', () => ({ default: { homedir: () => '/home/user' } }));
+
+import { loadConfig } from '../config.js';
+
+describe('config', () => {
   const originalEnv = process.env;
 
   beforeEach(() => {
-    process.env = { ...originalEnv, ANTHROPIC_API_KEY: 'test-key' };
     vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.OPENAI_API_KEY;
   });
 
   afterEach(() => {
     process.env = originalEnv;
-    vi.resetAllMocks();
   });
 
-  it('should call the API with correct parameters', async () => {
-    const provider = new AnthropicProvider();
-    const response = await provider.call({ messages: [{ role: 'user', content: 'test' }] });
-    expect(response).toBeDefined();
+  it('returns env config when ANTHROPIC_API_KEY is set', () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test';
+    const config = loadConfig();
+    expect(config?.provider).toBe('anthropic');
+  });
+
+  it('returns null when no env vars set', () => {
+    expect(loadConfig()).toBeNull();
   });
 });
 ```
 
-### Example: Testing a utility function
+### Example 2: Testing file system operations with temp cleanup (file-tree.test.ts pattern)
 
-User says: "Add tests for src/utils/sanitize.ts"
+**User asks**: "Write tests for file tree analysis."
 
-**Actions:**
-1. Create `src/utils/__tests__/sanitize.test.ts`
-2. Import the sanitize function
-3. Write tests for different input types
-4. No mocking needed (pure logic)
-5. Run: `npm run test -- src/utils/__tests__/sanitize.test.ts`
+**Actions taken**:
+1. Create `src/fingerprint/__tests__/file-tree.test.ts`
+2. Set up a cleanup array for temp directories
+3. Create temp dirs in each test and push to cleanup array
+4. Clean up all temp dirs in afterEach
+5. Test with various file mtimes and directory structures
 
-**Result:**
+**Result**:
 ```typescript
-import { describe, it, expect } from 'vitest';
-import { sanitize } from '../sanitize.js';
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { getFileTree } from '../file-tree.js';
 
-describe('sanitize', () => {
-  it('should remove dangerous characters', () => {
-    expect(sanitize('<script>alert()</script>')).toEqual('scriptalert()script');
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
+  }
+  dirs.length = 0;
+});
+
+describe('getFileTree', () => {
+  it('returns files sorted by mtime descending', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'caliber-ft-'));
+    dirs.push(tmp);
+
+    fs.writeFileSync(path.join(tmp, 'a.ts'), 'a');
+    fs.writeFileSync(path.join(tmp, 'b.ts'), 'b');
+    const tree = getFileTree(tmp);
+    expect(tree).toHaveLength(2);
+  });
+});
+```
+
+### Example 3: Testing with module mocking and factory functions (index.test.ts pattern)
+
+**User asks**: "Write tests for the provider factory that instantiates different providers based on config."
+
+**Actions taken**:
+1. Create `src/llm/__tests__/index.test.ts`
+2. Use `vi.unmock('../index.js')` to test the real module
+3. Create mock classes in `vi.hoisted()`
+4. Mock dependencies (config, provider classes)
+5. Test provider selection logic
+6. Use `resetProvider()` between tests to clear cached instances
+
+**Result**:
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.unmock('../index.js');
+
+const { mockLoadConfig, MockAnthropicProvider } = vi.hoisted(() => {
+  class MockAnthropicProvider {
+    config: unknown;
+    call = vi.fn();
+    constructor(c: unknown) { this.config = c; }
+  }
+  return {
+    mockLoadConfig: vi.fn(),
+    MockAnthropicProvider,
+  };
+});
+
+vi.mock('../config.js', () => ({
+  loadConfig: () => mockLoadConfig(),
+}));
+
+vi.mock('../anthropic.js', () => ({
+  AnthropicProvider: MockAnthropicProvider,
+}));
+
+import { getProvider, resetProvider } from '../index.js';
+
+describe('getProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetProvider();
   });
 
-  it('should handle null input', () => {
-    expect(sanitize(null)).toEqual('');
+  it('creates AnthropicProvider for anthropic config', () => {
+    mockLoadConfig.mockReturnValue({
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      apiKey: 'sk-test',
+    });
+    const provider = getProvider();
+    expect(provider).toBeInstanceOf(MockAnthropicProvider);
   });
 });
 ```
 
 ## Common Issues
 
-**Issue: "Cannot find module" error when importing from test**
-- **Cause**: Missing `.js` extension in ESM imports
-- **Fix**: Ensure all imports in test files use `.js` extension: `import { foo } from '../module.js'`
+**"Cannot find module" when running tests**
+- **Cause**: `vi.mock()` called after the import statement
+- **Fix**: Move all `vi.mock()` and `vi.unmock()` calls to the TOP of the file, before any `import` statements
 
-**Issue: "process.env.VARIABLE is undefined" in tests**
-- **Cause**: Environment variable not set up in test or not restored properly
-- **Fix**: Use the save/restore pattern from Step 4. Set `process.env.VARIABLE = 'value'` in `beforeEach`.
+**Environment variable persists across tests**
+- **Cause**: `beforeEach` assigns by reference instead of copying: `process.env = originalEnv`
+- **Fix**: Create a copy in `beforeEach`: `process.env = { ...originalEnv }; delete process.env.VAR`
 
-**Issue: "vi.mock is not defined" or mock not working**
-- **Cause**: Attempting to mock after imports, or mocking an already-imported module
-- **Fix**: Call `vi.mock()` at the top of the file, before any imports of the mocked module.
+**Temporary files not cleaned up, filling disk**
+- **Cause**: `afterEach` not called or temp paths not tracked
+- **Fix**: Use centralized cleanup array: `dirs: string[] = []` pushed to in tests, cleaned in `afterEach` with `fs.rmSync(..., { recursive: true, force: true })`
 
-**Issue: Tests pass locally but fail in CI**
-- **Cause**: Mock state or env vars not cleaned up between tests
-- **Fix**: Add `vi.clearAllMocks()` in `beforeEach` and restore `process.env` in `afterEach`.
+**Mock return value from previous test bleeds into next test**
+- **Cause**: `vi.clearAllMocks()` not called in `beforeEach`
+- **Fix**: Add `vi.clearAllMocks()` as first statement in `beforeEach`
 
-**Issue: "Timeout of 5000ms exceeded"**
-- **Cause**: Async test or mock not resolving
-- **Fix**: Ensure mocks return resolved promises. Use `vi.fn().mockResolvedValue()` for async mocks.
+**"vi.mocked() is not a function" when accessing mock calls**
+- **Cause**: Trying to use `vi.mocked()` on a non-mocked module
+- **Fix**: Ensure the module is mocked with `vi.mock()` before importing, then cast: `const mockFn = vi.mocked(importedFn)`
 
-**Issue: Tests reference global LLM mock but it's not available**
-- **Cause**: Test setup not loading `src/test/setup.ts`
-- **Fix**: Verify `vitest.config.ts` includes `setupFiles: ['src/test/setup.ts']`. This is already configured in the project.
+**Test passes locally but fails in CI**
+- **Cause**: Tests rely on real file system or network (not mocked)
+- **Fix**: Check if temp files are being created in real directories instead of mocked ones. Verify all external calls use `vi.mock()` for fs/http/exec
+
+**Coverage threshold failures: "lines not covered", "statements not covered"**
+- **Cause**: Branches or error paths not tested
+- **Fix**: Run `pnpm test:coverage` locally to see untested lines. Add `it()` tests for error cases, edge conditions, and branches that return different values
+- **Example**: If `if (x) return 'a'; else return 'b';` has 0% branch coverage, add tests: one with x=true, one with x=false
+
+**"expected 1 error but got 0" when testing error throws**
+- **Cause**: Error not actually thrown, or thrown asynchronously
+- **Fix**: For sync functions: `expect(() => fn()).toThrow('message')`. For async: `expect(async () => { await fn() }).rejects.toThrow('message')` or use `await expect(promise).rejects.toThrow()`
+
+**Mock factory returns undefined**
+- **Cause**: `vi.hoisted()` variables used before definition in the same block
+- **Fix**: Ensure `vi.hoisted()` block returns all factories, and `vi.mock()` blocks use them after the hoisted definition
+
+**Test flakes (sometimes passes, sometimes fails)**
+- **Cause**: Timing issues or file system race conditions in cleanup
+- **Fix**: For file cleanup, use `{ force: true }` in `rmSync`. For timing, avoid `setTimeout`; use `vi.useFakeTimers()` and `vi.runAllTimers()` if needed. Check for leftover files from previous test runs in `beforeEach`

--- a/.claude/skills/llm-provider/SKILL.md
+++ b/.claude/skills/llm-provider/SKILL.md
@@ -1,300 +1,247 @@
 ---
 name: llm-provider
-description: Adds a new LLM provider implementing LLMProvider interface with call() and stream() methods. Integrates config in src/llm/config.ts, factory in src/llm/index.ts, and error handling. Use when adding a new provider backend, integrating a model API, or extending LLM capabilities. Do NOT use for modifying existing providers or fixing provider bugs.
+description: Adds a new LLM provider implementing LLMProvider interface with call() and stream() methods. Integrates with provider factory in src/llm/index.ts, config detection in src/llm/config.ts, and error handling via tracking and recovery. Use when adding a new model backend, integrating a third-party LLM API, or extending LLM platform support. Do NOT use for fixing bugs in existing providers, modifying existing provider behavior, or changing the LLMProvider interface.
+paths:
+  - src/llm/**/*.ts
+  - src/llm/__tests__/**/*.ts
 ---
-# llm-provider
+# LLM Provider
 
 ## Critical
 
-- **Interface compliance**: Every provider MUST implement `LLMProvider` from `src/llm/types.ts` with exactly two methods: `call(params)` and `stream(params)`. Both return `Promise<LLMResponse>` and `AsyncIterable<StreamChunk>` respectively.
-- **No hardcoded model mappings**: Detection and selection MUST be LLM-driven or user-selected, never static. Seat-based providers (Cursor, Claude CLI) must skip validation in `validateModel()` checks.
-- **Error handling**: All network/auth errors MUST be caught and wrapped in `LLMError` with code (e.g., `'auth'`, `'rate_limit'`, `'model_not_found'`). Provide actionable error messages.
-- **Stream format**: Stream chunks MUST follow `{ type: 'text' | 'stop', text?: string, stop_reason?: string }`. The `stream-parser.ts` expects exact format.
-- **Fast model scoping**: `ANTHROPIC_SMALL_FAST_MODEL` env var is scoped ONLY to `anthropic` and `vertex` providers in `getFastModel()`. Other providers must not read this var.
+1. **All providers MUST implement the LLMProvider interface** from src/llm/types.ts with three methods:
+   - call(options: LLMCallOptions): Promise<string> — single non-streaming call returning text
+   - stream(options: LLMStreamOptions, callbacks: LLMStreamCallbacks): Promise<void> — streaming call invoking callbacks
+   - listModels?(): Promise<string[]> — optional; list available models from the API
+
+2. **Initialize client in constructor and store defaultModel from config**. Example: `this.client = new YourSDK({ apiKey: config.apiKey })`. Never lazy-initialize on first call — providers are instantiated once and cached in src/llm/index.ts.
+
+3. **For EVERY response in call() and stream(), invoke trackUsage(model, usage)** from src/llm/usage.js before returning/ending. This is mandatory — it captures token metrics for CLI telemetry and cost analysis. If the API doesn't return usage data, estimate via estimateTokens(text), which assumes ~4 chars per token.
+
+4. **Both call() and stream() must respect the model parameter** using pattern: `options.model || this.defaultModel`. Never hardcode model names. Callers supply model overrides via LLMCallOptions.model.
+
+5. **Error handling: catch all errors, preserve error messages unchanged**. The retry logic in src/llm/index.ts handles transient errors (ECONNRESET, socket hang up, 529 overload). For seat-based providers (Cursor, Claude CLI), wrap stderr via parseSeatBasedError() for user-friendly messages.
+
+6. **Always update ProviderType union** (Step 2), DEFAULT_MODELS (Step 4), and createProvider() switch case (Step 5) in lock-step. Missing any one breaks the build or causes runtime Unknown provider error.
 
 ## Instructions
 
-### Step 1: Create the provider file
-**File**: `src/llm/{provider-name}.ts`
+### Step 1: Create provider class file
+Verify directory exists: `ls -la src/llm/`. Create `src/llm/your-provider.ts`. Match existing provider patterns (src/llm/anthropic.ts, src/llm/openai-compat.ts).
 
-Start with the exact structure from existing providers (e.g., `anthropic.ts`, `openai-compat.ts`):
-
+Minimal structure:
 ```typescript
-import { LLMProvider, LLMResponse, StreamChunk, LLMError } from './types.js';
+import type { LLMProvider, LLMCallOptions, LLMStreamOptions, LLMStreamCallbacks, LLMConfig, TokenUsage } from './types.js';
+import { trackUsage } from './usage.js';
+import { estimateTokens } from './utils.js';
 
-export class MyProvider implements LLMProvider {
-  private apiKey: string;
-  private baseUrl?: string;
+export class YourProviderProvider implements LLMProvider {
+  private client: YourSDKType;
+  private defaultModel: string;
 
-  constructor(apiKey: string, baseUrl?: string) {
-    if (!apiKey) throw new Error('API key required for MyProvider');
-    this.apiKey = apiKey;
-    this.baseUrl = baseUrl;
+  constructor(config: LLMConfig) {
+    if (!config.apiKey) throw new Error('API key required');
+    this.client = new YourSDK({ apiKey: config.apiKey, ...(config.baseUrl && { baseURL: config.baseUrl }) });
+    this.defaultModel = config.model;
   }
 
-  async call(params: {
-    model: string;
-    messages: Array<{ role: 'user' | 'assistant'; content: string }>;
-    temperature?: number;
-    max_tokens?: number;
-    system?: string;
-  }): Promise<LLMResponse> {
-    // Implementation
+  async call(options: LLMCallOptions): Promise<string> {
+    const model = options.model || this.defaultModel;
+    const response = await this.client.messages.create({ model, max_tokens: options.maxTokens || 4096, system: options.system, messages: [{ role: 'user', content: options.prompt }] });
+    trackUsage(model, { inputTokens: response.usage?.input_tokens || 0, outputTokens: response.usage?.output_tokens || 0 });
+    return response.content?.[0]?.text || '';
   }
 
-  async *stream(params: {
-    model: string;
-    messages: Array<{ role: 'user' | 'assistant'; content: string }>;
-    temperature?: number;
-    max_tokens?: number;
-    system?: string;
-  }): AsyncIterable<StreamChunk> {
-    // Implementation
-  }
-}
-```
-
-**Verify**: Both methods exist. Constructor validates required config. No hardcoded API URLs (use env vars or constructor params).
-
-### Step 2: Export from LLM index
-**File**: `src/llm/index.ts`
-
-Add import and factory export:
-
-```typescript
-import { MyProvider } from './my-provider.js';
-
-export { MyProvider };
-export type { /* types if needed */ };
-
-// In the getLLMProvider() factory function:
-case 'my-provider':
-  return new MyProvider(
-    process.env.MY_PROVIDER_API_KEY || '',
-    process.env.MY_PROVIDER_BASE_URL
-  );
-```
-
-**Verify**: Provider is exported. Factory case handles env var reads. No bare API keys in code.
-
-### Step 3: Add configuration in config.ts
-**File**: `src/llm/config.ts`
-
-Add to the config object returned by `getConfig()`:
-
-```typescript
-my_provider: {
-  apiKey: process.env.MY_PROVIDER_API_KEY,
-  baseUrl: process.env.MY_PROVIDER_BASE_URL,
-  isSeatBased: false, // or true if user-seat-licensed (e.g., Cursor)
-  requiresAuth: true,
-}
-```
-
-If the provider has a fast-model option, add to `getFastModel()`:
-
-```typescript
-if (provider === 'my-provider') {
-  return process.env.MY_PROVIDER_FAST_MODEL || 'my-provider-fast-default';
-}
-```
-
-**Verify**: Config key matches case in factory. Env vars are consistent across both files. `isSeatBased` is set correctly.
-
-### Step 4: Implement error handling
-**File**: `src/llm/my-provider.ts`
-
-Wrap API calls in try/catch. Map errors to `LLMError`:
-
-```typescript
-try {
-  const response = await fetch(`${this.baseUrl}/chat`, {
-    method: 'POST',
-    headers: { 'Authorization': `Bearer ${this.apiKey}`, 'Content-Type': 'application/json' },
-    body: JSON.stringify(payload),
-  });
-
-  if (!response.ok) {
-    if (response.status === 401) {
-      throw new LLMError('Invalid API key', 'auth');
-    }
-    if (response.status === 429) {
-      throw new LLMError('Rate limit exceeded', 'rate_limit');
-    }
-    if (response.status === 404) {
-      throw new LLMError(`Model ${params.model} not found`, 'model_not_found');
-    }
-    throw new LLMError(`HTTP ${response.status}: ${await response.text()}`, 'unknown');
-  }
-  // Parse and return
-} catch (err) {
-  if (err instanceof LLMError) throw err;
-  throw new LLMError(`Provider error: ${err.message}`, 'unknown');
-}
-```
-
-**Verify**: All HTTP error codes (401, 429, 404, 5xx) are handled. Network errors are caught. Messages are clear and actionable.
-
-### Step 5: Implement stream() with correct format
-**File**: `src/llm/my-provider.ts`
-
-Yield chunks in the exact format expected by `stream-parser.ts`:
-
-```typescript
-async *stream(params: {...}): AsyncIterable<StreamChunk> {
-  const response = await fetch(`${this.baseUrl}/chat/stream`, { /* ... */ });
-  const reader = response.body?.getReader();
-  if (!reader) throw new LLMError('Stream not available', 'unknown');
-
-  let buffer = '';
-  const decoder = new TextDecoder();
-
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) break;
-
-      buffer += decoder.decode(value, { stream: true });
-      const lines = buffer.split('\n');
-      buffer = lines.pop() || '';
-
-      for (const line of lines) {
-        if (!line || line.startsWith(':')) continue; // SSE comments
-        if (line.startsWith('data: ')) {
-          const data = JSON.parse(line.slice(6));
-          if (data.choices?.[0]?.delta?.content) {
-            yield { type: 'text', text: data.choices[0].delta.content };
-          }
-          if (data.choices?.[0]?.finish_reason) {
-            yield { type: 'stop', stop_reason: data.choices[0].finish_reason };
-          }
-        }
+  async stream(options: LLMStreamOptions, callbacks: LLMStreamCallbacks): Promise<void> {
+    const model = options.model || this.defaultModel;
+    const messages = [...(options.messages || []), { role: 'user' as const, content: options.prompt }];
+    try {
+      const stream = await this.client.stream({ model, max_tokens: options.maxTokens || 10240, system: options.system, messages });
+      let stopReason: string | undefined, usage: TokenUsage | undefined;
+      for await (const chunk of stream) {
+        if (chunk.delta?.text) callbacks.onText(chunk.delta.text);
+        if (chunk.delta?.stop_reason) stopReason = chunk.delta.stop_reason;
+        if (chunk.usage) usage = { inputTokens: chunk.usage.input_tokens, outputTokens: chunk.usage.output_tokens };
       }
-    }
-  } finally {
-    reader.releaseLock();
+      if (usage) trackUsage(model, usage);
+      callbacks.onEnd({ stopReason, usage });
+    } catch (error) { callbacks.onError(error instanceof Error ? error : new Error(String(error))); }
   }
 }
 ```
 
-**Verify**: Stream yields chunks with correct type field. Stop reason is included on finish. Buffer handles partial lines correctly.
+Verify: File exports the class; imports match existing providers.
 
-### Step 6: Write tests
-**File**: `src/llm/__tests__/my-provider.test.ts`
-
-Add minimal tests covering both methods:
-
+### Step 2: Add to ProviderType union
+Edit `src/llm/types.ts` line 1. Add your provider in kebab-case:
 ```typescript
-import { describe, it, expect, vi } from 'vitest';
-import { MyProvider } from '../my-provider.js';
+export type ProviderType = 'anthropic' | 'vertex' | 'openai' | 'cursor' | 'claude-cli' | 'your-provider';
+```
+Verify: `npx tsc --noEmit` shows no ProviderType errors.
 
-describe('MyProvider', () => {
-  it('throws if API key is missing', () => {
-    expect(() => new MyProvider('')).toThrow('API key required');
-  });
-
-  it('call() returns LLMResponse with text', async () => {
-    vi.stubGlobal('fetch', vi.fn(() =>
-      Promise.resolve(new Response(JSON.stringify({
-        choices: [{ message: { content: 'Hello' } }],
-      })))
-    ));
-
-    const provider = new MyProvider('test-key');
-    const response = await provider.call({
-      model: 'gpt-5',
-      messages: [{ role: 'user', content: 'Hi' }],
-    });
-
-    expect(response.text).toBe('Hello');
-  });
-
-  it('stream() yields text chunks', async () => {
-    // Mock streaming response
-    vi.stubGlobal('fetch', vi.fn(() =>
-      Promise.resolve(new Response(new ReadableStream({ /* ... */ })))
-    ));
-
-    const provider = new MyProvider('test-key');
-    const chunks = [];
-    for await (const chunk of provider.stream({
-      model: 'gpt-5',
-      messages: [{ role: 'user', content: 'Hi' }],
-    })) {
-      chunks.push(chunk);
-    }
-
-    expect(chunks.some(c => c.type === 'text')).toBe(true);
-  });
-});
+### Step 3: Add config fields
+If your provider needs fields beyond apiKey, model, baseUrl, extend LLMConfig in src/llm/types.ts:
+```typescript
+export interface LLMConfig {
+  provider: ProviderType;
+  model: string;
+  fastModel?: string;
+  apiKey?: string;
+  baseUrl?: string;
+  yourProviderSecret?: string;
+}
 ```
 
-**Verify**: Tests run without errors. `npm run test -- src/llm/__tests__/my-provider.test.ts` passes.
+### Step 4: Update config.ts
+Edit `src/llm/config.ts`:
 
-### Step 7: Update types if needed
-**File**: `src/llm/types.ts`
-
-If your provider needs additional config fields, extend `ProviderConfig`:
-
+**Line 9:** Add to DEFAULT_MODELS:
 ```typescript
-export interface ProviderConfig {
-  // ... existing fields
-  myProvider?: {
-    apiKey: string;
-    baseUrl?: string;
-    customField?: string;
+export const DEFAULT_MODELS: Record<ProviderType, string> = {
+  anthropic: 'claude-sonnet-4-6',
+  vertex: 'claude-sonnet-4-6',
+  openai: 'gpt-5.4-mini',
+  cursor: 'sonnet-4.6',
+  'claude-cli': 'default',
+  'your-provider': 'your-provider/default-model',
+};
+```
+
+**Line 17:** Add to MODEL_CONTEXT_WINDOWS if known:
+```typescript
+export const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
+  'your-provider/model-name': 128_000,
+};
+```
+
+**Line 59:** In resolveFromEnv(), add env detection before final return null:
+```typescript
+if (process.env.YOUR_PROVIDER_API_KEY) {
+  return {
+    provider: 'your-provider',
+    apiKey: process.env.YOUR_PROVIDER_API_KEY,
+    model: process.env.CALIBER_MODEL || DEFAULT_MODELS['your-provider'],
+    baseUrl: process.env.YOUR_PROVIDER_BASE_URL,
   };
 }
 ```
 
-**Verify**: Type is used consistently in `config.ts` and `index.ts`.
+**Line 115:** In readConfigFile() validation, add 'your-provider' to includes list.
+
+Verify: `npm run test -- src/llm/__tests__/ -t config` confirms env var detection works.
+
+### Step 5: Register in factory
+Edit `src/llm/index.ts`. Add import (line ~4):
+```typescript
+import { YourProviderProvider } from './your-provider.js';
+```
+
+In createProvider() switch (line ~24), add before default case:
+```typescript
+case 'your-provider':
+  return new YourProviderProvider(config);
+```
+
+Verify: `npx tsc --noEmit` passes; no type errors on switch cases.
+
+### Step 6: Write tests
+Create `src/llm/__tests__/your-provider.test.ts`:
+```typescript
+import { describe, it, expect, beforeEach } from 'vitest';
+import { YourProviderProvider } from '../your-provider.js';
+
+describe('YourProviderProvider', () => {
+  let provider: YourProviderProvider;
+  beforeEach(() => {
+    provider = new YourProviderProvider({ provider: 'your-provider', model: 'test', apiKey: 'test' });
+  });
+
+  it('implements LLMProvider interface', () => {
+    expect(typeof provider.call).toBe('function');
+    expect(typeof provider.stream).toBe('function');
+  });
+
+  it('call() returns string', async () => {
+    const result = await provider.call({ system: 'helpful', prompt: 'hi' });
+    expect(typeof result).toBe('string');
+  });
+
+  it('stream() invokes callbacks', async () => {
+    const texts: string[] = [];
+    let ended = false;
+    await provider.stream({ system: 'helpful', prompt: 'hi' }, {
+      onText: (t) => texts.push(t),
+      onEnd: () => { ended = true; },
+      onError: () => {},
+    });
+    expect(ended).toBe(true);
+  });
+});
+```
+
+Verify: `npm run test -- src/llm/__tests__/your-provider.test.ts` passes.
+
+### Step 7: Integration test
+Run factory tests with your provider env var:
+```bash
+YOUR_PROVIDER_API_KEY=test npm run test -- src/llm/__tests__/index.test.ts
+```
+Verify: getProvider() instantiates your provider; llmCall() dispatches correctly.
 
 ## Examples
 
-### User request:
-"Add support for Anthropic's Vertex AI provider."
+### Example 1: Local LM Studio server
+User says: "I need caliber to use my local LM Studio instance."
 
-### Actions taken:
+Actions: Create src/llm/lm-studio.ts extending OpenAICompatProvider. Add 'lm-studio' to ProviderType. In config.ts:
+```typescript
+if (process.env.LM_STUDIO_BASE_URL) {
+  return { provider: 'lm-studio', apiKey: '', model: 'local', baseUrl: process.env.LM_STUDIO_BASE_URL };
+}
+```
+Register in createProvider() case. User: `export LM_STUDIO_BASE_URL=http://localhost:8000/v1`. Result: caliber uses local LM Studio; tokens estimated via estimateTokens().
 
-1. Create `src/llm/vertex.ts` implementing `LLMProvider` with `call()` and `stream()` using Vertex SDK.
-2. Export from `src/llm/index.ts`: `export { VertexProvider }`.
-3. Add factory case in `getLLMProvider()`: `case 'vertex': return new VertexProvider(projectId, location, ...)`
-4. Update `src/llm/config.ts` with Vertex env vars and `isSeatBased: false`.
-5. Implement error handling for Vertex-specific errors (auth, model not found, quota).
-6. Implement `stream()` yielding chunks from Vertex streaming API.
-7. Write tests in `src/llm/__tests__/vertex.test.ts` for both methods.
-8. Run `npm run test -- src/llm/__tests__/vertex.test.ts` to verify.
+### Example 2: Ollama (seat-based)
+User says: "Ollama is auto-detected; no API key needed."
 
-### Result:
-Caliber now supports Vertex AI. Users can set `VERTEX_PROJECT_ID` and `VERTEX_LOCATION`, then select Vertex as their LLM provider during `caliber init`.
+Actions: Create src/llm/ollama.ts extending OpenAICompatProvider. Add 'ollama' to ProviderType and SEAT_BASED_PROVIDERS. In config.ts:
+```typescript
+if (process.env.OLLAMA_HOST) {
+  return { provider: 'ollama', model: 'mistral', baseUrl: process.env.OLLAMA_HOST || 'http://localhost:11434/v1' };
+}
+```
+Result: Offline per-machine LLM without API keys.
 
 ## Common Issues
 
-**Error: "Cannot find module './my-provider.js'"**
-- ESM imports require `.js` extensions. Add `.js` to all relative imports in `index.ts`.
-- Verify file exists at exact path.
+**Unknown provider: your-provider**
+- Cause: ProviderType updated but createProvider() case missing.
+- Fix: Add case in src/llm/index.ts and import the class.
 
-**Error: "LLMError is not exported"**
-- Import from `src/llm/types.js` not `src/llm.js`.
-- Correct: `import { LLMError } from './types.js';`
+**Cannot find module './your-provider.js'**
+- Cause: File named your_provider.ts (underscore) not your-provider.ts (kebab).
+- Fix: Rename file to use kebab-case.
 
-**Stream yields empty text or stops early**
-- Verify buffer handling in stream loop. Lines must be split on `\n` and incomplete lines stored in buffer.
-- Check API response format. Some APIs use Server-Sent Events (`data: `), others use line-delimited JSON.
-- Test with `curl` first: `curl -N https://api/stream` to see raw format.
+**API key is required for YourProvider**
+- Cause: Env var YOUR_PROVIDER_API_KEY not set; resolveFromEnv() didn't detect it.
+- Fix: Verify env var name in config.ts matches. Test: `YOUR_PROVIDER_API_KEY=test npm run test -- src/llm/__tests__/index.test.ts`.
 
-**"Rate limit exceeded" error on every call**
-- Verify API key is valid and has quota remaining. Check provider dashboard.
-- If seat-based, ensure you have a valid license (Cursor, Claude CLI).
-- Check if `isSeatBased: true` is set correctly — seat-based providers bypass rate limit checks in some contexts.
+**LLM response did not include usage tokens**
+- Cause: Provider API doesn't return usage (local models).
+- Fix: Estimate tokens: `trackUsage(model, { inputTokens: estimateTokens(options.system + options.prompt), outputTokens: estimateTokens(response.text) });`
 
-**Provider not appearing in `caliber init` flow**
-- Verify provider is exported from `src/llm/index.ts`.
-- Check `getLLMProvider()` case statement matches provider name.
-- Verify config key exists in `src/llm/config.ts`.
-- Run `caliber status` to see if provider is detected.
+**Stream callbacks never fire; onEnd not called**
+- Cause: Async iterator not fully consumed before method returns.
+- Fix: Ensure iteration completes before onEnd(): `for await (const chunk of stream) { } callbacks.onEnd({ stopReason, usage });`
 
-**Tests fail with "fetch is not defined"**
-- Use `vi.stubGlobal('fetch', ...)` in Vitest to mock fetch.
-- Or import a fetch polyfill like `node-fetch` if targeting Node < 18.
-- Verify `src/test/setup.ts` doesn't stub fetch globally (it shouldn't).
+**My model parameter is ignored**
+- Cause: call()/stream() doesn't use `options.model || this.defaultModel`.
+- Fix: Replace hardcoded model: `const model = options.model || this.defaultModel; const response = await this.client.create({ model, ... });`
+
+**trackUsage() is never called**
+- Cause: Forgot to call trackUsage() in call() or stream().
+- Fix: Add after every response: `trackUsage(model, { inputTokens: ..., outputTokens: ... });`
+
+**Type error: Provider doesn't implement LLMProvider**
+- Cause: Missing method or wrong signature.
+- Fix: Verify all required methods exist with exact signatures from src/llm/types.ts. Copy-paste from anthropic.ts as reference.

--- a/.claude/skills/scoring-checks/SKILL.md
+++ b/.claude/skills/scoring-checks/SKILL.md
@@ -1,231 +1,284 @@
 ---
 name: scoring-checks
-description: Add a new deterministic scoring check in src/scoring/checks/ that evaluates CLAUDE.md quality. Follows the Check[] return pattern, uses point constants from src/scoring/constants.ts, and integrates via filterChecksForTarget() in src/scoring/index.ts. Use when user says 'add scoring check', 'new check', 'modify scoring criteria', or works in src/scoring/checks/. Do NOT use for display changes, refactoring scoring logic, or changing how checks are executed.
+description: Add a new deterministic scoring check in src/scoring/checks/ that evaluates config quality. Follows the Check[] return pattern, uses point constants from src/scoring/constants.ts, and integrates via filterChecksForTarget() in src/scoring/index.ts. Use when user says 'add scoring check', 'new check', 'modify scoring criteria', or works in src/scoring/checks/. Do NOT use for display changes or refactoring scoring logic.
+paths:
+  - src/scoring/checks/**/*.ts
+  - src/scoring/constants.ts
+  - src/scoring/index.ts
 ---
-# scoring-checks
+# Adding a Scoring Check
+
+Add a new deterministic check that evaluates a single aspect of AI agent config quality. All checks must be filesystem-based with no network calls or LLM inference.
 
 ## Critical
 
-- **All checks are deterministic**: No LLM calls, no network I/O, no randomness. Evaluation must be 100% reproducible given the same input.
-- **Return type is `Check[]`**: Each check MUST return an array of objects with `{ id: string; points: number; detail?: string }`. Points are deducted from 100, not added.
-- **Point values come from `src/scoring/constants.ts`**: Never hardcode point values. Import `POINTS_*` constants and use them directly. Example: `POINTS_MISSING_TITLE` is the deduction for a missing title.
-- **Integration happens automatically**: Once your check exports a default function matching the signature, it is auto-discovered and integrated via `filterChecksForTarget()` in `src/scoring/index.ts`. No manual registration needed.
-- **Check signature**: `async (fingerprint: Fingerprint, target: 'claude' | 'cursor' | 'codex', config: Config) => Promise<Check[]>`
-- **Use `=== 100` for validation**: When checking if the score is perfect, use strict equality `=== 100`, not `>= 100`. Score cannot exceed 100.
+- **Check must be deterministic**: Same filesystem state → same result every time. No randomness, no external APIs.
+- **Point values come from constants.ts**: Every `earnedPoints` and `maxPoints` must reference `POINTS_*` from `src/scoring/constants.ts`. Do NOT hardcode numbers.
+- **Always return `Check[]` array**: Export a function `check<Category>(dir: string): Check[]` where category is one of: `existence`, `quality`, `grounding`, `accuracy`, `freshness`, `bonus`.
+- **Every check must have**: `id` (kebab-case, unique), `name`, `category`, `maxPoints`, `earnedPoints`, `passed`, `detail`, and optional `suggestion`/`fix`.
+- **Fix object fields**: `action` (string describing what to do), `data` (context for the fix), `instruction` (user-facing guidance).
+- **Register in src/scoring/index.ts**: Add the import and spread the result into the `allChecks` array in `computeLocalScore()`.
+- **Target filtering**: If the check is platform-specific (Claude-only, Cursor-only, etc.), add its ID to the appropriate `*_ONLY_CHECKS` set in `constants.ts`.
 
 ## Instructions
 
-**Step 1: Create the check file**
+### Step 1: Define point constants in src/scoring/constants.ts
 
-Create `src/scoring/checks/{name}.ts`. Name must be kebab-case and match the check's purpose.
+Verify before proceeding: Is your check measurable with a numeric point value?
+
+Add constants below the appropriate category section (existence, quality, grounding, accuracy, freshness, bonus):
 
 ```typescript
-import { Check, Fingerprint } from '../types.js';
-import { POINTS_MISSING_CONTENT } from '../constants.js';
-import type { Config } from '../../llm/types.js';
+// In the appropriate CATEGORY section, e.g., Quality checks (25 pts):
+export const POINTS_YOUR_CHECK_NAME = 4; // 1-12 pts typical
 
-export default async function checkMyFeature(
-  fingerprint: Fingerprint,
-  target: 'claude' | 'cursor' | 'codex',
-  config: Config
-): Promise<Check[]> {
+// If threshold-based, add a companion array:
+export const YOUR_THRESHOLD_ARRAY = [
+  { minValue: 10, points: 4 },
+  { minValue: 5, points: 2 },
+] as const;
+```
+
+Check existing patterns: Token budgets use `TOKEN_BUDGET_THRESHOLDS`, code blocks use `CODE_BLOCK_THRESHOLDS`, concreteness uses `CONCRETENESS_THRESHOLDS`.
+
+Verify: Review `CATEGORY_MAX` object to ensure your check fits within its category's point budget.
+
+### Step 2: Create or edit check function in src/scoring/checks/
+
+Choose the file based on category. Each file exports a `check<Name>(dir: string): Check[]` function:
+
+- `existence.ts` — files/directories exist (CLAUDE.md, .cursorrules, skills, MCP servers)
+- `quality.ts` — config structure, size, clarity (code blocks, token budget, concreteness, duplicates)
+- `grounding.ts` — references to actual project files/directory structure
+- `accuracy.ts` — validity of references, git-based config drift
+- `freshness.ts` — git commit-based staleness, secrets, permissions
+- `bonus.ts` — hooks, learned content, OpenSkills format
+- `sources.ts` — source configuration and usage
+
+Create the function following this structure:
+
+```typescript
+import type { Check } from '../index.js';
+import {
+  POINTS_YOUR_CHECK,
+  YOUR_THRESHOLD_ARRAY,
+} from '../constants.js';
+import { readFileOrNull } from '../utils.js'; // or other helpers
+
+export function checkYourCategory(dir: string): Check[] {
   const checks: Check[] = [];
 
-  // evaluation logic here
-  // if condition fails:
+  // 1. Measure something concrete
+  const yourMetric = /* e.g., countFiles(), validatePaths(), etc. */;
+  const threshold = YOUR_THRESHOLD_ARRAY.find(t => yourMetric >= t.minValue);
+  const earnedPts = threshold?.points ?? 0;
+
   checks.push({
-    id: 'my-feature-missing',
-    points: POINTS_MISSING_CONTENT,
-    detail: 'User message explaining why this was deducted',
+    id: 'your_unique_check_id',
+    name: 'Human-readable check name',
+    category: 'quality', // matches function context
+    maxPoints: POINTS_YOUR_CHECK,
+    earnedPoints: earnedPts,
+    passed: earnedPts >= Math.ceil(POINTS_YOUR_CHECK * 0.6), // or custom logic
+    detail: `${earnedPts}/${POINTS_YOUR_CHECK} points — ${yourMetric} items found`,
+    suggestion: earnedPts >= POINTS_YOUR_CHECK ? undefined : 'Action to improve',
+    fix: earnedPts >= POINTS_YOUR_CHECK ? undefined : {
+      action: 'verb_noun', // e.g., 'add_code_blocks', 'fix_references'
+      data: { currentValue: yourMetric, targetValue: 10 },
+      instruction: 'Specific, actionable guidance for the user.',
+    },
   });
 
   return checks;
 }
 ```
 
-Verify: File exists at `src/scoring/checks/{name}.ts` with correct function signature.
+Verify ID uniqueness: Run `grep -r "'your_unique_check_id'" src/scoring/checks/` — should return only your new check.
 
-**Step 2: Determine what to evaluate**
+### Step 3: Handle platform-specific filtering (if applicable)
 
-Inspect the fingerprint object (passed as first argument). Common fields:
-- `fingerprint.claude_md.content` — raw CLAUDE.md file content
-- `fingerprint.claude_md.parsed.sections` — parsed sections (title, instructions, etc.)
-- `fingerprint.cursor_rules` — array of Cursor rule files
-- `fingerprint.codex_instructions` — Codex instruction content
-- `fingerprint.codebase_files` — array of codebase files
-
-Verify: Check `src/fingerprint/types.ts` to see all available fields on `Fingerprint`.
-
-**Step 3: Evaluate the target type**
-
-Use the `target` parameter to apply checks only to the relevant agent config. Example:
+If your check only applies to certain agents (Claude, Cursor, Codex, GitHub Copilot), register it in `src/scoring/constants.ts`:
 
 ```typescript
-if (target !== 'claude') return []; // Only check CLAUDE.md
+// Add to the appropriate set:
+export const CLAUDE_ONLY_CHECKS = new Set([
+  'claude_md_exists',
+  'your_new_check_id', // ← add here
+  'claude_rules_exist',
+]);
+```
 
-if (!fingerprint.claude_md.parsed?.sections?.instructions) {
-  checks.push({
-    id: 'missing-instructions',
-    points: POINTS_MISSING_INSTRUCTIONS,
-    detail: 'CLAUDE.md must include an Instructions section.',
-  });
+Available sets (update exactly one if applicable):
+- `CLAUDE_ONLY_CHECKS` — Claude Code targets
+- `CURSOR_ONLY_CHECKS` — Cursor targets
+- `CODEX_ONLY_CHECKS` — Codex/OpenCode targets
+- `COPILOT_ONLY_CHECKS` — GitHub Copilot targets
+- `BOTH_ONLY_CHECKS` — Both Claude AND Cursor (cross-platform parity)
+- `NON_CODEX_CHECKS` — Everything except Codex/OpenCode
+- `CLAUDE_OR_CODEX_CHECKS` — Claude OR Codex
+
+Verify filtering: Examine `filterChecksForTarget()` in `src/scoring/index.ts` to ensure your category will work correctly for your target agents.
+
+### Step 4: Register in src/scoring/index.ts
+
+Import your function at the top:
+
+```typescript
+import { checkYourCategory } from './checks/your-file.js';
+```
+
+Add to `computeLocalScore()` inside the `allChecks` array initialization:
+
+```typescript
+export function computeLocalScore(dir: string, targetAgent?: TargetAgent): ScoreResult {
+  const target = targetAgent ?? detectTargetAgent(dir);
+
+  const allChecks: Check[] = [
+    ...checkExistence(dir),
+    ...checkQuality(dir),
+    ...checkGrounding(dir),
+    ...checkAccuracy(dir),
+    ...checkYourCategory(dir), // ← ADD HERE IN ORDER
+    ...checkFreshness(dir),
+    ...checkBonus(dir),
+    ...checkSources(dir),
+  ];
+  // ... rest of function
 }
 ```
 
-Verify: Check only evaluates for the correct target. If target is not relevant, return an empty array.
+Verify registration: Run `npm test src/scoring/__tests__/accuracy.test.ts` (or similar) — all existing tests should still pass.
 
-**Step 4: Define point deductions**
+### Step 5: Write deterministic unit tests
 
-Open `src/scoring/constants.ts`. If your deduction type doesn't exist, add it:
-
-```typescript
-export const POINTS_MISSING_TITLE = 5;
-export const POINTS_VAGUE_INSTRUCTIONS = 10;
-// etc.
-```
-
-Then import and use in your check:
-
-```typescript
-import { POINTS_MISSING_TITLE, POINTS_VAGUE_INSTRUCTIONS } from '../constants.js';
-
-checks.push({ id: 'no-title', points: POINTS_MISSING_TITLE, detail: '...' });
-```
-
-Verify: All point values are imported from constants, not hardcoded.
-
-**Step 5: Handle edge cases**
-
-For each check, handle missing or null data gracefully:
-
-```typescript
-const content = fingerprint.claude_md.content || '';
-if (!content.trim()) {
-  checks.push({
-    id: 'empty-claude-md',
-    points: POINTS_MISSING_CONTENT,
-    detail: 'CLAUDE.md is empty or missing.',
-  });
-}
-```
-
-Do NOT throw errors. Always return a `Check[]` array, even if it's empty.
-
-Verify: All code paths return `Promise<Check[]>`. No exceptions are thrown.
-
-**Step 6: Write tests**
-
-Create `src/scoring/__tests__/{name}.test.ts`:
+Create or edit `src/scoring/checks/__tests__/your-file.test.ts`:
 
 ```typescript
 import { describe, it, expect } from 'vitest';
-import check from '../checks/{name}.js';
-import type { Fingerprint } from '../types.js';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { checkYourCategory } from '../your-file.js';
+import { POINTS_YOUR_CHECK } from '../../constants.js';
 
-describe('check{Name}', () => {
-  it('returns no checks when content is valid', async () => {
-    const fingerprint: Fingerprint = {
-      claude_md: {
-        content: 'valid content',
-        parsed: { sections: { instructions: 'do X' } },
-      },
-      // ... other required fields
-    };
-    const result = await check(fingerprint, 'claude', {} as any);
-    expect(result).toEqual([]);
+describe('checkYourCategory', () => {
+  it('awards full points when condition passes', () => {
+    const dir = mkdtempSync('test-scoring-');
+    try {
+      // Set up the passing condition
+      writeFileSync(join(dir, 'SOME_FILE.md'), 'content that satisfies check');
+      
+      const checks = checkYourCategory(dir);
+      const check = checks.find(c => c.id === 'your_unique_check_id');
+      
+      expect(check).toBeDefined();
+      expect(check?.passed).toBe(true);
+      expect(check?.earnedPoints).toBe(POINTS_YOUR_CHECK);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
   });
 
-  it('deducts points when content is missing', async () => {
-    const fingerprint: Fingerprint = {
-      claude_md: { content: '', parsed: { sections: {} } },
-      // ...
-    };
-    const result = await check(fingerprint, 'claude', {} as any);
-    expect(result).toContainEqual(
-      expect.objectContaining({ id: 'my-check-id', points: expect.any(Number) })
-    );
+  it('awards zero points when condition fails', () => {
+    const dir = mkdtempSync('test-scoring-');
+    try {
+      // Don't create the required condition
+      const checks = checkYourCategory(dir);
+      const check = checks.find(c => c.id === 'your_unique_check_id');
+      
+      expect(check?.passed).toBe(false);
+      expect(check?.earnedPoints).toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  it('returns correct detail message', () => {
+    const dir = mkdtempSync('test-scoring-');
+    try {
+      const checks = checkYourCategory(dir);
+      const check = checks.find(c => c.id === 'your_unique_check_id');
+      expect(check?.detail).toBeTruthy();
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
   });
 });
 ```
 
-Run: `npm run test -- src/scoring/__tests__/{name}.test.ts`
-
-Verify: All tests pass. Test covers happy path and failure cases.
-
-**Step 7: Verify integration**
-
-Run `npm run build && npm run test`. The check is auto-discovered. No changes to `src/scoring/index.ts` are needed.
-
-Run a manual test:
-
-```bash
-npm run build
-node dist/bin.js score --path /tmp/test-repo
-```
-
-Look for your check ID in the output. Verify: Score calculation includes your check's deductions.
+Run tests: `npm test src/scoring/checks/__tests__/your-file.test.ts`. All must pass before shipping.
 
 ## Examples
 
-**User**: "Add a check to verify CLAUDE.md has a title section."
+### Example 1: Existence Check
+
+**Trigger**: User says "Add a check to verify .claude/rules/ directory exists."
 
 **Actions**:
-1. Create `src/scoring/checks/title.ts`
-2. Add `POINTS_MISSING_TITLE = 5` to `src/scoring/constants.ts`
-3. Write check logic:
+1. Add `export const POINTS_CLAUDE_RULES = 3;` to constants.ts
+2. In existence.ts: `existsSync(join(dir, '.claude', 'rules'))` → true/false
+3. Import in index.ts and add `...checkExistence(dir)` (already done)
+4. Test with mkdtempSync; verify earnedPoints matches POINTS_CLAUDE_RULES
+
+**Result**: Check `id: 'claude_rules_exist'` returns `earnedPoints: 3, passed: true` when dir exists.
+
+### Example 2: Quality Check with Thresholds
+
+**Trigger**: User says "Verify config has at least 3 code blocks with executable commands."
+
+**Actions**:
+1. Add to constants.ts:
    ```typescript
-   if (target !== 'claude') return [];
-   if (!fingerprint.claude_md.parsed?.sections?.title) {
-     checks.push({
-       id: 'missing-title',
-       points: POINTS_MISSING_TITLE,
-       detail: 'CLAUDE.md must have a title section at the top.',
-     });
-   }
-   return checks;
+   export const CODE_BLOCK_THRESHOLDS = [
+     { minBlocks: 3, points: 8 },
+     { minBlocks: 2, points: 6 },
+     { minBlocks: 1, points: 3 },
+   ] as const;
    ```
-4. Write tests in `src/scoring/__tests__/title.test.ts`
-5. Run `npm run test && npm run build`
+2. In quality.ts:
+   - Parse CLAUDE.md with regex to count \`\`\` blocks
+   - Match against CODE_BLOCK_THRESHOLDS
+   - Return points based on threshold match
+3. In fix: Suggest which commands to add
 
-**Result**: Score now deducts 5 points if CLAUDE.md lacks a title. Integration is automatic.
+**Result**: 3+ blocks = 8 pts, 2 blocks = 6 pts, 1 block = 3 pts, 0 blocks = 0 pts.
 
----
+### Example 3: Accuracy Check (Reference Validation)
 
-**User**: "Modify the grounding check to be stricter about vague language."
+**Trigger**: User says "Check that all file paths mentioned in config actually exist."
 
 **Actions**:
-1. Open `src/scoring/checks/grounding.ts`
-2. Add new detection for vague words: `['roughly', 'approximately', 'maybe']`
-3. Create `POINTS_VAGUE_LANGUAGE = 3` in constants
-4. Push new check: `{ id: 'vague-language', points: POINTS_VAGUE_LANGUAGE, detail: '...' }`
-5. Update tests to cover the new words
-6. Run `npm run test -- src/scoring/__tests__/grounding.test.ts`
+1. Add `export const POINTS_REFERENCES_VALID = 8;` to constants.ts
+2. In accuracy.ts:
+   - Extract backtick-quoted paths and dir patterns from config
+   - Check existence with `existsSync(join(dir, path))`
+   - Calculate ratio: `valid / total`
+   - Award partial points: `Math.round(ratio * POINTS_REFERENCES_VALID)`
+3. In fix: List invalid paths the user should fix
 
-**Result**: Grounding check now penalizes vague language more strictly.
+**Result**: 80% valid refs = ~6 pts; 100% valid = 8 pts; 0% valid = 0 pts.
 
 ## Common Issues
 
-**Issue**: "Check not appearing in the score output"
-- **Cause**: File is not being imported or function signature is wrong.
-- **Fix**: Verify the file is in `src/scoring/checks/`, is named correctly, and exports a default async function with signature `(fingerprint, target, config) => Promise<Check[]>`.
-- **Verify**: Run `npm run build` and check for any TypeScript errors. Run `node dist/bin.js score --path /tmp/test` and look for your check ID in output.
+**Issue**: "My check doesn't appear in the score report."
+**Fix**: 1) Verify ID in `*_ONLY_CHECKS` if platform-specific. 2) Verify import and spread in `index.ts` `allChecks` array. 3) Run `npm test` to ensure no tsc errors. 4) Check `detectTargetAgent()` returns your target platform.
 
-**Issue**: "TypeError: Cannot read property 'parsed' of undefined"
-- **Cause**: Accessing fingerprint fields without null checks.
-- **Fix**: Always guard with optional chaining or explicit checks:
-  ```typescript
-  const sections = fingerprint.claude_md?.parsed?.sections;
-  if (!sections) return []; // Handle gracefully
-  ```
+**Issue**: "Points are hardcoded but should use constants."
+**Fix**: Replace all literal numbers like `earnedPoints: 5` with `earnedPoints: POINTS_YOUR_CHECK`. Constants are in `src/scoring/constants.ts` — use them consistently.
 
-**Issue**: "Score calculation includes my check but points don't match"
-- **Cause**: Using hardcoded point values instead of constants, or using `>= 100` instead of `=== 100`.
-- **Fix**: Import all point values from `src/scoring/constants.ts`. When checking if score is perfect, use `score === 100`, not `score >= 100`.
+**Issue**: "Check makes an API call or network request."
+**Fix**: Scoring MUST be deterministic and offline. Use only: `fs` module (readFileSync, existsSync, readdirSync), `path`, `execSync` for git commands. No HTTP, no LLM calls, no external services.
 
-**Issue**: "Test passes locally but fails in CI"
-- **Cause**: Test relies on file system state or environment variables.
-- **Fix**: Use `memfs` or mock the fingerprint object directly. See existing tests in `src/scoring/__tests__/` for patterns.
+**Issue**: "Platform-specific check appears for the wrong agent."
+**Fix**: 1) Verify check ID is in correct `*_ONLY_CHECKS` set. 2) Double-check `filterChecksForTarget()` handles your platform set. 3) Test with `detectTargetAgent()` on a real project.
 
-**Issue**: "My check runs but returns incorrect points"
-- **Cause**: Logic error in condition or wrong constant value.
-- **Fix**: Add console logs or debug statements. Run `npm run test -- --inspect-brk` to step through. Verify the constant value in `constants.ts` matches expected deduction.
+**Issue**: "Test fails with 'Module not found' error."
+**Fix**: Ensure file is in `src/scoring/checks/` (not nested). Use `.js` extension in imports (TypeScript transpiles to ES modules). Run `npm run build` to check for tsc errors.
+
+**Issue**: "Detail message is confusing or too technical."
+**Fix**: Use friendly language: `3 code blocks found (need 3 for full points)` instead of `codeBlockCount=3`. Make it clear WHY they got/lost points.
+
+**Issue**: "Threshold-based check gives wrong points for edge cases."
+**Fix**: Test all boundaries: value=0, value=threshold, value>>threshold. Use `.find()` to match highest-to-lowest: `find(t => value >= t.minValue)`.
+
+**Issue**: "Two checks have the same ID."
+**Fix**: Run `grep -r "'my_id'" src/scoring/checks/` to find duplicates. IDs must be globally unique across all check files. Use descriptive names like `claude_md_exists`, not `check_1`.

--- a/.claude/skills/writers-pattern/SKILL.md
+++ b/.claude/skills/writers-pattern/SKILL.md
@@ -1,200 +1,272 @@
 ---
 name: writers-pattern
-description: Add a new platform writer in src/writers/ that writes agent config files. Generates a writer module matching claude/index.ts, cursor/index.ts, codex/index.ts pattern. Each writer returns string[] of written paths and integrates with writeSetup() in src/writers/index.ts. Use when: 'add platform support', 'new writer for X agent', 'support Y in caliber'. Do NOT use for: modifying existing writers, changing scoring logic, or LLM provider setup.
+description: Add a new platform writer module in src/writers/ that generates and writes agent config files for a supported platform. Each writer exports a function that accepts a config interface, creates directories (rules/, skills/, mcp configs), writes files with proper formatting and frontmatter, and returns string[] of written file paths. Use when adding platform support for a new agent, integrating a new code AI tool, or extending caliber to support new targets. Do NOT use for modifying existing writers, refactoring scoring logic, or changing how writers are invoked.
+paths:
+  - src/writers/*/index.ts
+  - src/writers/__tests__/*.test.ts
+  - src/writers/index.ts
 ---
-# Writers Pattern
+# Platform Writer Pattern
 
 ## Critical
 
-- **All writers are async functions** that take `(config: ResolvedCaliber, options: WriteOptions) => Promise<string[]>`
-- **Always return the array of written file paths**. This integrates with `src/writers/index.ts` for manifest tracking and backup.
-- **Follow the exact import structure** from existing writers: `import type { ResolvedCaliber } from '../types.js'` and `import type { WriteOptions } from './index.js'`
-- **Place the new writer in its own directory** at `src/writers/{platform-name}/index.ts` (e.g., `src/writers/jetbrains/index.ts`)
-- **Validate that the writer is exported from `src/writers/index.ts`** before testing. The main writer exports (claude, cursor, codex) must be added to the switch statement in the `writeSetup()` function.
-- **Create a test file at `src/writers/{platform-name}/__tests__/index.test.ts`** following the Vitest pattern used in existing writer tests.
+- **Every writer MUST**:
+  1. Export a single named function: `write<Platform>Config(config: <PlatformConfig>): string[]`
+  2. Accept a platform-specific config interface defining what content to write
+  3. Return `string[]` of all written file paths (used by manifest and progress display)
+  4. Create parent directories with `fs.mkdirSync(dir, { recursive: true })` before writing files
+  5. Wrap skill frontmatter exactly as shown in Step 4 (YAML between `---` markers)
+  6. NOT modify files outside the intended platform directories (e.g., Claude writer only touches `.claude/`, `CLAUDE.md`, `.mcp.json`)
+
+- **Integration point**: Every writer MUST be imported and called in `src/writers/index.ts` within the `writeSetup()` function. Missing this step means the writer will never execute.
+
+- **Validation before Step 1**: Verify the platform name is unique (`ls src/writers/` shows no `<platform>/index.ts`). If it exists, you are modifying, not adding.
 
 ## Instructions
 
-### Step 1: Study the existing writer pattern
-Examine `src/writers/claude/index.ts`, `src/writers/cursor/index.ts`, or `src/writers/codex/index.ts`.
-- Note the function signature: `export default async function writeWriter(config: ResolvedCaliber, options: WriteOptions): Promise<string[]>`
-- Identify the config properties being used (e.g., `config.paths.claude`, `config.content.claude`)
-- Observe how paths are constructed with `path.join()` and how content is written with `fs.promises.writeFile()`
-- Note error handling: wrap file operations in try-catch, log errors, and always include the file path in the return array on success
+### Step 1: Define the Platform Config Interface
+Verify the platform name is unique (see Critical). Create `src/writers/<platform>/index.ts`.
 
-**Verify**: You can explain what properties from `ResolvedCaliber` and `WriteOptions` are available before proceeding.
+At the top of the file, define a config interface that describes all content the writer accepts. The interface MUST include:
+- A main markdown/text file (e.g., `claudeMd`, `cursorrules`, `agentsMd`, `instructions`)
+- Optional nested arrays: `rules`, `skills`, `mcpServers`, `instructionFiles`, etc.
+- Each rule/skill/file has at minimum: `name` or `filename`, `content`, and for skills, `description`
 
-### Step 2: Create the writer directory and index file
-Create `src/writers/{platform-name}/index.ts`:
+Example (matching GitHub Copilot pattern already in codebase):
 ```typescript
-import path from 'path';
-import { promises as fs } from 'fs';
-import type { ResolvedCaliber } from '../../types.js';
-import type { WriteOptions } from '../index.js';
-
-export default async function write{PlatformName}(
-  config: ResolvedCaliber,
-  options: WriteOptions,
-): Promise<string[]> {
-  const writtenPaths: string[] = [];
-  const { workspaceRoot, dryRun, verbose } = options;
-
-  try {
-    // Get config content (passed from writeSetup)
-    const content = config.content['{platform-key}'] || '';
-    if (!content) {
-      if (verbose) console.log(`No content for {platform-name}`);
-      return writtenPaths;
-    }
-
-    // Determine output path from config.paths or use default
-    const outputPath = path.join(workspaceRoot, config.paths['{platform-key}'] || '{default-path}');
-
-    // Write file if not in dry run
-    if (!dryRun) {
-      await fs.mkdir(path.dirname(outputPath), { recursive: true });
-      await fs.writeFile(outputPath, content, 'utf-8');
-    }
-
-    writtenPaths.push(outputPath);
-    if (verbose) console.log(`Wrote {platform-name} config to ${outputPath}`);
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    console.error(`Failed to write {platform-name} config: ${message}`);
-  }
-
-  return writtenPaths;
+interface CopilotConfig {
+  instructions: string;  // Main content
+  instructionFiles?: Array<{ filename: string; content: string }>;
 }
 ```
 
-**Verify**: File exists at correct path, function signature matches pattern, imports are correct.
+**Validation**: Confirm the interface property names match platform conventions (e.g., Claude uses `claudeMd`, Cursor uses `cursorrules`). Check existing writers: `src/writers/claude/index.ts` line 9, `src/writers/cursor/index.ts` line 9, `src/writers/codex/index.ts` line 5.
 
-### Step 3: Export the writer from src/writers/index.ts
-Open `src/writers/index.ts` and locate the `writeSetup()` function. Add a case for the new platform:
+### Step 2: Implement the Writer Export Function
+Export a function named `write<Platform>Config(config: <PlatformConfig>): string[]` that:
+
+1. Initialize an empty `written: string[] = []` array to track all written paths.
+2. For the **main config file** (e.g., `CLAUDE.md` for Claude, `.cursorrules` for Cursor):
+   - Wrap the content with **platform-specific blocks**: Use helpers from `src/writers/pre-commit-block.ts`
+   - Common blocks: `appendPreCommitBlock(content, platform)`, `appendLearningsBlock(content)`, `appendSyncBlock(content)`
+   - Examples from actual codebase:
+     - **Claude** (`src/writers/claude/index.ts` line 19-22): `appendSyncBlock(appendLearningsBlock(appendPreCommitBlock(config.claudeMd)))`
+     - **Cursor** (`src/writers/cursor/index.ts` line 19-22): No sync block; injects rules instead (pre-commit, learnings, sync as separate files)
+     - **Codex** (`src/writers/codex/index.ts` line 13-16): `appendLearningsBlock(appendPreCommitBlock(config.agentsMd, 'codex'))`
+     - **Copilot** (`src/writers/github-copilot/index.ts` line 19-22): `appendSyncBlock(appendLearningsBlock(appendPreCommitBlock(config.instructions, 'copilot')))`
+   - Write to the exact path (e.g., `fs.writeFileSync('CLAUDE.md', wrappedContent)`) and push to `written`.
+
+3. For **rules** (if applicable): Platform convention determines directory.
+   - Cursor uses `.cursor/rules/`, Claude uses `.claude/rules/` (see `src/writers/index.ts` lines 123-126 and 135-137)
+   - For each rule: create the directory, write to `<dir>/<rule.filename>`, push path to `written`
+   - **Cursor special case** (`src/writers/cursor/index.ts` line 24-27): Cursor injects three system rules:
+     ```typescript
+     const preCommitRule = getCursorPreCommitRule();
+     const learningsRule = getCursorLearningsRule();
+     const syncRule = getCursorSyncRule();
+     const allRules = [...(config.rules || []), preCommitRule, learningsRule, syncRule];
+     ```
+
+4. For **skills**: Write with YAML frontmatter.
+   - Directory pattern: `.claude/skills/<skillName>/SKILL.md`, `.cursor/skills/<skillName>/SKILL.md`, `.agents/skills/<skillName>/SKILL.md`, `.opencode/skills/<skillName>/SKILL.md`
+   - Frontmatter format (exact indentation from `src/writers/claude/index.ts` line 40-47):
+     ```
+     ---
+     name: <skill.name>
+     description: <skill.description>
+     paths:
+       - <optional path pattern 1>
+       - <optional path pattern 2>
+     ---
+     <skill.content>
+     ```
+   - For **Opencode** (`src/writers/opencode/index.ts` line 30): Use `buildSkillContent(skill)` from `src/lib/builtin-skills.js` instead of manual frontmatter.
+   - Create directory with `fs.mkdirSync(skillDir, { recursive: true })`, write skill, push to `written`
+
+5. For **MCP Servers** (if applicable): Write/merge JSON at platform-specific path.
+   - **Claude** (`src/writers/claude/index.ts` line 54-65): `.mcp.json` at root
+   - **Cursor** (`src/writers/cursor/index.ts` line 54-69): `.cursor/mcp.json`
+   - Pattern: Read existing servers (if file exists, try to parse JSON with try/catch), merge with new servers using spread operator `{ ...existingServers, ...config.mcpServers }`, write merged object
+   - Wrap in `{ mcpServers: mergedServers }` and output as pretty-printed JSON: `JSON.stringify(wrapped, null, 2)`
+
+6. For **instruction files** (GitHub Copilot, `src/writers/github-copilot/index.ts` line 26-33): Write to `.github/instructions/` directory.
+   - Create directory, iterate files, write each to `<dir>/<file.filename>`, push paths
+
+Return the `written` array.
+
+**Validation**: Confirm all file write operations are synchronous (`fs.writeFileSync`, `fs.mkdirSync`). Ensure every written path is added to the array. No async operations allowed.
+
+### Step 3: Add Type Exports (if complex interface)
+If the config interface may be reused elsewhere (e.g., in `src/writers/index.ts` for the `AgentSetup` type), export the interface from the module.
+
+**Validation**: Check `src/writers/index.ts` lines 15-19 to see if new agent setup params are needed.
+
+### Step 4: Import and Register in `src/writers/index.ts`
+Open `src/writers/index.ts`. At the top (around line 2-6), add:
 ```typescript
-case '{platform-key}':
-  writeResult = await write{PlatformName}(config, options);
-  break;
+import { write<Platform>Config } from './<platform>/index.js';
 ```
 
-Also add the import at the top:
+Update the `AgentSetup` interface (around line 12-20):
+- Add `'<platform>'` to the `targetAgent` tuple (line 13: `('claude' | 'cursor' | 'codex' | 'opencode' | 'github-copilot' | '<platform>')[]`)
+- Add a new property: `<platform>?: Parameters<typeof write<Platform>Config>[0];`
+
+Update `getFilesToWrite()` function (starting line 117): Add a new conditional block:
 ```typescript
-import write{PlatformName} from './{platform-name}/index.js';
+if (setup.targetAgent.includes('<platform>') && setup.<platform>) {
+  files.push('<main-config-file>');
+  if (setup.<platform>.rules) {
+    for (const r of setup.<platform>.rules) files.push(`<rules-dir>/${r.filename}`);
+  }
+  if (setup.<platform>.skills) {
+    for (const s of setup.<platform>.skills) files.push(`<skills-dir>/${s.name}/SKILL.md`);
+  }
+  // ... repeat for other config types (mcpServers, instructionFiles, etc.)
+}
 ```
 
-Locate the `writerMap` object and add an entry:
+Update `writeSetup()` function (starting line 22): Add a new conditional block before the return (after line 56):
 ```typescript
-{platform-key}: write{PlatformName},
+if (setup.targetAgent.includes('<platform>') && setup.<platform>) {
+  written.push(...write<Platform>Config(setup.<platform>));
+}
 ```
 
-**Verify**: The new writer is callable from `writeSetup()` and `writerMap` is complete.
+**Validation**: Confirm the function call order in `writeSetup()` is consistent (line 37-56): claude → cursor → codex → opencode → github-copilot → (new platform). This ensures AGENTS.md is written once if shared (as with Codex/Opencode, see line 50-52).
 
-### Step 4: Create a test file
-Create `src/writers/{platform-name}/__tests__/index.test.ts`:
+### Step 5: Add Tests
+Create `src/writers/__tests__/<platform>.test.ts` following the vitest pattern in `src/writers/__tests__/codex.test.ts`:
+
+1. Mock `fs` module: `vi.mock('fs')`
+2. Mock return values in `beforeEach`: `vi.mocked(fs.existsSync).mockReturnValue(false)`
+3. Test that:
+   - Main config file is written to correct path
+   - Returned array includes all written paths
+   - Directories are created before file writes (use `.toHaveBeenCalledWith(path, { recursive: true })`)
+   - Skills have correct frontmatter format (check `vi.mocked(fs.writeFileSync).mock.calls`)
+   - MCP/instruction files are merged/created correctly
+   - Pre-commit/learnings/sync blocks are included in main file (expect content `.toContain('caliber:managed:pre-commit')`)
+
+Run: `npm test -- src/writers/__tests__/<platform>.test.ts`
+
+**Validation**: All tests pass. Confirm mocked file operations match actual file system structure.
+
+### Step 6: Update `detectSyncedAgents()` in `src/commands/refresh.ts` (Optional)
+If the platform writes config files with distinct naming (e.g., `.newplatform/`), update the detection logic around line 68-77 so end-user refresh output correctly identifies the synced platform:
+
 ```typescript
-import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { memfs } from 'memfs';
-import path from 'path';
-import write{PlatformName} from '../index.js';
-import type { ResolvedCaliber, WriteOptions } from '../../types.js';
-
-describe('write{PlatformName}', () => {
-  let vol: ReturnType<typeof memfs>['vol'];
-  let workspaceRoot: string;
-
-  beforeEach(() => {
-    const { fs: memfsFs } = memfs();
-    vol = memfsFs;
-    workspaceRoot = '/test-workspace';
-  });
-
-  it('writes {platform-name} config to correct path', async () => {
-    const config: ResolvedCaliber = {
-      paths: { '{platform-key}': '{expected-path}' },
-      content: { '{platform-key}': '# Test Config' },
-    } as unknown as ResolvedCaliber;
-
-    const options: WriteOptions = {
-      workspaceRoot,
-      dryRun: false,
-      verbose: false,
-    };
-
-    const written = await write{PlatformName}(config, options);
-
-    expect(written).toContain(path.join(workspaceRoot, '{expected-path}'));
-  });
-
-  it('returns empty array when no content provided', async () => {
-    const config: ResolvedCaliber = {
-      paths: {},
-      content: {},
-    } as unknown as ResolvedCaliber;
-
-    const options: WriteOptions = {
-      workspaceRoot,
-      dryRun: false,
-      verbose: false,
-    };
-
-    const written = await write{PlatformName}(config, options);
-
-    expect(written).toEqual([]);
-  });
-});
+if (joined.includes('.newplatform/') || joined.includes('newplatform-config')) {
+  agents.push('<Platform Name>');
+}
 ```
 
-**Verify**: Test file runs without errors. Run `npm run test -- src/writers/{platform-name}/__tests__/`.
-
-### Step 5: Integrate with content generation
-If the writer requires generated content, add a case in `src/ai/generate.ts` that populates `config.content['{platform-key}']`. If using existing content paths from `ResolvedCaliber.paths`, no additional generation step is needed.
-
-**Verify**: The new writer receives content via the config object, either from existing paths or generated content.
+**Validation**: Run `npm run refresh` and confirm the summary message lists the new platform.
 
 ## Examples
 
-### User: "Add support for VS Code Settings Sync in Caliber"
+### Example 1: Add a hypothetical "DevCode" platform writer
+
+**User says**: "Add support for DevCode, a new agent that reads config from `.devcode/settings.md` and `.devcode/rules/` directory."
 
 **Actions taken**:
-1. Create `src/writers/vscode-settings/index.ts`
-2. Writer reads `config.content.vscodeSettings` (populated by `src/ai/generate.ts`)
-3. Writes to `.vscode/settings.json` or path specified in `config.paths.vscodeSettings`
-4. Returns `['/path/to/.vscode/settings.json']`
-5. Add to `src/writers/index.ts`: `import writeVscodeSettings from './vscode-settings/index.js'`
-6. Add case in `writeSetup()`: `case 'vscodeSettings': writeResult = await writeVscodeSettings(config, options);`
-7. Create test in `src/writers/vscode-settings/__tests__/index.test.ts`
 
-**Result**: `caliber refresh` now writes VS Code settings alongside CLAUDE.md and .cursor/rules/.
+1. Create `src/writers/devcode/index.ts` (matching pattern from `src/writers/claude/index.ts`):
+   ```typescript
+   import fs from 'fs';
+   import path from 'path';
+   import { appendPreCommitBlock, appendLearningsBlock } from '../pre-commit-block.js';
 
-### User: "Add a new writer for GitHub Copilot Chat context"
+   interface DevcodeConfig {
+     settingsMd: string;
+     rules?: Array<{ filename: string; content: string }>;
+   }
 
-**Actions taken**:
-1. Study `src/writers/github-copilot/index.ts` to understand existing Copilot support
-2. Create `src/writers/copilot-chat/index.ts` for Chat-specific context
-3. Writer reads `config.content.copilotChat` and writes to `.github/copilot-chat.md`
-4. Export from `src/writers/index.ts` with import and writeSetup case
-5. Test with `npm run test`
+   export function writeDevcodeConfig(config: DevcodeConfig): string[] {
+     const written: string[] = [];
 
-**Result**: New Copilot Chat context file is written as part of the config sync workflow.
+     fs.writeFileSync(
+       '.devcode/settings.md',
+       appendLearningsBlock(appendPreCommitBlock(config.settingsMd, 'devcode'))
+     );
+     written.push('.devcode/settings.md');
+
+     if (config.rules?.length) {
+       const rulesDir = path.join('.devcode', 'rules');
+       if (!fs.existsSync(rulesDir)) fs.mkdirSync(rulesDir, { recursive: true });
+       for (const rule of config.rules) {
+         const rulePath = path.join(rulesDir, rule.filename);
+         fs.writeFileSync(rulePath, rule.content);
+         written.push(rulePath);
+       }
+     }
+
+     return written;
+   }
+   ```
+
+2. Update `src/writers/index.ts`:
+   - Line 2: Add `import { writeDevcodeConfig } from './devcode/index.js';`
+   - Line 13: Change `targetAgent` tuple to include `'devcode'`
+   - Line 19: Add `devcode?: Parameters<typeof writeDevcodeConfig>[0];`
+   - Line 117+: Add devcode block to `getFilesToWrite()` (match Codex pattern lines 144-149)
+   - Line 37+: Add devcode block to `writeSetup()` (match Codex pattern lines 45-47)
+   - Line 68+: Update `detectSyncedAgents()` to check for `.devcode/`
+
+3. Create `src/writers/__tests__/devcode.test.ts` (matching `src/writers/__tests__/codex.test.ts`):
+   ```typescript
+   import { describe, it, expect, vi, beforeEach } from 'vitest';
+   import fs from 'fs';
+   import path from 'path';
+
+   vi.mock('fs');
+
+   import { writeDevcodeConfig } from '../devcode/index.js';
+
+   describe('writeDevcodeConfig', () => {
+     beforeEach(() => {
+       vi.clearAllMocks();
+       vi.mocked(fs.existsSync).mockReturnValue(false);
+     });
+
+     it('writes settings.md and rules', () => {
+       const config = {
+         settingsMd: '# DevCode Config',
+         rules: [{ filename: 'style.md', content: 'Style rules' }],
+       };
+       const written = writeDevcodeConfig(config);
+       expect(written).toContain('.devcode/settings.md');
+       expect(written).toContain(path.join('.devcode', 'rules', 'style.md'));
+     });
+   });
+   ```
+
+4. Run: `npm test && npm run build`
+
+**Result**: Caliber now generates `.devcode/settings.md` and rules on `caliber refresh` and `caliber init`.
 
 ## Common Issues
 
-**Issue**: `TypeError: Cannot read property 'content' of undefined`
-- **Cause**: Writer function not receiving `ResolvedCaliber` object properly from `writeSetup()`
-- **Fix**: 1. Verify the writer is called with `config` parameter in `writeSetup()`. 2. Check that `ResolvedCaliber` type is imported correctly. 3. Log `config` at the start of the writer to confirm structure.
+**Issue**: "TypeError: write<Platform>Config is not a function"
+- **Fix**: Verify the function is **exported** (not just defined). Check `export function write<Platform>Config(...)` in the writer file. Missing `export` is a common mistake.
 
-**Issue**: `ENOENT: no such file or directory, open '/path/to/file'`
-- **Cause**: Parent directory doesn't exist
-- **Fix**: Always call `fs.mkdir(path.dirname(outputPath), { recursive: true })` before writing. This creates parent directories automatically.
+**Issue**: "ENOENT: no such file or directory, open '.platform/config.md'"
+- **Fix**: The parent directory was not created. Ensure `fs.mkdirSync(parentDir, { recursive: true })` is called **before** `fs.writeFileSync(filePath, content)`. See correct order in `src/writers/claude/index.ts` lines 26-27.
 
-**Issue**: Writer returns empty array even though file should exist
-- **Cause**: Config.content is empty or undefined, function returns early
-- **Fix**: 1. Check that content is being populated in `src/ai/generate.ts` or passed via config.content. 2. Add verbose logging: `if (verbose) console.log('content:', content)` to debug. 3. Verify the platform key matches exactly (case-sensitive).
+**Issue**: "Skill file has no frontmatter / malformed YAML"
+- **Fix**: Verify frontmatter format is exactly (no extra blank lines):
+  ```
+  ---\nname: <name>\ndescription: <desc>\n---\n<content>
+  ```
+  Use `[...].join('\n')` and test with a single skill first. Compare with working code in `src/writers/claude/index.ts` lines 40-48.
 
-**Issue**: Test fails with `memfs not set up correctly`
-- **Cause**: Mock filesystem not initialized before test
-- **Fix**: Ensure `beforeEach` runs before each test and initializes `memfs()` properly. Verify `vi.mock()` patches are applied if mocking `fs.promises`.
+**Issue**: "MCP servers not merging, file is truncated"
+- **Fix**: Confirm the merge pattern from `src/writers/claude/index.ts` line 54-65: read existing JSON (with try/catch), parse safely, merge with spread operator `{ ...existingServers, ...config.mcpServers }`, then write the merged object. Do NOT overwrite — always merge.
 
-**Issue**: `Module not found: src/writers/{platform-name}/index.js`
-- **Cause**: Import path in `src/writers/index.ts` is wrong or file doesn't exist
-- **Fix**: 1. Verify file exists at `src/writers/{platform-name}/index.ts`. 2. Double-check import path uses `.js` extension (ESM). 3. Run `npm run build` and check for TypeScript errors.
+**Issue**: "new writer is called but written files are empty array"
+- **Fix**: Verify the writer function returns the `written` array. Check that every file operation pushes to `written`. Missing a `written.push(filePath)` after `fs.writeFileSync()` is the most common error. See `src/writers/codex/index.ts` lines 17 and 32 for correct pattern.
+
+**Issue**: "Tests mock fs but actual files are created in .tmp/ or cause permission errors"
+- **Fix**: Ensure `vi.mock('fs')` is at the top of the test file before any imports. All `fs` operations will be mocked and return mock values from `beforeEach` setup. See `src/writers/__tests__/codex.test.ts` line 5.
+
+**Issue**: "Cursor pre-commit rule not applied, or learnings block missing"
+- **Fix**: Cursor injects system rules during the write, unlike Claude which uses block appenders. Check that `getCursorPreCommitRule()`, `getCursorLearningsRule()`, and `getCursorSyncRule()` are called and concatenated with user rules **before** iterating (see `src/writers/cursor/index.ts` lines 24-27). Claude and Codex use block-append helpers instead.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What Is This
 
-`@rely-ai/caliber` — CLI that keeps AI agent configs in sync with your codebase, automatically. Generates and continuously refreshes `CLAUDE.md`, `.cursor/rules/`, `AGENTS.md`, `.github/copilot-instructions.md`, and skills across Claude Code, Cursor, Codex, and GitHub Copilot. Supports Anthropic, OpenAI, Google Vertex AI, OpenAI-compatible endpoints, Claude Code CLI, and Cursor ACP.
+`@rely-ai/caliber` — CLI that keeps AI agent configs in sync with your codebase. Generates and refreshes `CLAUDE.md`, `.cursor/rules/`, `AGENTS.md`, `.github/copilot-instructions.md`, and skills across Claude Code, Cursor, Codex, OpenCode, and GitHub Copilot. Supports Anthropic, OpenAI, Google Vertex AI, OpenAI-compatible endpoints, Claude Code CLI, and Cursor ACP.
 
 ## Commands
 
@@ -19,7 +19,7 @@ npx vitest run src/scoring/__tests__/accuracy.test.ts  # single test
 
 **Entry**: `src/bin.ts` → `src/cli.ts` (Commander.js) · **Config**: `tsconfig.json` · `tsup.config.ts` · `vitest.config.ts` · `eslint.config.js` · `.prettierrc`
 
-**Commands** (`src/commands/`): `init.ts` · `score.ts` · `refresh.ts` · `regenerate.ts` · `config.ts` · `hooks.ts` · `insights.ts` · `learn.ts` · `recommend.ts` · `sources.ts` · `publish.ts` · `undo.ts` · `status.ts` · Helpers: `init-helpers.ts` · `init-prompts.ts` · `init-display.ts` · `setup-files.ts` · `interactive-provider-setup.ts`
+**Commands** (`src/commands/`): `init.ts` · `score.ts` · `refresh.ts` · `regenerate.ts` · `config.ts` · `hooks.ts` · `insights.ts` · `learn.ts` · `recommend.ts` · `sources.ts` · `publish.ts` · `undo.ts` · `status.ts` · `bootstrap.ts` · `uninstall.ts` · Helpers: `init-helpers.ts` · `init-prompts.ts` · `init-display.ts` · `setup-files.ts` · `interactive-provider-setup.ts`
 
 **LLM** (`src/llm/`): `anthropic.ts` · `vertex.ts` · `openai-compat.ts` · `cursor-acp.ts` · `claude-cli.ts` · `types.ts` · `config.ts` · `utils.ts` · `usage.ts` · `model-recovery.ts` · `seat-based-errors.ts` · `index.ts`
 
@@ -29,19 +29,21 @@ npx vitest run src/scoring/__tests__/accuracy.test.ts  # single test
 
 **Scoring** (`src/scoring/`): `index.ts` · `display.ts` · `constants.ts` · `utils.ts` · `history.ts` · `dismissed.ts` · Checks (`src/scoring/checks/`): `existence.ts` · `quality.ts` · `grounding.ts` · `accuracy.ts` · `freshness.ts` · `bonus.ts` · `sources.ts`
 
-**Writers** (`src/writers/`): `index.ts` · `claude/index.ts` · `cursor/index.ts` · `codex/index.ts` · `github-copilot/index.ts` · `refresh.ts` · `staging.ts` · `backup.ts` · `manifest.ts` · `pre-commit-block.ts`
+**Writers** (`src/writers/`): `index.ts` · `claude/index.ts` · `cursor/index.ts` · `codex/index.ts` · `opencode/index.ts` · `github-copilot/index.ts` · `refresh.ts` · `staging.ts` · `backup.ts` · `manifest.ts` · `pre-commit-block.ts`
 
-**Scanner** (`src/scanner/`): `index.ts` — detects local MCP servers, rules, and skills across platforms
+**Scanner** (`src/scanner/`): `index.ts` — detects local `.mcp.json`, `.cursor/mcp.json` MCP servers, rules, and skills across platforms
 
-**Lib** (`src/lib/`): `hooks.ts` · `learning-hooks.ts` · `state.ts` · `resolve-caliber.ts` · `builtin-skills.ts` · `sanitize.ts` · `notifications.ts` · `git-diff.ts` · `lock.ts` · `debug-report.ts`
+**Lib** (`src/lib/`): `hooks.ts` · `learning-hooks.ts` · `state.ts` · `resolve-caliber.ts` · `builtin-skills.ts` · `sanitize.ts` · `notifications.ts` · `git-diff.ts` · `lock.ts` · `debug-report.ts` · `config-discovery.ts` · `terminal.ts`
 
 **Utils** (`src/utils/`): `parallel-tasks.ts` · `spinner-messages.ts` · `editor.ts` · `review.ts` · `prompt.ts` · `version-check.ts` · `dependencies.ts` · `waiting-content.ts` · `waiting-cards.json`
 
 **Telemetry** (`src/telemetry/`): `index.ts` · `config.ts` · `events.ts` · **Learner** (`src/learner/`): `writer.ts` · `storage.ts` · `attribution.ts` · `roi.ts` · `utils.ts` · `stdin.ts`
 
-**Other**: `github-action/action.yml` · `github-action/index.js` · `assets/video/` (Remotion) · `scripts/` · `docs/FLOW.md` · `src/constants.ts` · `src/test/setup.ts` · `CONTRIBUTING.md` · `CHANGELOG.md` · `TODOS.md`
+**Other**: `github-action/action.yml` · `github-action/index.js` · `assets/video/` (Remotion) · `scripts/` · `docs/FLOW.md` · `src/constants.ts` · `src/test/setup.ts` · `CHANGELOG.md` · `TODOS.md`
 
 **Workspaces**: `packages/shared/` · `packages/mcp-server/` (MCP server) · `apps/web/` · `apps/api/`
+
+@./CONTRIBUTING.md
 
 ## Conventions
 
@@ -54,17 +56,18 @@ npx vitest run src/scoring/__tests__/accuracy.test.ts  # single test
 ## Key Patterns
 
 - **Providers**: implement `LLMProvider` from `src/llm/types.ts` (`call()`, `stream()`)
-- **Writers**: `src/writers/claude/index.ts` · `src/writers/cursor/index.ts` · `src/writers/codex/index.ts` each return `string[]`
+- **Writers**: `src/writers/claude/index.ts` · `src/writers/cursor/index.ts` · `src/writers/codex/index.ts` · `src/writers/opencode/index.ts` each return `string[]`
 - **Scoring**: checks in `src/scoring/checks/` return `Check[]`, constants in `src/scoring/constants.ts`
 - **No hardcoded mappings**: detection is LLM-driven via `src/ai/detect.ts`
-- `collectFingerprint()` in `src/fingerprint/index.ts` is async with internal LLM enrichment
+- `collectFingerprint()` in `src/fingerprint/index.ts` — async with LLM enrichment
 - `resolveCaliber()` from `src/lib/resolve-caliber.ts` for CLI binary resolution
 - Cursor provider: `agent --print --trust --workspace /tmp` in `src/llm/cursor-acp.ts`
 - `getFastModel()` in `src/llm/config.ts`: `ANTHROPIC_SMALL_FAST_MODEL` scoped to anthropic/vertex
 - `validateModel()` skips seat-based providers (`isSeatBased()` in `src/llm/types.ts`)
 - Scoring: deterministic, no LLM · Backups via `src/writers/backup.ts`
 - Scanner: `src/scanner/index.ts` detects local MCP servers, rules, skills for state comparison
-- MCP server workspace: `packages/mcp-server/`
+- MCP server workspace: `packages/mcp-server/` · Config discovery: `src/lib/config-discovery.ts`
+- Builtin skills (`src/lib/builtin-skills.ts`): `find-skills`, `save-learning`, `setup-caliber`
 
 <!-- caliber:managed:pre-commit -->
 ## Before Committing
@@ -79,7 +82,7 @@ grep -q "caliber" .git/hooks/pre-commit 2>/dev/null && echo "hook-active" || ech
 - If **hook-active**: the hook handles sync automatically — just commit normally. Tell the user: "Caliber will sync your agent configs automatically via the pre-commit hook."
 - If **no-hook**: run Caliber manually before committing:
   1. Tell the user: "Caliber: Syncing agent configs with your latest changes..."
-  2. Run: `caliber refresh && git add CLAUDE.md .claude/ .cursor/ .cursorrules .github/copilot-instructions.md .github/instructions/ AGENTS.md CALIBER_LEARNINGS.md 2>/dev/null`
+  2. Run: `caliber refresh && git add CLAUDE.md .claude/ .cursor/ .cursorrules .github/copilot-instructions.md .github/instructions/ AGENTS.md CALIBER_LEARNINGS.md .agents/ .opencode/ 2>/dev/null`
   3. After it completes, briefly tell the user what Caliber updated. Then proceed with the commit.
 
 If `caliber` is not found, tell the user: "This project uses Caliber for agent config sync. Run /setup-caliber to get set up."

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Requires **Node.js >= 20**.
 npx @rely-ai/caliber bootstrap
 ```
 
-Then, in your next Claude Code or Cursor chat session, type:
+Then, in your terminal (not the IDE chat), start a Claude Code or Cursor CLI session and type:
 
 > **/setup-caliber**
 
@@ -60,6 +60,18 @@ Your agent detects your stack, generates tailored configs for every platform you
 **Don't use Claude Code or Cursor?** Run `caliber init` instead — it's the same setup as a CLI wizard. Works with any LLM provider: bring your own Anthropic, OpenAI, or Vertex AI key.
 
 > **Your code stays on your machine.** Bootstrap is 100% local — no LLM calls, no code sent anywhere. Generation uses your own AI subscription or API key. Caliber never sees your code.
+
+<details>
+<summary><strong>Windows Users</strong></summary>
+
+Caliber works on Windows with a few notes:
+
+- **Run from your terminal** (PowerShell, CMD, or Git Bash) — not from inside an IDE chat window. Open a terminal, `cd` into your project folder, then run `npx @rely-ai/caliber bootstrap`.
+- **Git Bash is recommended.** Caliber's pre-commit hooks and auto-sync scripts use shell syntax. Git for Windows includes Git Bash, which handles this automatically. If you only use PowerShell, hooks may be skipped silently.
+- **Cursor Agent CLI:** If prompted to install it, download from [cursor.com/downloads](https://www.cursor.com/downloads) instead of the `curl | bash` command shown on macOS/Linux. Then run `agent login` in your terminal to authenticate.
+- **One terminal at a time.** Avoid running Caliber from multiple terminals simultaneously — this can cause conflicting state and unexpected provider detection.
+
+</details>
 
 ## Audits first, writes second
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -59,6 +59,8 @@ import {
 } from './init-helpers.js';
 import { recordScore } from '../scoring/history.js';
 
+const IS_WINDOWS = process.platform === 'win32';
+
 export type { TargetAgent };
 
 interface InitOptions {
@@ -230,6 +232,11 @@ export async function initCommand(options: InitOptions) {
   console.log(`  ${chalk.green('✓')} Onboarding hook — nudges new team members to set up`);
   installSessionStartHook();
   console.log(`  ${chalk.green('✓')} Freshness hook — warns when configs are stale`);
+
+  if (IS_WINDOWS) {
+    console.log(chalk.yellow('\n  Note: hooks use shell syntax and require Git Bash (included with Git for Windows).'));
+    console.log(chalk.dim('  If hooks don\'t run, ensure Git for Windows is installed and git is using its bundled sh.'));
+  }
 
   // Install builtin skills (setup-caliber, find-skills, save-learning)
   const { ensureBuiltinSkills } = await import('../lib/builtin-skills.js');

--- a/src/commands/interactive-provider-setup.ts
+++ b/src/commands/interactive-provider-setup.ts
@@ -7,6 +7,8 @@ import { isCursorAgentAvailable, isCursorLoggedIn } from '../llm/cursor-acp.js';
 import { isClaudeCliAvailable } from '../llm/claude-cli.js';
 import { promptInput } from '../utils/prompt.js';
 
+const IS_WINDOWS = process.platform === 'win32';
+
 const PROVIDER_CHOICES: Array<{ name: string; value: ProviderType }> = [
   { name: 'Claude Code — use your existing subscription (no API key)', value: 'claude-cli' },
   { name: 'Cursor — use your existing subscription (no API key)', value: 'cursor' },
@@ -48,8 +50,13 @@ export async function runInteractiveProviderSetup(options?: {
     case 'cursor': {
       if (!isCursorAgentAvailable()) {
         console.log(chalk.yellow('\n  Cursor Agent CLI not found.'));
-        console.log(chalk.dim('  Install it: ') + chalk.hex('#83D1EB')('curl https://cursor.com/install -fsS | bash'));
-        console.log(chalk.dim('  Then run ') + chalk.hex('#83D1EB')('agent login') + chalk.dim(' to authenticate.\n'));
+        if (IS_WINDOWS) {
+          console.log(chalk.dim('  Install it from: ') + chalk.hex('#83D1EB')('https://www.cursor.com/downloads'));
+          console.log(chalk.dim('  Then run ') + chalk.hex('#83D1EB')('agent login') + chalk.dim(' in PowerShell to authenticate.\n'));
+        } else {
+          console.log(chalk.dim('  Install it: ') + chalk.hex('#83D1EB')('curl https://cursor.com/install -fsS | bash'));
+          console.log(chalk.dim('  Then run ') + chalk.hex('#83D1EB')('agent login') + chalk.dim(' to authenticate.\n'));
+        }
         const proceed = await confirm({ message: 'Continue anyway?' });
         if (!proceed) throw new Error('__exit__');
       } else if (!isCursorLoggedIn()) {

--- a/src/commands/score.ts
+++ b/src/commands/score.ts
@@ -160,13 +160,13 @@ export async function scoreCommand(options: ScoreOptions) {
     console.log(
       chalk.gray('  Run ') +
         chalk.hex('#83D1EB')(`${bin} init`) +
-        chalk.gray(' to auto-fix these.'),
+        chalk.gray(' to generate or update your agent config files.'),
     );
   } else if (failing.length > 0) {
     console.log(
       chalk.green('  Looking good!') +
         chalk.gray(
-          ` ${failing.length} check${failing.length === 1 ? '' : 's'} can still be improved.`,
+          ` ${failing.length} optional improvement${failing.length === 1 ? '' : 's'} available.`,
         ),
     );
     console.log(

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -7,6 +7,7 @@ import { CursorAcpProvider, isCursorAgentAvailable } from './cursor-acp.js';
 import { ClaudeCliProvider, isClaudeCliAvailable } from './claude-cli.js';
 import { parseJsonResponse, extractJson, estimateTokens } from './utils.js';
 import { isModelNotAvailableError, handleModelNotAvailable } from './model-recovery.js';
+import { isRateLimitError } from './seat-based-errors.js';
 import { resolveCaliber } from '../lib/resolve-caliber.js';
 
 export type { LLMProvider, LLMConfig, LLMCallOptions };
@@ -120,6 +121,11 @@ export async function llmCall(options: LLMCallOptions): Promise<string> {
 
       if (isOverloaded(error) && attempt < MAX_RETRIES) {
         await new Promise(r => setTimeout(r, 1000 * Math.pow(2, attempt - 1)));
+        continue;
+      }
+
+      if (isRateLimitError(error.message) && attempt < MAX_RETRIES) {
+        await new Promise(r => setTimeout(r, 2000 * Math.pow(2, attempt - 1)));
         continue;
       }
 

--- a/src/scoring/checks/bonus.ts
+++ b/src/scoring/checks/bonus.ts
@@ -71,7 +71,7 @@ export function checkBonus(dir: string): Check[] {
     detail: hasHooks ? hookSources.join(', ') : 'No hooks configured',
     suggestion: hasHooks
       ? undefined
-      : `Run \`${resolveCaliber()} init\` to add pre-commit instructions`,
+      : `Hooks auto-sync your agent config on every commit so it stays fresh. Run \`${resolveCaliber()} init\` to set up`,
     fix: hasHooks
       ? undefined
       : {
@@ -91,7 +91,7 @@ export function checkBonus(dir: string): Check[] {
     earnedPoints: agentsMdExists ? POINTS_AGENTS_MD : 0,
     passed: agentsMdExists,
     detail: agentsMdExists ? 'Found at project root' : 'Not found',
-    suggestion: agentsMdExists ? undefined : 'Add AGENTS.md — the emerging cross-agent standard',
+    suggestion: agentsMdExists ? undefined : 'AGENTS.md provides project context to Codex, Copilot, and other agents. Works alongside CLAUDE.md',
     fix: agentsMdExists
       ? undefined
       : {
@@ -141,7 +141,7 @@ export function checkBonus(dir: string): Check[] {
           : `${openSkillsCount}/${totalSkillFiles} use OpenSkills format`,
     suggestion:
       totalSkillFiles > 0 && !allOpenSkills
-        ? 'Migrate skills to .claude/skills/{name}/SKILL.md with YAML frontmatter'
+        ? 'OpenSkills format (SKILL.md with YAML header) makes skills portable across agents. Migrate for cross-tool compatibility'
         : undefined,
     fix:
       totalSkillFiles > 0 && !allOpenSkills
@@ -170,7 +170,7 @@ export function checkBonus(dir: string): Check[] {
     detail: hasLearned ? 'Session learnings found in CALIBER_LEARNINGS.md' : 'No learned content',
     suggestion: hasLearned
       ? undefined
-      : `Install learning hooks: \`${resolveCaliber()} learn install\``,
+      : `Session learnings capture patterns from your coding sessions so the agent improves over time. Run \`${resolveCaliber()} learn install\``,
   });
 
   return checks;

--- a/src/scoring/checks/existence.ts
+++ b/src/scoring/checks/existence.ts
@@ -206,7 +206,7 @@ export function checkExistence(dir: string): Check[] {
         : `${skillCount} skill${skillCount === 1 ? '' : 's'} found`,
     suggestion:
       skillCount === 0
-        ? 'Add .claude/skills/ with project-specific workflows'
+        ? 'Skills are reusable agent workflows (e.g., deploy, test, review). Add 2-3 for your most common tasks'
         : skillCount < 3
           ? 'Optimal is 2-3 focused skills'
           : undefined,
@@ -234,7 +234,7 @@ export function checkExistence(dir: string): Check[] {
       mdcCount === 0
         ? 'No .mdc rule files'
         : `${mdcCount} .mdc rule${mdcCount === 1 ? '' : 's'} found`,
-    suggestion: mdcCount === 0 ? 'Add .cursor/rules/*.mdc with frontmatter for Cursor' : undefined,
+    suggestion: mdcCount === 0 ? 'Cursor .mdc rules use frontmatter to scope rules to specific files/paths. Add them for more targeted Cursor behavior' : undefined,
     fix:
       mdcCount === 0
         ? {
@@ -260,7 +260,7 @@ export function checkExistence(dir: string): Check[] {
         : 'No MCP servers configured',
     suggestion:
       mcp.count === 0
-        ? 'Configure MCP servers in .mcp.json for external service access'
+        ? 'MCP servers connect your agent to external tools (databases, Slack, Linear, etc). Add if your team uses external services'
         : undefined,
     fix:
       mcp.count === 0

--- a/src/scoring/checks/freshness.ts
+++ b/src/scoring/checks/freshness.ts
@@ -184,7 +184,7 @@ export function checkFreshness(dir: string): Check[] {
     detail: permissionDetail,
     suggestion: hasPermissions
       ? undefined
-      : 'Add permissions.allow to .claude/settings.json for safer agent execution',
+      : 'Permissions control which shell commands the agent can run without asking. Adds a safety layer for your team',
     fix: hasPermissions
       ? undefined
       : {

--- a/src/scoring/checks/quality.ts
+++ b/src/scoring/checks/quality.ts
@@ -84,7 +84,7 @@ export function checkQuality(dir: string): Check[] {
         : `~${totalTokens} tokens total across all config files`,
     suggestion:
       tokenPoints < 4 && totalContent.length > 0
-        ? `Total config is ~${totalTokens} tokens — reduce to under 5000 for better agent performance`
+        ? `Config is ~${totalTokens} tokens. Agents work best under ~5000 tokens (~4 pages of text) — trim verbose sections`
         : undefined,
     fix:
       tokenPoints < 4 && totalContent.length > 0

--- a/src/scoring/display.ts
+++ b/src/scoring/display.ts
@@ -144,7 +144,7 @@ export function displayScore(result: ScoreResult): void {
 function formatTopImprovements(checks: readonly Check[]): void {
   const improvable = checks
     .filter(c => c.earnedPoints < c.maxPoints)
-    .map(c => ({ name: c.name, potential: c.maxPoints - c.earnedPoints }))
+    .map(c => ({ name: c.name, potential: c.maxPoints - c.earnedPoints, suggestion: c.suggestion }))
     .sort((a, b) => b.potential - a.potential)
     .slice(0, 5);
 
@@ -159,6 +159,9 @@ function formatTopImprovements(checks: readonly Check[]): void {
     const label = chalk.white(item.name.padEnd(42));
     const pts = chalk.yellow(`+${item.potential} pts`);
     console.log(`  ${num} ${label}${pts}`);
+    if (item.suggestion) {
+      console.log(chalk.gray(`     ${item.suggestion}`));
+    }
   }
 
   console.log('');


### PR DESCRIPTION
## Summary

- Rewrite all scoring suggestion strings to explain WHAT each feature is and WHY it matters (MCPs, hooks, skills, OpenSkills, learnings, permissions, token budget) — addresses feedback from a Windows/Cursor user who found the jargon impenetrable
- Add Windows-aware provider setup: show download link instead of `curl | bash` for Cursor CLI on Windows
- Add Windows hook warning during `caliber init` (Git Bash requirement for shell hooks)
- Add rate limit retry with exponential backoff in `llmCall()` — reuses existing `isRateLimitError()` from `seat-based-errors.ts` to prevent token-burning loops on 429s
- Show inline suggestion text in the TOP IMPROVEMENTS section of `caliber score`
- Clarify CLI vs IDE context in README ("in your terminal, not the IDE chat") and add a Windows Users section
- Update Caliber-managed skills, rules, and CLAUDE.md to reflect current codebase

## Test plan

- [x] `npm run build` passes
- [x] `npx tsc --noEmit` passes  
- [x] All 793 tests pass (`npm run test`)
- [x] Scoring tests pass (`npx vitest run src/scoring/__tests__/`)
- [ ] Visual check: run `caliber score` and verify new suggestion text reads clearly
- [ ] Verify Windows behavior: run `caliber init` on Windows and check hook warning appears