### PR TITLE
fix: prevent CWD corruption and state desync in refresh/learn

### DIFF
--- a/src/commands/refresh.ts
+++ b/src/commands/refresh.ts
@@ -423,9 +423,10 @@ export async function refreshCommand(options: RefreshOptions) {
             `${repoName}: refresh failed — ${err instanceof Error ? err.message : 'unknown error'}`,
           ),
         );
+      } finally {
+        process.chdir(originalDir);
       }
     }
-    process.chdir(originalDir);
   } catch (err) {
     if (err instanceof Error && err.message === '__exit__') throw err;
     writeRefreshError(err);

--- a/src/learner/storage.ts
+++ b/src/learner/storage.ts
@@ -71,6 +71,7 @@ function trimSessionFileIfNeeded(filePath: string): void {
     const stat = fs.statSync(filePath);
     if (stat.size > MAX_SESSION_FILE_BYTES) {
       fs.writeFileSync(filePath, '');
+      resetState();
       return;
     }
   } catch { return; }
@@ -113,6 +114,7 @@ export function readAllEvents(): SessionEvent[] {
     const stat = fs.statSync(filePath);
     if (stat.size > MAX_SESSION_FILE_BYTES) {
       fs.writeFileSync(filePath, '');
+      resetState();
       return [];
     }
   } catch { return []; }
@@ -143,7 +145,11 @@ export function getEventCount(): number {
 
 export function clearSession(): void {
   const filePath = sessionFilePath();
-  if (fs.existsSync(filePath)) fs.unlinkSync(filePath);
+  try {
+    fs.writeFileSync(filePath, '');
+  } catch {
+    // File may not exist — that's fine
+  }
 }
 
 export function readState(): LearningState {


### PR DESCRIPTION
## Summary

Three robustness fixes found during deep review of the refresh and learn commands:

- **CWD corruption in multi-repo refresh** — `process.chdir(originalDir)` moved into `finally` block so CWD is restored even when a repo refresh throws. Previously, an error would leave CWD stuck in the failed repo's directory for all subsequent repos.
- **State desync on 10MB truncation** — `resetState()` now called when the session file is wiped due to being oversized. Previously `eventCount` retained a stale high value, causing broken incremental offsets.
- **Race condition in clearSession** — Changed from `unlinkSync` to `writeFileSync('')` so concurrent observe hooks append to an empty file instead of recreating a deleted one.

## Test plan

- [x] `npm run build` passes
- [x] All 805 tests pass
- [x] Reviewed by 3 parallel agents (reuse, quality, efficiency) — no issues