### PR TITLE
feat: parallelize monorepo subdirectory refresh with Promise.allSettled

### DIFF
--- a/src/commands/refresh.ts
+++ b/src/commands/refresh.ts
@@ -319,23 +319,37 @@ async function refreshSingleRepo(
     await refreshDir(repoDir, '.', diff, options);
   } else {
     log(quiet, chalk.dim(`${prefix}Found configs in ${configDirs.length} directories\n`));
+
+    // Build the list of dirs that actually have changes before launching parallel work
+    const dirsWithChanges = configDirs
+      .map((dir) => ({ dir, scopedDiff: scopeDiffToDir(diff, dir, configDirs) }))
+      .filter(({ scopedDiff }) => scopedDiff.hasChanges);
+
+    // Refresh all subdirectories in parallel — each is independent (separate fingerprint,
+    // separate doc set, separate LLM call). Promise.allSettled ensures that a failure in
+    // one directory does not prevent the others from completing.
+    const results = await Promise.allSettled(
+      dirsWithChanges.map(({ dir, scopedDiff }) => {
+        const dirLabel = dir === '.' ? 'root' : dir;
+        return refreshDir(repoDir, dir, scopedDiff, { ...options, label: dirLabel });
+      }),
+    );
+
     let hadFailure = false;
-    for (const dir of configDirs) {
-      const scopedDiff = scopeDiffToDir(diff, dir, configDirs);
-      if (!scopedDiff.hasChanges) continue;
-      const dirLabel = dir === '.' ? 'root' : dir;
-      try {
-        await refreshDir(repoDir, dir, scopedDiff, { ...options, label: dirLabel });
-      } catch (err) {
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
+      if (result.status === 'rejected') {
         hadFailure = true;
+        const dirLabel = dirsWithChanges[i].dir === '.' ? 'root' : dirsWithChanges[i].dir;
         log(
           quiet,
           chalk.yellow(
-            `  ${dirLabel}: refresh failed — ${err instanceof Error ? err.message : 'unknown error'}`,
+            `  ${dirLabel}: refresh failed — ${result.reason instanceof Error ? result.reason.message : 'unknown error'}`,
           ),
         );
       }
     }
+
     if (hadFailure) {
       // Don't update state SHA — failed dirs need to be retried on next run
       return;


### PR DESCRIPTION
## Problem

On large monorepos with multiple config directories (e.g. `packages/api`, `packages/web`, `packages/shared`), `caliber refresh` processes each directory sequentially — one full fingerprint + LLM call at a time. With 4 packages and a 10s LLM latency, that's 40s of wall time.

## Solution

Replace the sequential `for...of` loop in `refreshSingleRepo` with `Promise.allSettled`. Each config directory is fully independent: it gets its own fingerprint, its own LLM call, and writes to its own file set. There is no shared state between directories that would require sequential execution.

### What changed (`src/commands/refresh.ts`)

- Pre-compute scoped diffs for all config dirs, filter out dirs with no changes **before** launching any parallel work
- Dispatch all dirs simultaneously with `Promise.allSettled`
- Post-process settled results to surface per-directory failures and set `hadFailure`
- Preserve the "don't advance state SHA when any directory fails" invariant — failed dirs are retried on next run

### Performance

| Scenario | Before | After |
|---|---|---|
| 4 packages, 10s LLM latency | ~40s | ~10s |
| 2 packages, 8s LLM latency | ~16s | ~8s |
| 1 package (no change) | same | same |

### Error handling

`Promise.allSettled` (not `Promise.all`) means a failure in one directory does not cancel others — all directories complete, failures are logged, and the state SHA is not advanced so retries happen on the next run.

## Tests

844 passed. 1 pre-existing failure in `recommend.test.ts` (`getInstalledSkills` multi-platform) unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)