### PR TITLE
feat: add OpenCode as LLM provider

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -18,6 +18,7 @@ import { loadConfig, getFastModel, getDisplayModel, writeConfigFile } from '../l
 import { validateModel } from '../llm/index.js';
 import { runInteractiveProviderSetup } from './interactive-provider-setup.js';
 import { isClaudeCliAvailable, isClaudeCliLoggedIn } from '../llm/claude-cli.js';
+import { isOpenCodeAvailable } from '../llm/opencode.js';
 import { isCursorAgentAvailable, isCursorLoggedIn } from '../llm/cursor-acp.js';
 import confirm from '@inquirer/confirm';
 import { computeLocalScore } from '../scoring/index.js';
@@ -129,9 +130,27 @@ export async function initCommand(options: InitOptions) {
 
   // 1a. LLM provider — auto-detect before prompting
   let config = loadConfig();
+  const prefersOpenCode = options.agent?.includes('opencode');
+
+  // If user explicitly requested opencode agent, override existing config
+  if (prefersOpenCode && isOpenCodeAvailable()) {
+    const autoConfig = { provider: 'opencode' as const, model: 'default' };
+    writeConfigFile(autoConfig);
+    config = autoConfig;
+    console.log(chalk.dim('  Using OpenCode as LLM provider (requested via --agent opencode)\n'));
+  }
+
   if (!config && !options.autoApprove) {
     // Try seat-based auto-detection
-    if (isClaudeCliAvailable() && isClaudeCliLoggedIn()) {
+    if (prefersOpenCode && isOpenCodeAvailable()) {
+      console.log(chalk.dim('  Detected: OpenCode (uses opencode auth login)\n'));
+      const useIt = await confirm({ message: 'Use OpenCode as your LLM provider?' });
+      if (useIt) {
+        const autoConfig = { provider: 'opencode' as const, model: 'default' };
+        writeConfigFile(autoConfig);
+        config = autoConfig;
+      }
+    } else if (isClaudeCliAvailable() && isClaudeCliLoggedIn()) {
       console.log(chalk.dim('  Detected: Claude Code CLI (uses your Pro/Max/Team subscription)\n'));
       const useIt = await confirm({ message: 'Use Claude Code as your LLM provider?' });
       if (useIt) {
@@ -152,7 +171,11 @@ export async function initCommand(options: InitOptions) {
   if (!config) {
     if (options.autoApprove) {
       // In auto-approve mode, try seat-based silently
-      if (isClaudeCliAvailable() && isClaudeCliLoggedIn()) {
+      if (prefersOpenCode && isOpenCodeAvailable()) {
+        const autoConfig = { provider: 'opencode' as const, model: 'default' };
+        writeConfigFile(autoConfig);
+        config = autoConfig;
+      } else if (isClaudeCliAvailable() && isClaudeCliLoggedIn()) {
         const autoConfig = { provider: 'claude-cli' as const, model: 'default' };
         writeConfigFile(autoConfig);
         config = autoConfig;
@@ -518,10 +541,12 @@ export async function initCommand(options: InitOptions) {
 
     // Get project description if empty
     const isEmpty = fingerprint.fileTree.length < 3;
-    if (isEmpty) {
+    if (isEmpty && !options.autoApprove) {
       display.stop();
       fingerprint.description = await promptInput('What will you build in this project?');
       display.start();
+    } else if (isEmpty && options.autoApprove) {
+      fingerprint.description = 'A new project';
     }
 
     // Phase B: Generate + search in parallel (search always runs)

--- a/src/llm/__tests__/opencode.test.ts
+++ b/src/llm/__tests__/opencode.test.ts
@@ -1,0 +1,692 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { OpenCodeProvider, isOpenCodeAvailable } from '../opencode.js';
+import type { LLMConfig } from '../types.js';
+import { getUsageSummary, resetUsage } from '../usage.js';
+
+const IS_WINDOWS = process.platform === 'win32';
+const spawn = vi.fn();
+const execSync = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  spawn: (...args: unknown[]) => spawn(...args),
+  execSync: (...args: unknown[]) => execSync(...args),
+}));
+
+vi.mock('../seat-based-errors.js', () => ({
+  parseSeatBasedError: vi.fn((stderr: string, _code: number | null) => {
+    if (stderr.includes('not logged in') || stderr.includes('unauthorized')) {
+      return 'Not logged in. Run the login command for your provider to re-authenticate.';
+    }
+    if (stderr.includes('rate limit') || stderr.includes('429')) {
+      return 'Rate limit exceeded. Retrying...';
+    }
+    return null;
+  }),
+}));
+
+describe('OpenCodeProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetUsage();
+  });
+
+  describe('call()', () => {
+    it('spawns opencode run --format json and pipes prompt via stdin', async () => {
+      const stdoutChunks = [Buffer.from('{"type":"text","part":{"text":"Hello from OpenCode."}}')];
+      let closeCb: (code: number) => void;
+      const stdinEnd = vi.fn();
+      spawn.mockReturnValue({
+        stdin: { end: stdinEnd },
+        stdout: {
+          on: vi.fn((ev: string, fn: (c: Buffer) => void) => {
+            if (ev === 'data') setTimeout(() => stdoutChunks.forEach(fn), 0);
+          }),
+        },
+        stderr: { on: vi.fn() },
+        on: vi.fn((ev: string, fn: (code: number) => void) => {
+          if (ev === 'close') closeCb = fn;
+        }),
+        kill: vi.fn(),
+      });
+
+      const config: LLMConfig = { provider: 'opencode', model: 'default' };
+      const provider = new OpenCodeProvider(config);
+
+      const resultPromise = provider.call({
+        system: 'You are helpful.',
+        prompt: 'Say hello.',
+      });
+
+      await new Promise((r) => setTimeout(r, 10));
+      closeCb!(0);
+
+      const result = await resultPromise;
+      expect(result).toBe('Hello from OpenCode.');
+      expect(spawn).toHaveBeenCalledWith(
+        'opencode',
+        expect.arrayContaining(['run', '--format', 'json']),
+        expect.objectContaining({ cwd: process.cwd() }),
+      );
+      expect(stdinEnd).toHaveBeenCalledWith(expect.stringContaining('You are helpful.'));
+      expect(stdinEnd).toHaveBeenCalledWith(expect.stringContaining('Say hello.'));
+    });
+
+    it('passes --model flag when options.model is set', async () => {
+      const stdoutChunks = [Buffer.from('{"type":"text","part":{"text":"response"}}')];
+      let closeCb: (code: number) => void;
+      spawn.mockReturnValue({
+        stdin: { end: vi.fn() },
+        stdout: {
+          on: vi.fn((ev: string, fn: (c: Buffer) => void) => {
+            if (ev === 'data') setTimeout(() => stdoutChunks.forEach(fn), 0);
+          }),
+        },
+        stderr: { on: vi.fn() },
+        on: vi.fn((ev: string, fn: (code: number) => void) => {
+          if (ev === 'close') closeCb = fn;
+        }),
+        kill: vi.fn(),
+      });
+
+      const provider = new OpenCodeProvider({ provider: 'opencode', model: 'default' });
+      const resultPromise = provider.call({
+        system: 'S',
+        prompt: 'P',
+        model: 'anthropic/claude-sonnet-4-5',
+      });
+
+      await new Promise((r) => setTimeout(r, 10));
+      closeCb!(0);
+      await resultPromise;
+
+      const args = spawn.mock.calls[0][1];
+      expect(args).toContain('--model');
+      expect(args).toContain('anthropic/claude-sonnet-4-5');
+    });
+
+    it('does not pass --model flag when options.model is not set', async () => {
+      const stdoutChunks = [Buffer.from('{"type":"text","part":{"text":"response"}}')];
+      let closeCb: (code: number) => void;
+      spawn.mockReturnValue({
+        stdin: { end: vi.fn() },
+        stdout: {
+          on: vi.fn((ev: string, fn: (c: Buffer) => void) => {
+            if (ev === 'data') setTimeout(() => stdoutChunks.forEach(fn), 0);
+          }),
+        },
+        stderr: { on: vi.fn() },
+        on: vi.fn((ev: string, fn: (code: number) => void) => {
+          if (ev === 'close') closeCb = fn;
+        }),
+        kill: vi.fn(),
+      });
+
+      const provider = new OpenCodeProvider({ provider: 'opencode', model: 'default' });
+      const resultPromise = provider.call({ system: 'S', prompt: 'P' });
+
+      await new Promise((r) => setTimeout(r, 10));
+      closeCb!(0);
+      await resultPromise;
+
+      if (IS_WINDOWS) {
+        const cmdStr = spawn.mock.calls[0][0] as string;
+        expect(cmdStr).not.toContain('--model');
+      } else {
+        const args = spawn.mock.calls[0][1];
+        expect(args).not.toContain('--model');
+      }
+    });
+
+    it('tracks usage after successful call', async () => {
+      const stdoutChunks = [Buffer.from('{"type":"text","part":{"text":"response"}}')];
+      let closeCb: (code: number) => void;
+      spawn.mockReturnValue({
+        stdin: { end: vi.fn() },
+        stdout: {
+          on: vi.fn((ev: string, fn: (c: Buffer) => void) => {
+            if (ev === 'data') setTimeout(() => stdoutChunks.forEach(fn), 0);
+          }),
+        },
+        stderr: { on: vi.fn() },
+        on: vi.fn((ev: string, fn: (code: number) => void) => {
+          if (ev === 'close') closeCb = fn;
+        }),
+        kill: vi.fn(),
+      });
+
+      const provider = new OpenCodeProvider({ provider: 'opencode', model: 'default' });
+      const resultPromise = provider.call({ system: 'S', prompt: 'P' });
+
+      await new Promise((r) => setTimeout(r, 10));
+      closeCb!(0);
+
+      await resultPromise;
+
+      const usage = getUsageSummary();
+      expect(usage).toHaveLength(1);
+      expect(usage[0].model).toBe('default');
+      expect(usage[0].calls).toBe(1);
+    });
+
+    it('includes message history in combined prompt', async () => {
+      const stdoutChunks = [Buffer.from('{"type":"text","part":{"text":"response"}}')];
+      let closeCb: (code: number) => void;
+      const stdinEnd = vi.fn();
+      spawn.mockReturnValue({
+        stdin: { end: stdinEnd },
+        stdout: {
+          on: vi.fn((ev: string, fn: (c: Buffer) => void) => {
+            if (ev === 'data') setTimeout(() => stdoutChunks.forEach(fn), 0);
+          }),
+        },
+        stderr: { on: vi.fn() },
+        on: vi.fn((ev: string, fn: (code: number) => void) => {
+          if (ev === 'close') closeCb = fn;
+        }),
+        kill: vi.fn(),
+      });
+
+      const provider = new OpenCodeProvider({ provider: 'opencode', model: 'default' });
+      const streamPromise = provider.stream(
+        {
+          system: 'You are a helpful assistant.',
+          prompt: 'What is the weather?',
+          messages: [
+            { role: 'user', content: 'Hello!' },
+            { role: 'assistant', content: 'Hi there!' },
+          ],
+        },
+        { onText: vi.fn(), onEnd: vi.fn(), onError: vi.fn() },
+      );
+
+      await new Promise((r) => setTimeout(r, 10));
+      closeCb!(0);
+
+      await streamPromise;
+
+      expect(stdinEnd).toHaveBeenCalledWith(expect.stringContaining('User: Hello!'));
+      expect(stdinEnd).toHaveBeenCalledWith(expect.stringContaining('Assistant: Hi there!'));
+    });
+
+    it('rejects with error when opencode exits with non-zero code', async () => {
+      let closeCb: (code: number) => void;
+      spawn.mockReturnValue({
+        stdin: { end: vi.fn() },
+        stdout: { on: vi.fn() },
+        stderr: {
+          on: vi.fn((ev: string, fn: (c: Buffer) => void) => {
+            if (ev === 'data') fn(Buffer.from('Some error occurred'));
+          }),
+        },
+        on: vi.fn((ev: string, fn: (code: number) => void) => {
+          if (ev === 'close') closeCb = fn;
+        }),
+        kill: vi.fn(),
+      });
+
+      const provider = new OpenCodeProvider({ provider: 'opencode', model: 'default' });
+      const resultPromise = provider.call({ system: 'S', prompt: 'P' });
+
+      await new Promise((r) => setTimeout(r, 10));
+      closeCb!(1);
+
+      await expect(resultPromise).rejects.toThrow('OpenCode exited with code 1');
+    });
+
+    it('rejects with error when opencode returns empty response', async () => {
+      let closeCb: (code: number) => void;
+      spawn.mockReturnValue({
+        stdin: { end: vi.fn() },
+        stdout: {
+          on: vi.fn((ev: string, fn: (c: Buffer) => void) => {
+            if (ev === 'data') fn(Buffer.from(''));
+          }),
+        },
+        stderr: { on: vi.fn() },
+        on: vi.fn((ev: string, fn: (code: number) => void) => {
+          if (ev === 'close') closeCb = fn;
+        }),
+        kill: vi.fn(),
+      });
+
+      const provider = new OpenCodeProvider({ provider: 'opencode', model: 'default' });
+      const resultPromise = provider.call({ system: 'S', prompt: 'P' });
+
+      await new Promise((r) => setTimeout(r, 10));
+      closeCb!(0);
+
+      await expect(resultPromise).rejects.toThrow('OpenCode returned empty response');
+    });
+
+    it('uses parseSeatBasedError for friendly auth errors', async () => {
+      let closeCb: (code: number) => void;
+      spawn.mockReturnValue({
+        stdin: { end: vi.fn() },
+        stdout: { on: vi.fn() },
+        stderr: {
+          on: vi.fn((ev: string, fn: (c: Buffer) => void) => {
+            if (ev === 'data') fn(Buffer.from('Error: not logged in'));
+          }),
+        },
+        on: vi.fn((ev: string, fn: (code: number) => void) => {
+          if (ev === 'close') closeCb = fn;
+        }),
+        kill: vi.fn(),
+      });
+
+      const provider = new OpenCodeProvider({ provider: 'opencode', model: 'default' });
+      const resultPromise = provider.call({ system: 'S', prompt: 'P' });
+
+      await new Promise((r) => setTimeout(r, 10));
+      closeCb!(1);
+
+      await expect(resultPromise).rejects.toThrow('Not logged in');
+      await expect(resultPromise).rejects.not.toThrow('not logged in');
+    });
+
+    it('uses parseSeatBasedError for friendly rate-limit errors', async () => {
+      let closeCb: (code: number) => void;
+      spawn.mockReturnValue({
+        stdin: { end: vi.fn() },
+        stdout: { on: vi.fn() },
+        stderr: {
+          on: vi.fn((ev: string, fn: (c: Buffer) => void) => {
+            if (ev === 'data') fn(Buffer.from('Error: rate limit exceeded 429'));
+          }),
+        },
+        on: vi.fn((ev: string, fn: (code: number) => void) => {
+          if (ev === 'close') closeCb = fn;
+        }),
+        kill: vi.fn(),
+      });
+
+      const provider = new OpenCodeProvider({ provider: 'opencode', model: 'default' });
+      const resultPromise = provider.call({ system: 'S', prompt: 'P' });
+
+      await new Promise((r) => setTimeout(r, 10));
+      closeCb!(1);
+
+      await expect(resultPromise).rejects.toThrow('Rate limit exceeded');
+    });
+
+    it('parses multi-line JSON event output correctly', async () => {
+      const stdoutChunks = [
+        Buffer.from('{"type":"text","part":{"text":"Hello"}}\n'),
+        Buffer.from('{"type":"text","part":{"text":" World"}}\n'),
+        Buffer.from('{"type":"step_finish","reason":"stop"}\n'),
+      ];
+      let closeCb: (code: number) => void;
+      spawn.mockReturnValue({
+        stdin: { end: vi.fn() },
+        stdout: {
+          on: vi.fn((ev: string, fn: (c: Buffer) => void) => {
+            if (ev === 'data') setTimeout(() => stdoutChunks.forEach(fn), 0);
+          }),
+        },
+        stderr: { on: vi.fn() },
+        on: vi.fn((ev: string, fn: (code: number) => void) => {
+          if (ev === 'close') closeCb = fn;
+        }),
+        kill: vi.fn(),
+      });
+
+      const provider = new OpenCodeProvider({ provider: 'opencode', model: 'default' });
+      const resultPromise = provider.call({ system: 'S', prompt: 'P' });
+
+      await new Promise((r) => setTimeout(r, 10));
+      closeCb!(0);
+
+      const result = await resultPromise;
+      expect(result).toBe('Hello World');
+    });
+
+    it('skips non-JSON lines in output', async () => {
+      const stdoutChunks = [
+        Buffer.from('some random text\n'),
+        Buffer.from('{"type":"text","part":{"text":"actual response"}}\n'),
+        Buffer.from('more noise\n'),
+      ];
+      let closeCb: (code: number) => void;
+      spawn.mockReturnValue({
+        stdin: { end: vi.fn() },
+        stdout: {
+          on: vi.fn((ev: string, fn: (c: Buffer) => void) => {
+            if (ev === 'data') setTimeout(() => stdoutChunks.forEach(fn), 0);
+          }),
+        },
+        stderr: { on: vi.fn() },
+        on: vi.fn((ev: string, fn: (code: number) => void) => {
+          if (ev === 'close') closeCb = fn;
+        }),
+        kill: vi.fn(),
+      });
+
+      const provider = new OpenCodeProvider({ provider: 'opencode', model: 'default' });
+      const resultPromise = provider.call({ system: 'S', prompt: 'P' });
+
+      await new Promise((r) => setTimeout(r, 10));
+      closeCb!(0);
+
+      const result = await resultPromise;
+      expect(result).toBe('actual response');
+    });
+
+    it('skips markdown code fences in output', async () => {
+      const stdoutChunks = [
+        Buffer.from('```\n'),
+        Buffer.from('{"type":"text","part":{"text":"code block"}}\n'),
+        Buffer.from('```\n'),
+      ];
+      let closeCb: (code: number) => void;
+      spawn.mockReturnValue({
+        stdin: { end: vi.fn() },
+        stdout: {
+          on: vi.fn((ev: string, fn: (c: Buffer) => void) => {
+            if (ev === 'data') setTimeout(() => stdoutChunks.forEach(fn), 0);
+          }),
+        },
+        stderr: { on: vi.fn() },
+        on: vi.fn((ev: string, fn: (code: number) => void) => {
+          if (ev === 'close') closeCb = fn;
+        }),
+        kill: vi.fn(),
+      });
+
+      const provider = new OpenCodeProvider({ provider: 'opencode', model: 'default' });
+      const resultPromise = provider.call({ system: 'S', prompt: 'P' });
+
+      await new Promise((r) => setTimeout(r, 10));
+      closeCb!(0);
+
+      const result = await resultPromise;
+      expect(result).toBe('code block');
+    });
+  });
+
+  describe('stream()', () => {
+    it('pipes prompt via stdin and invokes onText and onEnd', async () => {
+      let closeCb: (code: number) => void;
+      spawn.mockReturnValue({
+        stdin: { end: vi.fn() },
+        stdout: {
+          on: vi.fn((ev: string, fn: (c: Buffer) => void) => {
+            if (ev === 'data') {
+              setTimeout(() => fn(Buffer.from('{"type":"text","part":{"text":"Streamed"}}')), 0);
+            }
+          }),
+        },
+        stderr: { on: vi.fn() },
+        on: vi.fn((ev: string, fn: (code: number) => void) => {
+          if (ev === 'close') closeCb = fn;
+        }),
+        kill: vi.fn(),
+      });
+
+      const provider = new OpenCodeProvider({ provider: 'opencode', model: 'default' });
+      const onText = vi.fn();
+      const onEnd = vi.fn();
+
+      const streamPromise = provider.stream(
+        { system: 'S', prompt: 'P' },
+        { onText, onEnd, onError: vi.fn() },
+      );
+
+      await new Promise((r) => setTimeout(r, 10));
+      closeCb!(0);
+      await streamPromise;
+
+      expect(onText).toHaveBeenCalledWith('Streamed');
+      expect(onEnd).toHaveBeenCalledWith({ stopReason: 'end_turn' });
+    });
+
+    it('tracks usage on stream end', async () => {
+      let closeCb: (code: number) => void;
+      spawn.mockReturnValue({
+        stdin: { end: vi.fn() },
+        stdout: {
+          on: vi.fn((ev: string, fn: (c: Buffer) => void) => {
+            if (ev === 'data') {
+              setTimeout(() => fn(Buffer.from('{"type":"text","part":{"text":"Hi"}}')), 0);
+            }
+          }),
+        },
+        stderr: { on: vi.fn() },
+        on: vi.fn((ev: string, fn: (code: number) => void) => {
+          if (ev === 'close') closeCb = fn;
+        }),
+        kill: vi.fn(),
+      });
+
+      const provider = new OpenCodeProvider({ provider: 'opencode', model: 'default' });
+      const streamPromise = provider.stream(
+        { system: 'S', prompt: 'P' },
+        { onText: vi.fn(), onEnd: vi.fn(), onError: vi.fn() },
+      );
+
+      await new Promise((r) => setTimeout(r, 10));
+      closeCb!(0);
+
+      await streamPromise;
+
+      const usage = getUsageSummary();
+      expect(usage).toHaveLength(1);
+    });
+
+    it('passes --model flag when options.model is set', async () => {
+      let closeCb: (code: number) => void;
+      spawn.mockReturnValue({
+        stdin: { end: vi.fn() },
+        stdout: {
+          on: vi.fn((ev: string, fn: (c: Buffer) => void) => {
+            if (ev === 'data')
+              setTimeout(() => fn(Buffer.from('{"type":"text","part":{"text":"ok"}}')), 0);
+          }),
+        },
+        stderr: { on: vi.fn() },
+        on: vi.fn((ev: string, fn: (code: number) => void) => {
+          if (ev === 'close') closeCb = fn;
+        }),
+        kill: vi.fn(),
+      });
+
+      const provider = new OpenCodeProvider({ provider: 'opencode', model: 'default' });
+      const streamPromise = provider.stream(
+        { system: 'S', prompt: 'P', model: 'claude-haiku-4-5' },
+        { onText: vi.fn(), onEnd: vi.fn(), onError: vi.fn() },
+      );
+
+      await new Promise((r) => setTimeout(r, 10));
+      closeCb!(0);
+      await streamPromise;
+
+      const args = spawn.mock.calls[0][1];
+      expect(args).toContain('--model');
+      expect(args).toContain('claude-haiku-4-5');
+    });
+
+    it('invokes onError when opencode exits with error', async () => {
+      let closeCb: (code: number) => void;
+      const onError = vi.fn();
+      spawn.mockReturnValue({
+        stdin: { end: vi.fn() },
+        stdout: { on: vi.fn() },
+        stderr: {
+          on: vi.fn((ev: string, fn: (c: Buffer) => void) => {
+            if (ev === 'data') fn(Buffer.from('Error message'));
+          }),
+        },
+        on: vi.fn((ev: string, fn: (code: number) => void) => {
+          if (ev === 'close') closeCb = fn;
+        }),
+        kill: vi.fn(),
+      });
+
+      const provider = new OpenCodeProvider({ provider: 'opencode', model: 'default' });
+      const streamPromise = provider.stream(
+        { system: 'S', prompt: 'P' },
+        { onText: vi.fn(), onEnd: vi.fn(), onError },
+      );
+
+      await new Promise((r) => setTimeout(r, 10));
+      closeCb!(1);
+
+      await streamPromise;
+
+      expect(onError).toHaveBeenCalled();
+      const error = onError.mock.calls[0][0] as Error;
+      expect(error.message).toContain('OpenCode exited with code 1');
+    });
+
+    it('invokes onError for JSON error events during streaming', async () => {
+      const onError = vi.fn();
+      const onEnd = vi.fn();
+      let settleResolve: () => void;
+      const settledPromise = new Promise<void>((r) => {
+        settleResolve = r;
+      });
+
+      spawn.mockReturnValue({
+        stdin: { end: vi.fn() },
+        stdout: {
+          on: vi.fn((ev: string, fn: (c: Buffer) => void) => {
+            if (ev === 'data') {
+              setTimeout(
+                () =>
+                  fn(
+                    Buffer.from(
+                      '{"type":"error","error":{"data":{"message":"Something went wrong"}}}',
+                    ),
+                  ),
+                5,
+              );
+            }
+          }),
+        },
+        stderr: { on: vi.fn() },
+        on: vi.fn((ev: string, fn: (code: number) => void) => {
+          if (ev === 'close') {
+            setTimeout(() => {
+              fn(0);
+              setTimeout(() => settleResolve(), 10);
+            }, 50);
+          }
+        }),
+        kill: vi.fn(),
+      });
+
+      const provider = new OpenCodeProvider({ provider: 'opencode', model: 'default' });
+      void provider.stream({ system: 'S', prompt: 'P' }, { onText: vi.fn(), onEnd, onError });
+
+      await settledPromise;
+
+      expect(onError).toHaveBeenCalled();
+      const error = onError.mock.calls[0][0] as Error;
+      expect(error.message).toBe('Something went wrong');
+    });
+
+    it('handles streaming with multiple text events', async () => {
+      let closeCb: (code: number) => void;
+      const onText = vi.fn();
+      spawn.mockReturnValue({
+        stdin: { end: vi.fn() },
+        stdout: {
+          on: vi.fn((ev: string, fn: (c: Buffer) => void) => {
+            if (ev === 'data') {
+              setTimeout(
+                () =>
+                  fn(
+                    Buffer.from(
+                      '{"type":"text","part":{"text":"Hello"}}\n{"type":"text","part":{"text":" World"}}',
+                    ),
+                  ),
+                0,
+              );
+            }
+          }),
+        },
+        stderr: { on: vi.fn() },
+        on: vi.fn((ev: string, fn: (code: number) => void) => {
+          if (ev === 'close') closeCb = fn;
+        }),
+        kill: vi.fn(),
+      });
+
+      const provider = new OpenCodeProvider({ provider: 'opencode', model: 'default' });
+      const streamPromise = provider.stream(
+        { system: 'S', prompt: 'P' },
+        { onText, onEnd: vi.fn(), onError: vi.fn() },
+      );
+
+      await new Promise((r) => setTimeout(r, 10));
+      closeCb!(0);
+      await streamPromise;
+
+      expect(onText).toHaveBeenCalledTimes(2);
+      expect(onText).toHaveBeenNthCalledWith(1, 'Hello');
+      expect(onText).toHaveBeenNthCalledWith(2, ' World');
+    });
+  });
+
+  describe('timeout handling', () => {
+    it('uses CALIBER_OPENCODE_TIMEOUT_MS when set', () => {
+      const orig = process.env.CALIBER_OPENCODE_TIMEOUT_MS;
+      process.env.CALIBER_OPENCODE_TIMEOUT_MS = '120000';
+      const provider = new OpenCodeProvider({ provider: 'opencode', model: 'default' });
+      expect(provider).toBeDefined();
+      process.env.CALIBER_OPENCODE_TIMEOUT_MS = orig;
+    });
+
+    it('uses default timeout when env var is invalid', () => {
+      const orig = process.env.CALIBER_OPENCODE_TIMEOUT_MS;
+      process.env.CALIBER_OPENCODE_TIMEOUT_MS = 'not-a-number';
+      const provider = new OpenCodeProvider({ provider: 'opencode', model: 'default' });
+      expect(provider).toBeDefined();
+      process.env.CALIBER_OPENCODE_TIMEOUT_MS = orig;
+    });
+
+    it('uses default timeout when env var is below minimum', () => {
+      const orig = process.env.CALIBER_OPENCODE_TIMEOUT_MS;
+      process.env.CALIBER_OPENCODE_TIMEOUT_MS = '500';
+      const provider = new OpenCodeProvider({ provider: 'opencode', model: 'default' });
+      expect(provider).toBeDefined();
+      process.env.CALIBER_OPENCODE_TIMEOUT_MS = orig;
+    });
+  });
+
+  describe('constructor', () => {
+    it('should create instance with default config', () => {
+      const provider = new OpenCodeProvider({ provider: 'opencode', model: 'default' });
+      expect(provider).toBeDefined();
+    });
+
+    it('should create instance with custom model', () => {
+      const provider = new OpenCodeProvider({
+        provider: 'opencode',
+        model: 'anthropic/claude-sonnet-4-5',
+      });
+      expect(provider).toBeDefined();
+    });
+  });
+});
+
+describe('isOpenCodeAvailable', () => {
+  beforeEach(() => {
+    execSync.mockReset();
+  });
+
+  it('returns true when opencode is on PATH', () => {
+    execSync.mockReturnValue(undefined);
+    expect(isOpenCodeAvailable()).toBe(true);
+    expect(execSync).toHaveBeenCalled();
+    const cmd = execSync.mock.calls[0][0];
+    expect(cmd).toContain('opencode');
+    expect(execSync.mock.calls[0][1]).toEqual({ stdio: 'ignore' });
+  });
+
+  it('returns false when opencode is not found', () => {
+    execSync.mockImplementation(() => {
+      throw new Error('not found');
+    });
+    expect(isOpenCodeAvailable()).toBe(false);
+  });
+});

--- a/src/llm/config.ts
+++ b/src/llm/config.ts
@@ -12,6 +12,7 @@ export const DEFAULT_MODELS: Record<ProviderType, string> = {
   openai: 'gpt-5.4-mini',
   cursor: 'sonnet-4.6',
   'claude-cli': 'default',
+  opencode: 'default',
 };
 
 export const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
@@ -114,8 +115,18 @@ export function readConfigFile(): LLMConfig | null {
     const parsed = JSON.parse(raw) as Record<string, unknown>;
     if (
       !parsed.provider ||
-      !['anthropic', 'vertex', 'openai', 'cursor', 'claude-cli'].includes(parsed.provider as string)
+      !['anthropic', 'vertex', 'openai', 'cursor', 'claude-cli', 'opencode'].includes(
+        parsed.provider as string,
+      )
     ) {
+      // Prefer OpenCode (uses opencode auth login)
+      if (process.env.CALIBER_USE_OPENCODE === '1' || process.env.CALIBER_USE_OPENCODE === 'true') {
+        return {
+          provider: 'opencode',
+          model: process.env.OPENCODE_MODEL || DEFAULT_MODELS.opencode,
+        };
+      }
+
       return null;
     }
     return parsed as unknown as LLMConfig;

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -5,6 +5,7 @@ import { VertexProvider } from './vertex.js';
 import { OpenAICompatProvider } from './openai-compat.js';
 import { CursorAcpProvider, isCursorAgentAvailable, isCursorLoggedIn } from './cursor-acp.js';
 import { ClaudeCliProvider, isClaudeCliAvailable, isClaudeCliLoggedIn } from './claude-cli.js';
+import { OpenCodeProvider, isOpenCodeAvailable } from './opencode.js';
 import { parseJsonResponse, extractJson, estimateTokens } from './utils.js';
 import { isModelNotAvailableError, handleModelNotAvailable } from './model-recovery.js';
 import { isRateLimitError } from './seat-based-errors.js';
@@ -33,12 +34,12 @@ function createProvider(config: LLMConfig): LLMProvider {
     case 'cursor': {
       if (!isCursorAgentAvailable()) {
         throw new Error(
-          'Cursor provider requires the Cursor Agent CLI. Install it from https://cursor.com/install then run `agent login`. Alternatively set ANTHROPIC_API_KEY or another provider.'
+          'Cursor provider requires the Cursor Agent CLI. Install it from https://cursor.com/install then run `agent login`. Alternatively set ANTHROPIC_API_KEY or another provider.',
         );
       }
       if (!isCursorLoggedIn()) {
         throw new Error(
-          'Cursor Agent CLI is installed but not logged in. Run `agent login` in your terminal to authenticate, then retry.'
+          'Cursor Agent CLI is installed but not logged in. Run `agent login` in your terminal to authenticate, then retry.',
         );
       }
       return new CursorAcpProvider(config);
@@ -46,15 +47,23 @@ function createProvider(config: LLMConfig): LLMProvider {
     case 'claude-cli': {
       if (!isClaudeCliAvailable()) {
         throw new Error(
-          'Claude Code provider requires the Claude Code CLI. Install it from https://claude.ai/install (or run `claude` once and log in). Alternatively set ANTHROPIC_API_KEY or choose another provider.'
+          'Claude Code provider requires the Claude Code CLI. Install it from https://claude.ai/install (or run `claude` once and log in). Alternatively set ANTHROPIC_API_KEY or choose another provider.',
         );
       }
       if (!isClaudeCliLoggedIn()) {
         throw new Error(
-          'Claude Code CLI is installed but not logged in. Run `claude` in your terminal to log in, then retry.'
+          'Claude Code CLI is installed but not logged in. Run `claude` in your terminal to log in, then retry.',
         );
       }
       return new ClaudeCliProvider(config);
+    }
+    case 'opencode': {
+      if (!isOpenCodeAvailable()) {
+        throw new Error(
+          'OpenCode provider requires the opencode CLI. Install it from https://opencode.ai then run `opencode auth login`.',
+        );
+      }
+      return new OpenCodeProvider(config);
     }
     default:
       throw new Error(`Unknown provider: ${config.provider}`);
@@ -67,7 +76,7 @@ export function getProvider(): LLMProvider {
   const config = loadConfig();
   if (!config) {
     throw new Error(
-      `No LLM provider configured. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or VERTEX_PROJECT_ID; or run \`${resolveCaliber()} config\` and choose Cursor or Claude Code; or set CALIBER_USE_CURSOR_SEAT=1 / CALIBER_USE_CLAUDE_CLI=1.`
+      `No LLM provider configured. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or VERTEX_PROJECT_ID; or run \`${resolveCaliber()} config\` and choose Cursor or Claude Code; or set CALIBER_USE_CURSOR_SEAT=1 / CALIBER_USE_CLAUDE_CLI=1.`,
     );
   }
 
@@ -82,7 +91,7 @@ export function getConfig(): LLMConfig {
   const config = loadConfig();
   if (!config) {
     throw new Error(
-      `No LLM provider configured. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or VERTEX_PROJECT_ID; or run \`${resolveCaliber()} config\` and choose Cursor or Claude Code; or set CALIBER_USE_CURSOR_SEAT=1 / CALIBER_USE_CLAUDE_CLI=1.`
+      `No LLM provider configured. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or VERTEX_PROJECT_ID; or run \`${resolveCaliber()} config\` and choose Cursor or Claude Code; or set CALIBER_USE_CURSOR_SEAT=1 / CALIBER_USE_CLAUDE_CLI=1.`,
     );
   }
 
@@ -95,12 +104,18 @@ export function resetProvider(): void {
   cachedConfig = null;
 }
 
-export const TRANSIENT_ERRORS = ['terminated', 'ECONNRESET', 'ETIMEDOUT', 'socket hang up', 'other side closed'];
+export const TRANSIENT_ERRORS = [
+  'terminated',
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'socket hang up',
+  'other side closed',
+];
 const MAX_RETRIES = 3;
 
 function isTransientError(error: Error): boolean {
   const msg = error.message.toLowerCase();
-  return TRANSIENT_ERRORS.some(e => msg.includes(e.toLowerCase()));
+  return TRANSIENT_ERRORS.some((e) => msg.includes(e.toLowerCase()));
 }
 
 function isOverloaded(err: unknown): boolean {
@@ -130,17 +145,17 @@ export async function llmCall(options: LLMCallOptions): Promise<string> {
       }
 
       if (isOverloaded(error) && attempt < MAX_RETRIES) {
-        await new Promise(r => setTimeout(r, 1000 * Math.pow(2, attempt - 1)));
+        await new Promise((r) => setTimeout(r, 1000 * Math.pow(2, attempt - 1)));
         continue;
       }
 
       if (isRateLimitError(error.message) && attempt < MAX_RETRIES) {
-        await new Promise(r => setTimeout(r, 2000 * Math.pow(2, attempt - 1)));
+        await new Promise((r) => setTimeout(r, 2000 * Math.pow(2, attempt - 1)));
         continue;
       }
 
       if (isTransientError(error) && attempt < MAX_RETRIES) {
-        await new Promise(r => setTimeout(r, 1000 * Math.pow(2, attempt - 1)));
+        await new Promise((r) => setTimeout(r, 1000 * Math.pow(2, attempt - 1)));
         continue;
       }
 

--- a/src/llm/opencode.ts
+++ b/src/llm/opencode.ts
@@ -1,0 +1,266 @@
+import { spawn, execSync, type ChildProcess } from 'node:child_process';
+import type {
+  LLMProvider,
+  LLMCallOptions,
+  LLMStreamOptions,
+  LLMStreamCallbacks,
+  LLMConfig,
+} from './types.js';
+import { trackUsage } from './usage.js';
+import { estimateTokens } from './utils.js';
+import { parseSeatBasedError } from './seat-based-errors.js';
+
+const DEBUG = process.env.DEBUG?.includes('caliber:opencode') ?? false;
+
+const OPENCODE_BIN = 'opencode';
+const IS_WINDOWS = process.platform === 'win32';
+const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
+
+export class OpenCodeProvider implements LLMProvider {
+  private defaultModel: string;
+  private timeoutMs: number;
+
+  constructor(config: LLMConfig) {
+    this.defaultModel = config.model || 'default';
+
+    const envTimeout = process.env.CALIBER_OPENCODE_TIMEOUT_MS;
+    this.timeoutMs = envTimeout ? parseInt(envTimeout, 10) : DEFAULT_TIMEOUT_MS;
+    if (!Number.isFinite(this.timeoutMs) || this.timeoutMs < 1000) {
+      this.timeoutMs = DEFAULT_TIMEOUT_MS;
+    }
+  }
+
+  async call(options: LLMCallOptions): Promise<string> {
+    const combined = this.buildCombinedPrompt(options);
+    const result = await this.runCommand(combined, options.model);
+    trackUsage(options.model || this.defaultModel, {
+      inputTokens: estimateTokens(combined),
+      outputTokens: estimateTokens(result),
+    });
+    return result;
+  }
+
+  async stream(options: LLMStreamOptions, callbacks: LLMStreamCallbacks): Promise<void> {
+    const combined = this.buildCombinedPrompt(options);
+    const inputEstimate = estimateTokens(combined);
+    return this.runCommandStream(combined, options.model, callbacks, inputEstimate);
+  }
+
+  private buildCombinedPrompt(options: LLMCallOptions | LLMStreamOptions): string {
+    const streamOpts = options as LLMStreamOptions;
+    const hasHistory = streamOpts.messages && streamOpts.messages.length > 0;
+    let combined = options.system ? options.system + '\n\n' : '';
+
+    if (hasHistory) {
+      for (const msg of streamOpts.messages!) {
+        const label = msg.role === 'user' ? 'User' : 'Assistant';
+        combined += `${label}: ${msg.content}\n\n`;
+      }
+    }
+
+    combined += options.prompt;
+    return combined;
+  }
+
+  private async runCommand(prompt: string, model?: string): Promise<string> {
+    const args = ['run', '--format', 'json', '--', '-'];
+    const modelToUse = model || this.defaultModel;
+    if (modelToUse && modelToUse !== 'default') args.splice(1, 0, '--model', modelToUse);
+
+    if (DEBUG) {
+      console.debug('[caliber:opencode] spawn:', OPENCODE_BIN, args.join(' '));
+    }
+
+    return new Promise((resolve, reject) => {
+      const child = this.spawnOpenCode(args);
+      child.stdin!.end(prompt);
+
+      const chunks: Buffer[] = [];
+      const stderrChunks: Buffer[] = [];
+
+      child.stdout!.on('data', (chunk: Buffer) => {
+        chunks.push(chunk);
+      });
+
+      child.stderr!.on('data', (chunk: Buffer) => {
+        stderrChunks.push(chunk);
+      });
+
+      const timer = setTimeout(() => {
+        child.kill('SIGTERM');
+        reject(new Error(`OpenCode timed out after ${this.timeoutMs / 1000}s`));
+      }, this.timeoutMs);
+
+      child.on('error', (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+
+      child.on('close', (code) => {
+        clearTimeout(timer);
+
+        const stderr = Buffer.concat(stderrChunks).toString('utf-8');
+        const output = Buffer.concat(chunks).toString('utf-8');
+
+        if (code !== 0) {
+          const stderr = Buffer.concat(stderrChunks).toString('utf-8');
+          const friendly = parseSeatBasedError(stderr, code);
+          const base = `OpenCode exited with code ${code}`;
+          const detail = friendly || stderr.slice(0, 500);
+          reject(new Error(detail ? `${base}. ${detail}` : base));
+          return;
+        }
+
+        if (DEBUG) {
+          const stderr = Buffer.concat(stderrChunks).toString('utf-8');
+          if (stderr.trim()) {
+            console.debug('[caliber:opencode] stderr:', stderr.slice(0, 1000));
+          }
+        }
+
+        const text = this.parseJsonOutput(output);
+        if (!text.trim()) {
+          reject(
+            new Error(
+              `OpenCode returned empty response. stdout: ${output.slice(0, 500)}, stderr: ${stderr.slice(0, 500)}`,
+            ),
+          );
+          return;
+        }
+
+        resolve(text);
+      });
+    });
+  }
+
+  private async runCommandStream(
+    prompt: string,
+    model: string | undefined,
+    callbacks: LLMStreamCallbacks,
+    inputEstimate: number,
+  ): Promise<void> {
+    const args = ['run', '--format', 'json', '--', '-'];
+    const modelToUse = model || this.defaultModel;
+    if (modelToUse && modelToUse !== 'default') args.splice(1, 0, '--model', modelToUse);
+
+    return new Promise((resolve, _reject) => {
+      const child = this.spawnOpenCode(args);
+      child.stdin!.end(prompt);
+
+      let settled = false;
+      let outputChars = 0;
+      const stderrChunks: Buffer[] = [];
+
+      child.stdout!.on('data', (chunk: Buffer) => {
+        if (settled) return;
+
+        const lines = chunk.toString('utf-8').split('\n');
+        for (const line of lines) {
+          if (!line.trim()) continue;
+
+          try {
+            const event = JSON.parse(line);
+            if (event.type === 'text' && event.part?.text) {
+              outputChars += event.part.text.length;
+              callbacks.onText(event.part.text);
+            } else if (event.type === 'error') {
+              settled = true;
+              callbacks.onError(new Error(event.error?.data?.message || 'Unknown error'));
+              child.kill();
+              return;
+            }
+          } catch {
+            // Not JSON, skip
+          }
+        }
+      });
+
+      child.stderr!.on('data', (chunk: Buffer) => {
+        stderrChunks.push(chunk);
+      });
+
+      const timer = setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          callbacks.onError(new Error(`OpenCode timed out after ${this.timeoutMs / 1000}s`));
+          child.kill('SIGTERM');
+        }
+      }, this.timeoutMs);
+
+      child.on('error', (err) => {
+        clearTimeout(timer);
+        if (!settled) {
+          settled = true;
+          callbacks.onError(err);
+        }
+      });
+
+      child.on('close', (code) => {
+        clearTimeout(timer);
+        if (settled) {
+          resolve();
+          return;
+        }
+
+        const modelUsed = model || this.defaultModel;
+        if (code !== 0 && code !== null) {
+          const stderr = Buffer.concat(stderrChunks).toString('utf-8');
+          const friendly = parseSeatBasedError(stderr, code);
+          const base = `OpenCode exited with code ${code}`;
+          const detail = friendly || stderr.slice(0, 500);
+          callbacks.onError(new Error(detail ? `${base}. ${detail}` : base));
+        } else {
+          trackUsage(modelUsed, {
+            inputTokens: inputEstimate,
+            outputTokens: Math.ceil(outputChars / 4),
+          });
+          callbacks.onEnd({ stopReason: 'end_turn' });
+        }
+        resolve();
+      });
+    });
+  }
+
+  private spawnOpenCode(args: string[]): ChildProcess {
+    const env = { ...process.env, OPENCODE_DISABLE_AUTOCOMPACT: 'true' };
+
+    return spawn(OPENCODE_BIN, args, {
+      cwd: process.cwd(),
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env,
+    });
+  }
+
+  private parseJsonOutput(output: string): string {
+    const textParts: string[] = [];
+    const lines = output.split('\n');
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+
+      if (trimmed.startsWith('```') || trimmed === '```') continue;
+
+      try {
+        const event = JSON.parse(trimmed);
+        if (event.type === 'text' && event.part?.text) {
+          textParts.push(event.part.text);
+        }
+      } catch {
+        // Not JSON, skip
+      }
+    }
+
+    return textParts.join('');
+  }
+}
+
+export function isOpenCodeAvailable(): boolean {
+  try {
+    const cmd = IS_WINDOWS ? `where ${OPENCODE_BIN}` : `which ${OPENCODE_BIN}`;
+    execSync(cmd, { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -1,4 +1,4 @@
-export type ProviderType = 'anthropic' | 'vertex' | 'openai' | 'cursor' | 'claude-cli';
+export type ProviderType = 'anthropic' | 'vertex' | 'openai' | 'cursor' | 'claude-cli' | 'opencode';
 
 const SEAT_BASED_PROVIDERS: ReadonlySet<ProviderType> = new Set(['cursor', 'claude-cli']);
 


### PR DESCRIPTION
## Summary

Adds the OpenCode CLI as a seat-based LLM provider for Caliber. Users with OpenCode installed can use it as their LLM backend — no API keys needed, auth is handled via `opencode auth login`.

## Changes

### New files
- **`src/llm/opencode.ts`** — `OpenCodeProvider` implementing `LLMProvider`
  - `call()` — synchronous LLM calls via `opencode run --format json`
  - `stream()` — streaming via JSON event parsing
  - Token usage tracking via `trackUsage()`
  - Message history support for multi-turn refinement
  - `parseSeatBasedError()` integration for friendly auth/rate-limit errors
  - Debug logging for stderr (`DEBUG=caliber:opencode`)
  - Configurable timeout via `CALIBER_OPENCODE_TIMEOUT_MS`

- **`src/llm/__tests__/opencode.test.ts`** — 25 unit tests covering call, stream, model flags, usage tracking, error cases, JSON parsing, and availability detection

### Modified files
- **`src/llm/types.ts`** — added `'opencode'` to `ProviderType`
- **`src/llm/config.ts`** — opencode defaults, env var detection (`CALIBER_USE_OPENCODE=1`), config file validation
- **`src/llm/index.ts`** — factory integration with availability check
- **`src/commands/init.ts`** — auto-detection when `--agent opencode` is passed

## Usage

```bash
# Via env var
CALIBER_USE_OPENCODE=1 caliber init

# Via agent flag (auto-detects opencode)
caliber init --agent opencode --auto-approve
```

## Tested

End-to-end init tested with multiple models through opencode Zen:
- ✅ qwen3.6-plus-free (via opencode Zen) — full init completed
- ✅ kimi-k2.5 — full init completed
- ⚠️ trinity-large-preview — model-specific tool-loop issue (not a provider bug)