### PR TITLE
feat: parallelize monorepo subdirectory refresh with p-limit concurrency cap

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,2 @@
+export PATH="/opt/homebrew/bin:/opt/homebrew/Cellar/node/25.9.0_1/bin:$PATH"
 npx lint-staged

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,2 +1,7 @@
-export PATH="/opt/homebrew/bin:/opt/homebrew/Cellar/node/25.9.0_1/bin:$PATH"
+# Derive Homebrew prefix (works on Apple Silicon /opt/homebrew and Intel /usr/local)
+BREW_PREFIX=$(/opt/homebrew/bin/brew --prefix 2>/dev/null || /usr/local/bin/brew --prefix 2>/dev/null || echo "")
+if [ -n "$BREW_PREFIX" ]; then
+  export PATH="$BREW_PREFIX/bin:$PATH"
+fi
+
 npx lint-staged

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
         "google-auth-library": "^9.0.0",
         "openai": "^6.29.0",
         "ora": "^8.1.0",
+        "p-limit": "^5.0.0",
         "posthog-node": "^5.28.2"
       },
       "bin": {
@@ -3879,6 +3880,37 @@
       }
     },
     "node_modules/p-limit": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-5.0.0.tgz",
+      "integrity": "sha512-/Eaoq+QyLSiXQ4lyYV23f14mZRQcXnxfHrN0vCai+ak9G0pp9iEQukIIZq5NccEvwRB8PUnZT0KsOoDCINS1qQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
+      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "p-limit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-locate/node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
       "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
@@ -3894,15 +3926,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/p-locate": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-5.0.0.tgz",
-      "integrity": "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==",
+    "node_modules/p-locate/node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "p-limit": "^3.0.2"
-      },
       "engines": {
         "node": ">=10"
       },
@@ -4982,13 +5011,12 @@
       }
     },
     "node_modules/yocto-queue": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
-      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
-      "dev": true,
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-1.2.2.tgz",
+      "integrity": "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==",
       "license": "MIT",
       "engines": {
-        "node": ">=10"
+        "node": ">=12.20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "google-auth-library": "^9.0.0",
     "openai": "^6.29.0",
     "ora": "^8.1.0",
+    "p-limit": "^3.1.0",
     "posthog-node": "^5.28.2"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "google-auth-library": "^9.0.0",
     "openai": "^6.29.0",
     "ora": "^8.1.0",
-    "p-limit": "^3.1.0",
+    "p-limit": "^5.0.0",
     "posthog-node": "^5.28.2"
   },
   "files": [

--- a/src/commands/__tests__/interactive-provider-setup.test.ts
+++ b/src/commands/__tests__/interactive-provider-setup.test.ts
@@ -34,8 +34,15 @@ vi.mock('readline', () => ({
 import { runInteractiveProviderSetup } from '../interactive-provider-setup.js';
 
 describe('runInteractiveProviderSetup', () => {
+  let origIsTTY: boolean | undefined;
   beforeEach(() => {
     vi.clearAllMocks();
+    // Tests simulate an interactive (TTY) session — promptInput() guards on isTTY
+    origIsTTY = process.stdin.isTTY;
+    Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
+  });
+  afterEach(() => {
+    Object.defineProperty(process.stdin, 'isTTY', { value: origIsTTY, configurable: true });
   });
 
   it('configures claude-cli provider without API key', async () => {

--- a/src/commands/__tests__/interactive-provider-setup.test.ts
+++ b/src/commands/__tests__/interactive-provider-setup.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
 const { mockSelect, mockConfirm, mockWriteConfigFile, mockQuestion } = vi.hoisted(() => ({
   mockSelect: vi.fn(),

--- a/src/commands/learn.ts
+++ b/src/commands/learn.ts
@@ -15,7 +15,13 @@ import {
   releaseFinalizeLock,
 } from '../learner/storage.js';
 import type { ToolEvent, PromptEvent } from '../learner/storage.js';
-import { writeLearnedContent, readLearnedSection, readPersonalLearnings, migrateInlineLearnings, addLearning } from '../learner/writer.js';
+import {
+  writeLearnedContent,
+  readLearnedSection,
+  readPersonalLearnings,
+  migrateInlineLearnings,
+  addLearning,
+} from '../learner/writer.js';
 import { sanitizeSecrets } from '../lib/sanitize.js';
 import { writeFinalizeSummary } from '../lib/notifications.js';
 import {
@@ -32,8 +38,18 @@ import { loadConfig } from '../llm/config.js';
 import { validateModel } from '../llm/index.js';
 import { recordSession, formatROISummary, readROIStats, writeROIStats } from '../learner/roi.js';
 import type { LearningCostEntry, SessionROISummary } from '../learner/roi.js';
-import { matchLearningsToFailures, semanticMatchFallback, updateActivations, findStaleLearnings } from '../learner/attribution.js';
-import { PERSONAL_LEARNINGS_FILE, getLearningDir, LEARNING_FINALIZE_LOG, LEARNING_LAST_ERROR_FILE } from '../constants.js';
+import {
+  matchLearningsToFailures,
+  semanticMatchFallback,
+  updateActivations,
+  findStaleLearnings,
+} from '../learner/attribution.js';
+import {
+  PERSONAL_LEARNINGS_FILE,
+  getLearningDir,
+  LEARNING_FINALIZE_LOG,
+  LEARNING_LAST_ERROR_FILE,
+} from '../constants.js';
 import { resolveCaliber } from '../lib/resolve-caliber.js';
 import {
   trackLearnSessionAnalyzed,
@@ -51,11 +67,18 @@ function writeFinalizeError(message: string): void {
   try {
     const errorPath = path.join(getLearningDir(), LEARNING_LAST_ERROR_FILE);
     if (!fs.existsSync(getLearningDir())) fs.mkdirSync(getLearningDir(), { recursive: true });
-    fs.writeFileSync(errorPath, JSON.stringify({
-      timestamp: new Date().toISOString(),
-      error: message,
-      pid: process.pid,
-    }, null, 2));
+    fs.writeFileSync(
+      errorPath,
+      JSON.stringify(
+        {
+          timestamp: new Date().toISOString(),
+          error: message,
+          pid: process.pid,
+        },
+        null,
+        2,
+      ),
+    );
   } catch {
     // Best effort
   }
@@ -134,7 +157,10 @@ export async function learnObserveCommand(options: { failure?: boolean; prompt?:
         const logPath = path.join(getLearningDir(), LEARNING_FINALIZE_LOG);
         if (!fs.existsSync(getLearningDir())) fs.mkdirSync(getLearningDir(), { recursive: true });
         const logFd = fs.openSync(logPath, 'a');
-        spawn(bin, ['learn', 'finalize', '--auto', '--incremental'], {
+        // bin may be multi-word (e.g. '/abs/npx --yes @rely-ai/caliber') — split so
+        // spawn receives a single executable and an argv array.
+        const [exe, ...binArgs] = bin.split(' ');
+        spawn(exe, [...binArgs, 'learn', 'finalize', '--auto', '--incremental'], {
           detached: true,
           stdio: ['ignore', logFd, logFd],
         }).unref();
@@ -148,26 +174,32 @@ export async function learnObserveCommand(options: { failure?: boolean; prompt?:
   }
 }
 
-export async function learnFinalizeCommand(options?: { force?: boolean; auto?: boolean; incremental?: boolean }) {
+export async function learnFinalizeCommand(options?: {
+  force?: boolean;
+  auto?: boolean;
+  incremental?: boolean;
+}) {
   const isAuto = options?.auto === true;
   const isIncremental = options?.incremental === true;
 
   if (!options?.force && !isAuto) {
     const { isCaliberRunning } = await import('../lib/lock.js');
     if (isCaliberRunning()) {
-      if (!isAuto) console.log(chalk.dim('caliber: skipping finalize — another caliber process is running'));
+      if (!isAuto)
+        console.log(chalk.dim('caliber: skipping finalize — another caliber process is running'));
       return;
     }
   }
 
   // Wait for event hooks to finish writing (race condition guard)
   if (isAuto) {
-    await new Promise(r => setTimeout(r, AUTO_SETTLE_MS));
+    await new Promise((r) => setTimeout(r, AUTO_SETTLE_MS));
   }
 
   // Prevent concurrent finalize from parallel sessions
   if (!acquireFinalizeLock()) {
-    if (!isAuto) console.log(chalk.dim('caliber: skipping finalize — another finalize is in progress'));
+    if (!isAuto)
+      console.log(chalk.dim('caliber: skipping finalize — another finalize is in progress'));
     return;
   }
 
@@ -176,7 +208,11 @@ export async function learnFinalizeCommand(options?: { force?: boolean; auto?: b
     const config = loadConfig();
     if (!config) {
       if (isAuto) return; // Graceful degradation: preserve events for later
-      console.log(chalk.yellow(`caliber: no LLM provider configured — run \`${resolveCaliber()} config\` first`));
+      console.log(
+        chalk.yellow(
+          `caliber: no LLM provider configured — run \`${resolveCaliber()} config\` first`,
+        ),
+      );
       clearSession();
       resetState();
       return;
@@ -185,7 +221,12 @@ export async function learnFinalizeCommand(options?: { force?: boolean; auto?: b
     const allEvents = readAllEvents();
     const threshold = isAuto ? MIN_EVENTS_AUTO : MIN_EVENTS_FOR_ANALYSIS;
     if (allEvents.length < threshold) {
-      if (!isAuto) console.log(chalk.dim(`caliber: ${allEvents.length}/${threshold} events recorded — need more before analysis`));
+      if (!isAuto)
+        console.log(
+          chalk.dim(
+            `caliber: ${allEvents.length}/${threshold} events recorded — need more before analysis`,
+          ),
+        );
       return;
     }
 
@@ -195,11 +236,16 @@ export async function learnFinalizeCommand(options?: { force?: boolean; auto?: b
 
     // For incremental analysis, only analyze events after the last analysis point
     const state = readState();
-    const analysisOffset = isIncremental ? (state.lastAnalysisEventCount || 0) : 0;
+    const analysisOffset = isIncremental ? state.lastAnalysisEventCount || 0 : 0;
     const events = analysisOffset > 0 ? allEvents.slice(analysisOffset) : allEvents;
 
     if (events.length < threshold) {
-      if (!isAuto) console.log(chalk.dim(`caliber: ${events.length}/${threshold} new events since last analysis — need more`));
+      if (!isAuto)
+        console.log(
+          chalk.dim(
+            `caliber: ${events.length}/${threshold} new events since last analysis — need more`,
+          ),
+        );
       return;
     }
 
@@ -220,7 +266,7 @@ export async function learnFinalizeCommand(options?: { force?: boolean; auto?: b
 
     const waste = calculateSessionWaste(allEvents);
     const existingLearnedItems = existingLearnedSection
-      ? existingLearnedSection.split('\n').filter(l => l.startsWith('- ')).length
+      ? existingLearnedSection.split('\n').filter((l) => l.startsWith('- ')).length
       : 0;
     const hadLearnings = existingLearnedItems > 0;
     let newLearningsProduced = 0;
@@ -242,10 +288,15 @@ export async function learnFinalizeCommand(options?: { force?: boolean; auto?: b
             wasteTokens: waste.totalWasteTokens,
           });
         } else {
-          const wasteLabel = waste.totalWasteTokens > 0
-            ? ` (~${waste.totalWasteTokens.toLocaleString()} wasted tokens captured)`
-            : '';
-          console.log(chalk.dim(`caliber: learned ${result.newItemCount} new pattern${result.newItemCount === 1 ? '' : 's'}${wasteLabel}`));
+          const wasteLabel =
+            waste.totalWasteTokens > 0
+              ? ` (~${waste.totalWasteTokens.toLocaleString()} wasted tokens captured)`
+              : '';
+          console.log(
+            chalk.dim(
+              `caliber: learned ${result.newItemCount} new pattern${result.newItemCount === 1 ? '' : 's'}${wasteLabel}`,
+            ),
+          );
           for (const item of result.newItems) {
             console.log(chalk.dim(`  + ${item.replace(/^- /, '').slice(0, 80)}`));
           }
@@ -312,7 +363,7 @@ export async function learnFinalizeCommand(options?: { force?: boolean; auto?: b
     // Attribution: match existing learnings against session failure events
     if (roiStats.learnings.length > 0 && waste.failureCount > 0) {
       const failureEvents = allEvents.filter(
-        e => e.hook_event_name === 'PostToolUseFailure'
+        (e) => e.hook_event_name === 'PostToolUseFailure',
       ) as ToolEvent[];
 
       let attribution = matchLearningsToFailures(roiStats.learnings, failureEvents);
@@ -347,12 +398,14 @@ export async function learnFinalizeCommand(options?: { force?: boolean; auto?: b
       totalSessions,
       sessionsWithLearnings: t.totalSessionsWithLearnings,
       sessionsWithoutLearnings: t.totalSessionsWithoutLearnings,
-      failureRateWithLearnings: t.totalSessionsWithLearnings > 0
-        ? t.totalFailuresWithLearnings / t.totalSessionsWithLearnings
-        : 0,
-      failureRateWithoutLearnings: t.totalSessionsWithoutLearnings > 0
-        ? t.totalFailuresWithoutLearnings / t.totalSessionsWithoutLearnings
-        : 0,
+      failureRateWithLearnings:
+        t.totalSessionsWithLearnings > 0
+          ? t.totalFailuresWithLearnings / t.totalSessionsWithLearnings
+          : 0,
+      failureRateWithoutLearnings:
+        t.totalSessionsWithoutLearnings > 0
+          ? t.totalFailuresWithoutLearnings / t.totalSessionsWithoutLearnings
+          : 0,
       estimatedSavingsTokens: t.estimatedSavingsTokens,
       estimatedSavingsSeconds: t.estimatedSavingsSeconds,
       learningCount: roiStats.learnings.length,
@@ -362,14 +415,22 @@ export async function learnFinalizeCommand(options?: { force?: boolean; auto?: b
     if (!isIncremental) {
       const staleLearnings = findStaleLearnings(roiStats);
       if (staleLearnings.length > 0 && !isAuto) {
-        console.log(chalk.yellow(`caliber: ${staleLearnings.length} learning${staleLearnings.length === 1 ? '' : 's'} never activated — run \`${resolveCaliber()} learn list --verbose\` to review`));
+        console.log(
+          chalk.yellow(
+            `caliber: ${staleLearnings.length} learning${staleLearnings.length === 1 ? '' : 's'} never activated — run \`${resolveCaliber()} learn list --verbose\` to review`,
+          ),
+        );
       }
     }
 
     // Show savings summary if we have history
     if (!isAuto && t.estimatedSavingsTokens > 0) {
       const totalLearnings = existingLearnedItems + newLearningsProduced;
-      console.log(chalk.dim(`caliber: ${totalLearnings} learnings active — est. ~${t.estimatedSavingsTokens.toLocaleString()} tokens saved across ${t.totalSessionsWithLearnings} sessions`));
+      console.log(
+        chalk.dim(
+          `caliber: ${totalLearnings} learnings active — est. ~${t.estimatedSavingsTokens.toLocaleString()} tokens saved across ${t.totalSessionsWithLearnings} sessions`,
+        ),
+      );
     }
   } catch (err) {
     const errorMsg = err instanceof Error ? err.message : String(err);
@@ -419,12 +480,18 @@ export async function learnInstallCommand() {
 
   if (!fs.existsSync('.claude') && !fs.existsSync('.cursor')) {
     console.log(chalk.yellow('No .claude/ or .cursor/ directory found.'));
-    console.log(chalk.dim(`  Run \`${resolveCaliber()} init\` first, or create the directory manually.`));
+    console.log(
+      chalk.dim(`  Run \`${resolveCaliber()} init\` first, or create the directory manually.`),
+    );
     return;
   }
 
   if (anyInstalled) {
-    console.log(chalk.dim(`  Tool usage will be recorded and learnings extracted after ≥${MIN_EVENTS_FOR_ANALYSIS} events.`));
+    console.log(
+      chalk.dim(
+        `  Tool usage will be recorded and learnings extracted after ≥${MIN_EVENTS_FOR_ANALYSIS} events.`,
+      ),
+    );
     console.log(chalk.dim('  Learnings written to CALIBER_LEARNINGS.md.'));
   }
 }
@@ -471,7 +538,9 @@ export async function learnStatusCommand() {
   }
 
   if (!claudeInstalled && !cursorInstalled) {
-    console.log(chalk.dim(`  Run \`${resolveCaliber()} learn install\` to enable session learning.`));
+    console.log(
+      chalk.dim(`  Run \`${resolveCaliber()} learn install\` to enable session learning.`),
+    );
   }
 
   console.log();
@@ -523,14 +592,14 @@ function getAllLearnings(): LearningItem[] {
 
   const projectSection = readLearnedSection();
   if (projectSection) {
-    for (const line of projectSection.split('\n').filter(l => l.startsWith('- '))) {
+    for (const line of projectSection.split('\n').filter((l) => l.startsWith('- '))) {
       items.push({ text: line, source: 'project', index: idx++ });
     }
   }
 
   const personalSection = readPersonalLearnings();
   if (personalSection) {
-    for (const line of personalSection.split('\n').filter(l => l.startsWith('- '))) {
+    for (const line of personalSection.split('\n').filter((l) => l.startsWith('- '))) {
       items.push({ text: line, source: 'personal', index: idx++ });
     }
   }
@@ -556,7 +625,7 @@ export async function learnListCommand(options?: { verbose?: boolean }) {
     console.log(`  ${chalk.dim(String(item.index + 1).padStart(2, ' '))}. ${tag} ${display}`);
 
     if (options?.verbose && roiStats) {
-      const match = roiStats.learnings.find(l => display.includes(l.summary.slice(0, 40)));
+      const match = roiStats.learnings.find((l) => display.includes(l.summary.slice(0, 40)));
       if (match) {
         const activations = match.activationCount ?? 0;
         const stale = activations === 0 && roiStats.sessions.length >= 10;
@@ -576,7 +645,11 @@ export async function learnListCommand(options?: { verbose?: boolean }) {
 export async function learnDeleteCommand(indexStr: string) {
   const index = parseInt(indexStr, 10);
   if (isNaN(index) || index < 1) {
-    console.log(chalk.red(`Invalid index: "${indexStr}". Use a number from \`${resolveCaliber()} learn list\`.`));
+    console.log(
+      chalk.red(
+        `Invalid index: "${indexStr}". Use a number from \`${resolveCaliber()} learn list\`.`,
+      ),
+    );
     return;
   }
 
@@ -589,9 +662,7 @@ export async function learnDeleteCommand(indexStr: string) {
   }
 
   const item = items[targetIdx];
-  const filePath = item.source === 'personal'
-    ? PERSONAL_LEARNINGS_FILE
-    : 'CALIBER_LEARNINGS.md';
+  const filePath = item.source === 'personal' ? PERSONAL_LEARNINGS_FILE : 'CALIBER_LEARNINGS.md';
 
   if (!fs.existsSync(filePath)) {
     console.log(chalk.red('Learnings file not found.'));
@@ -602,7 +673,7 @@ export async function learnDeleteCommand(indexStr: string) {
   const lines = content.split('\n');
 
   // Find which bullet within this file corresponds to our item
-  const bulletsOfSource = items.filter(i => i.source === item.source);
+  const bulletsOfSource = items.filter((i) => i.source === item.source);
   const posInFile = bulletsOfSource.indexOf(item);
 
   // Find the Nth bullet line in the file
@@ -633,8 +704,11 @@ export async function learnDeleteCommand(indexStr: string) {
 
   // Clean up corresponding ROI stats entry
   const roiStats = readROIStats();
-  const cleanText = bulletToRemove.replace(/^- /, '').replace(/^\*\*\[[^\]]+\]\*\*\s*/, '').trim();
-  const roiIdx = roiStats.learnings.findIndex(l => cleanText.includes(l.summary.slice(0, 30)));
+  const cleanText = bulletToRemove
+    .replace(/^- /, '')
+    .replace(/^\*\*\[[^\]]+\]\*\*\s*/, '')
+    .trim();
+  const roiIdx = roiStats.learnings.findIndex((l) => cleanText.includes(l.summary.slice(0, 30)));
   if (roiIdx !== -1) {
     roiStats.learnings.splice(roiIdx, 1);
     writeROIStats(roiStats);

--- a/src/commands/learn.ts
+++ b/src/commands/learn.ts
@@ -151,15 +151,19 @@ export async function learnObserveCommand(options: { failure?: boolean; prompt?:
     const eventsSinceLastAnalysis = state.eventCount - (state.lastAnalysisEventCount || 0);
     if (eventsSinceLastAnalysis >= INCREMENTAL_INTERVAL) {
       try {
-        const { resolveCaliber } = await import('../lib/resolve-caliber.js');
+        const { resolveCaliber, isNpxResolution } = await import('../lib/resolve-caliber.js');
         const bin = resolveCaliber();
         const { spawn } = await import('child_process');
         const logPath = path.join(getLearningDir(), LEARNING_FINALIZE_LOG);
         if (!fs.existsSync(getLearningDir())) fs.mkdirSync(getLearningDir(), { recursive: true });
         const logFd = fs.openSync(logPath, 'a');
-        // bin may be multi-word (e.g. '/abs/npx --yes @rely-ai/caliber') — split so
-        // spawn receives a single executable and an argv array.
-        const [exe, ...binArgs] = bin.split(' ');
+        // resolveCaliber() returns multi-word strings only for npx invocations:
+        // '<npx_path> --yes @rely-ai/caliber'. The npx path itself may contain
+        // spaces, so split(' ') is fragile. Detect the known suffix instead.
+        const NPX_SUFFIX = ' --yes @rely-ai/caliber';
+        const [exe, binArgs] = isNpxResolution()
+          ? [bin.slice(0, -NPX_SUFFIX.length) || 'npx', ['--yes', '@rely-ai/caliber']]
+          : [bin, []];
         spawn(exe, [...binArgs, 'learn', 'finalize', '--auto', '--incremental'], {
           detached: true,
           stdio: ['ignore', logFd, logFd],

--- a/src/commands/recommend.ts
+++ b/src/commands/recommend.ts
@@ -599,6 +599,12 @@ export async function recommendCommand(options: { query?: string; install?: stri
     return;
   }
 
+  // Non-interactive context (git hooks, CI, subprocess): skip the confirmation prompt
+  if (!process.stdin.isTTY) {
+    console.log(chalk.dim('  Skills search requires an interactive terminal.'));
+    return;
+  }
+
   const proceed = await select({
     message: 'Search public repos for relevant skills to add to this project?',
     choices: [

--- a/src/commands/refresh.ts
+++ b/src/commands/refresh.ts
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import chalk from 'chalk';
 import ora from 'ora';
+import pLimit from 'p-limit';
 import { isGitRepo } from '../fingerprint/git.js';
 import { collectDiff, scopeDiffToDir, type DiffResult } from '../lib/git-diff.js';
 import { readState, writeState, getCurrentHeadSha } from '../lib/state.js';
@@ -125,6 +126,9 @@ export function collectFilesToWrite(
 }
 
 const REFRESH_COOLDOWN_MS = 30_000;
+// Max simultaneous LLM calls when refreshing multiple monorepo directories.
+// Caps concurrency to avoid rate-limit storms on lower-tier provider plans.
+const PARALLEL_DIR_CONCURRENCY = 4;
 
 async function refreshDir(
   repoDir: string,
@@ -319,23 +323,54 @@ async function refreshSingleRepo(
     await refreshDir(repoDir, '.', diff, options);
   } else {
     log(quiet, chalk.dim(`${prefix}Found configs in ${configDirs.length} directories\n`));
+
+    // Pre-filter to dirs that actually have changes before launching parallel work.
+    const dirsWithChanges = configDirs
+      .map((dir) => ({ dir, scopedDiff: scopeDiffToDir(diff, dir, configDirs) }))
+      .filter(({ scopedDiff }) => scopedDiff.hasChanges);
+
+    // Use a single top-level spinner — multiple concurrent ora instances corrupt
+    // the terminal by racing over the same cursor position with ANSI sequences.
+    const parallelSpinner = quiet
+      ? null
+      : ora(
+          `${prefix}Refreshing ${dirsWithChanges.length} director${dirsWithChanges.length === 1 ? 'y' : 'ies'}...`,
+        ).start();
+
+    // Refresh all dirs in parallel with a concurrency cap to avoid provider rate limits.
+    // Promise.allSettled ensures a failure in one dir doesn't prevent the others.
+    const limit = pLimit(PARALLEL_DIR_CONCURRENCY);
+    const results = await Promise.allSettled(
+      dirsWithChanges.map(({ dir, scopedDiff }) => {
+        const dirLabel = dir === '.' ? 'root' : dir;
+        // Pass quiet:true to suppress per-dir spinners — managed by parallelSpinner above.
+        return limit(() =>
+          refreshDir(repoDir, dir, scopedDiff, { ...options, quiet: true, label: dirLabel }),
+        );
+      }),
+    );
+
+    parallelSpinner?.stop();
+
+    // Print results sequentially so output is readable after all promises settle.
     let hadFailure = false;
-    for (const dir of configDirs) {
-      const scopedDiff = scopeDiffToDir(diff, dir, configDirs);
-      if (!scopedDiff.hasChanges) continue;
-      const dirLabel = dir === '.' ? 'root' : dir;
-      try {
-        await refreshDir(repoDir, dir, scopedDiff, { ...options, label: dirLabel });
-      } catch (err) {
+    for (const [i, result] of results.entries()) {
+      const dirLabel = dirsWithChanges[i].dir === '.' ? 'root' : dirsWithChanges[i].dir;
+      if (result.status === 'rejected') {
         hadFailure = true;
         log(
           quiet,
           chalk.yellow(
-            `  ${dirLabel}: refresh failed — ${err instanceof Error ? err.message : 'unknown error'}`,
+            `  ${dirLabel}: refresh failed — ${result.reason instanceof Error ? result.reason.message : 'unknown error'}`,
           ),
         );
+      } else {
+        for (const file of result.value.written) {
+          log(quiet, `  ${chalk.green('✓')} ${dirLabel}/${file}`);
+        }
       }
     }
+
     if (hadFailure) {
       // Don't update state SHA — failed dirs need to be retried on next run
       return;

--- a/src/commands/refresh.ts
+++ b/src/commands/refresh.ts
@@ -130,18 +130,28 @@ const REFRESH_COOLDOWN_MS = 30_000;
 // Caps concurrency to avoid rate-limit storms on lower-tier provider plans.
 const PARALLEL_DIR_CONCURRENCY = 4;
 
+interface RefreshDirResult {
+  written: string[];
+  fileChanges: Array<{ file: string; description: string }>;
+  syncedAgents: string[];
+  changesSummary: string | null | undefined;
+}
+
 async function refreshDir(
   repoDir: string,
   dir: string,
   diff: DiffResult,
-  options: RefreshOptions & { label?: string },
-): Promise<{ written: string[] }> {
+  options: RefreshOptions & { label?: string; suppressSpinner?: boolean },
+): Promise<RefreshDirResult> {
   const quiet = !!options.quiet;
+  // suppressSpinner: suppress spinner + all log output; caller prints results after settling
+  const suppress = !!options.suppressSpinner;
+  const effectiveQuiet = quiet || suppress;
   const prefix = options.label ? `${chalk.bold(options.label)} ` : '';
   const absDir = dir === '.' ? repoDir : path.resolve(repoDir, dir);
   const scope = dir === '.' ? undefined : dir;
 
-  const spinner = quiet ? null : ora(`${prefix}Analyzing changes...`).start();
+  const spinner = effectiveQuiet ? null : ora(`${prefix}Analyzing changes...`).start();
 
   const learnedSection = readLearnedSection();
   const fingerprint = await collectFingerprint(absDir);
@@ -198,7 +208,7 @@ async function refreshDir(
 
   if (!response.docsUpdated || response.docsUpdated.length === 0) {
     spinner?.succeed(`${prefix}No doc updates needed`);
-    return { written: [] };
+    return { written: [], fileChanges: [], syncedAgents: [], changesSummary: null };
   }
 
   if (options.dryRun) {
@@ -209,7 +219,7 @@ async function refreshDir(
     if (response.changesSummary) {
       console.log(chalk.dim(`\n  ${response.changesSummary}`));
     }
-    return { written: [] };
+    return { written: [], fileChanges: [], syncedAgents: [], changesSummary: null };
   }
 
   const allFilesToWrite = collectFilesToWrite(response.updatedDocs, dir);
@@ -252,37 +262,42 @@ async function refreshDir(
       spinner?.warn(
         `${prefix}Refresh reverted — score would drop from ${preScore.score} to ${postScore.score}`,
       );
-      log(quiet, chalk.dim(`  Config quality gate prevented a regression. No files were changed.`));
-      return { written: [] };
+      log(
+        effectiveQuiet,
+        chalk.dim(`  Config quality gate prevented a regression. No files were changed.`),
+      );
+      return { written: [], fileChanges: [], syncedAgents: [], changesSummary: null };
     }
     recordScore(postScore, 'refresh');
   }
 
   spinner?.succeed(`${prefix}Updated ${written.length} doc${written.length === 1 ? '' : 's'}`);
 
-  const fileChangesMap = new Map(
-    (response.fileChanges || []).map((fc: { file: string; description: string }) => [
-      fc.file,
-      fc.description,
-    ]),
-  );
+  const fileChanges: Array<{ file: string; description: string }> = response.fileChanges || [];
+  const fileChangesMap = new Map(fileChanges.map((fc) => [fc.file, fc.description]));
+  const syncedAgents = detectSyncedAgents(written);
 
-  for (const file of written) {
-    const desc = fileChangesMap.get(file);
-    const suffix = desc ? chalk.dim(` — ${desc}`) : '';
-    log(quiet, `  ${chalk.green('✓')} ${file}${suffix}`);
+  // When suppress is true, skip per-file output — caller prints results sequentially after settling.
+  if (!suppress) {
+    for (const file of written) {
+      const desc = fileChangesMap.get(file);
+      const suffix = desc ? chalk.dim(` — ${desc}`) : '';
+      log(effectiveQuiet, `  ${chalk.green('✓')} ${file}${suffix}`);
+    }
+
+    if (syncedAgents.length > 1) {
+      log(
+        effectiveQuiet,
+        chalk.cyan(`\n  ${syncedAgents.length} agent formats in sync (${syncedAgents.join(', ')})`),
+      );
+    }
+
+    if (response.changesSummary) {
+      log(effectiveQuiet, chalk.dim(`\n  ${response.changesSummary}`));
+    }
   }
 
-  const agents = detectSyncedAgents(written);
-  if (agents.length > 1) {
-    log(quiet, chalk.cyan(`\n  ${agents.length} agent formats in sync (${agents.join(', ')})`));
-  }
-
-  if (response.changesSummary) {
-    log(quiet, chalk.dim(`\n  ${response.changesSummary}`));
-  }
-
-  return { written };
+  return { written, fileChanges, syncedAgents, changesSummary: response.changesSummary };
 }
 
 async function refreshSingleRepo(
@@ -339,13 +354,18 @@ async function refreshSingleRepo(
 
     // Refresh all dirs in parallel with a concurrency cap to avoid provider rate limits.
     // Promise.allSettled ensures a failure in one dir doesn't prevent the others.
+    // suppressSpinner keeps quiet/hook mode intact while buffering per-dir output so
+    // results are printed sequentially after all promises settle (no interleaving).
     const limit = pLimit(PARALLEL_DIR_CONCURRENCY);
     const results = await Promise.allSettled(
       dirsWithChanges.map(({ dir, scopedDiff }) => {
         const dirLabel = dir === '.' ? 'root' : dir;
-        // Pass quiet:true to suppress per-dir spinners — managed by parallelSpinner above.
         return limit(() =>
-          refreshDir(repoDir, dir, scopedDiff, { ...options, quiet: true, label: dirLabel }),
+          refreshDir(repoDir, dir, scopedDiff, {
+            ...options,
+            suppressSpinner: true,
+            label: dirLabel,
+          }),
         );
       }),
     );
@@ -355,7 +375,8 @@ async function refreshSingleRepo(
     // Print results sequentially so output is readable after all promises settle.
     let hadFailure = false;
     for (const [i, result] of results.entries()) {
-      const dirLabel = dirsWithChanges[i].dir === '.' ? 'root' : dirsWithChanges[i].dir;
+      const { dir } = dirsWithChanges[i];
+      const dirLabel = dir === '.' ? 'root' : dir;
       if (result.status === 'rejected') {
         hadFailure = true;
         log(
@@ -365,8 +386,23 @@ async function refreshSingleRepo(
           ),
         );
       } else {
-        for (const file of result.value.written) {
-          log(quiet, `  ${chalk.green('✓')} ${dirLabel}/${file}`);
+        const { written, fileChanges, syncedAgents, changesSummary } = result.value;
+        const fileChangesMap = new Map(fileChanges.map((fc) => [fc.file, fc.description]));
+        for (const file of written) {
+          const desc = fileChangesMap.get(file);
+          const suffix = desc ? chalk.dim(` — ${desc}`) : '';
+          log(quiet, `  ${chalk.green('✓')} ${dirLabel}/${file}${suffix}`);
+        }
+        if (syncedAgents.length > 1) {
+          log(
+            quiet,
+            chalk.cyan(
+              `\n  ${syncedAgents.length} agent formats in sync (${syncedAgents.join(', ')})`,
+            ),
+          );
+        }
+        if (changesSummary) {
+          log(quiet, chalk.dim(`\n  ${changesSummary}`));
         }
       }
     }

--- a/src/lib/__tests__/hooks.test.ts
+++ b/src/lib/__tests__/hooks.test.ts
@@ -38,7 +38,7 @@ describe('pre-commit hook generation', () => {
       process.argv[1] = '/home/user/.npm/_npx/abc123/node_modules/.bin/caliber';
     });
 
-    it('uses command -v npx as the guard condition', async () => {
+    it('uses command -v npx guard and unquoted invocation when npx path is unknown', async () => {
       const { installPreCommitHook } = await import('../hooks.js');
 
       const tmpDir = makeTmpDir();
@@ -46,7 +46,12 @@ describe('pre-commit hook generation', () => {
       const hooksDir = path.join(gitDir, 'hooks');
       fs.mkdirSync(hooksDir, { recursive: true });
 
-      mockedExecSync.mockReturnValue(`${gitDir}\n`);
+      mockedExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === 'string' && (cmd.includes('which') || cmd.includes('where'))) {
+          throw new Error('not found');
+        }
+        return `${gitDir}\n`;
+      });
 
       const origCwd = process.cwd();
       process.chdir(tmpDir);
@@ -57,13 +62,18 @@ describe('pre-commit hook generation', () => {
         expect(hookContent).toContain('command -v npx >/dev/null 2>&1');
         expect(hookContent).not.toContain('[ -x "npx');
         expect(hookContent).not.toContain('command -v "npx --yes');
+        expect(hookContent).not.toContain('"npx --yes @rely-ai/caliber"');
+        expect(hookContent).toContain('npx --yes @rely-ai/caliber refresh');
+        expect(hookContent).toContain('npx --yes @rely-ai/caliber learn finalize');
       } finally {
         process.chdir(origCwd);
         fs.rmSync(tmpDir, { recursive: true, force: true });
       }
     });
 
-    it('invokes npx without quotes so shell word-splits correctly', async () => {
+    it('uses absolute npx path and -x guard when npx is found on PATH', async () => {
+      const { resetResolvedCaliber } = await import('../resolve-caliber.js');
+      resetResolvedCaliber();
       const { installPreCommitHook } = await import('../hooks.js');
 
       const tmpDir = makeTmpDir();
@@ -71,7 +81,18 @@ describe('pre-commit hook generation', () => {
       const hooksDir = path.join(gitDir, 'hooks');
       fs.mkdirSync(hooksDir, { recursive: true });
 
-      mockedExecSync.mockReturnValue(`${gitDir}\n`);
+      mockedExecSync.mockImplementation((cmd: string) => {
+        if (
+          typeof cmd === 'string' &&
+          (cmd.includes('which caliber') || cmd.includes('where caliber'))
+        ) {
+          throw new Error('not found');
+        }
+        if (typeof cmd === 'string' && (cmd.includes('which npx') || cmd.includes('where npx'))) {
+          return '/opt/homebrew/bin/npx\n';
+        }
+        return `${gitDir}\n`;
+      });
 
       const origCwd = process.cwd();
       process.chdir(tmpDir);
@@ -79,9 +100,12 @@ describe('pre-commit hook generation', () => {
         installPreCommitHook();
         const hookContent = fs.readFileSync(path.join(hooksDir, 'pre-commit'), 'utf-8');
 
-        expect(hookContent).not.toContain('"npx --yes @rely-ai/caliber"');
-        expect(hookContent).toContain('npx --yes @rely-ai/caliber refresh');
-        expect(hookContent).toContain('npx --yes @rely-ai/caliber learn finalize');
+        expect(hookContent).toContain('[ -x "/opt/homebrew/bin/npx" ]');
+        expect(hookContent).not.toContain('command -v npx');
+        expect(hookContent).toContain('"/opt/homebrew/bin/npx" --yes @rely-ai/caliber refresh');
+        expect(hookContent).toContain(
+          '"/opt/homebrew/bin/npx" --yes @rely-ai/caliber learn finalize',
+        );
       } finally {
         process.chdir(origCwd);
         fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -130,8 +154,8 @@ describe('pre-commit hook generation', () => {
         installPreCommitHook();
         const hookContent = fs.readFileSync(path.join(hooksDir, 'pre-commit'), 'utf-8');
 
-        expect(hookContent).toContain('[ -x "caliber" ] || command -v "caliber"');
-        expect(hookContent).toContain('"caliber" refresh');
+        expect(hookContent).toContain('[ -x "/usr/local/bin/caliber" ]');
+        expect(hookContent).toContain('"/usr/local/bin/caliber" refresh');
       } finally {
         process.chdir(origCwd);
         fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -158,8 +182,12 @@ describe('SessionEnd hook command', () => {
     vi.resetModules();
   });
 
-  it('uses npx command in Claude settings when in npx context', async () => {
+  it('uses bare npx command in Claude settings when caliber is not globally installed', async () => {
     process.argv[1] = '/home/user/.npm/_npx/abc/node_modules/.bin/caliber';
+    // Neither caliber nor npx on PATH — falls back to bare 'npx --yes @rely-ai/caliber'
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('not found');
+    });
 
     const { installHook } = await import('../hooks.js');
 

--- a/src/lib/__tests__/hooks.test.ts
+++ b/src/lib/__tests__/hooks.test.ts
@@ -118,7 +118,10 @@ describe('pre-commit hook generation', () => {
       process.argv[1] = '/usr/local/bin/caliber';
       delete process.env.npm_execpath;
       mockedExecSync.mockImplementation((cmd: string) => {
-        if (typeof cmd === 'string' && cmd.includes('which caliber')) {
+        if (
+          typeof cmd === 'string' &&
+          (cmd.includes('which caliber') || cmd.includes('where caliber'))
+        ) {
           return '/usr/local/bin/caliber\n';
         }
         if (typeof cmd === 'string' && cmd.includes('rev-parse')) {
@@ -139,7 +142,10 @@ describe('pre-commit hook generation', () => {
       fs.mkdirSync(hooksDir, { recursive: true });
 
       mockedExecSync.mockImplementation((cmd: string) => {
-        if (typeof cmd === 'string' && cmd.includes('which caliber')) {
+        if (
+          typeof cmd === 'string' &&
+          (cmd.includes('which caliber') || cmd.includes('where caliber'))
+        ) {
           return '/usr/local/bin/caliber\n';
         }
         if (typeof cmd === 'string' && cmd.includes('rev-parse')) {

--- a/src/lib/__tests__/resolve-caliber.test.ts
+++ b/src/lib/__tests__/resolve-caliber.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-import { resolveCaliber, isNpxResolution, resetResolvedCaliber, isCaliberCommand } from '../resolve-caliber.js';
+import {
+  resolveCaliber,
+  isNpxResolution,
+  resetResolvedCaliber,
+  isCaliberCommand,
+} from '../resolve-caliber.js';
 import { execSync } from 'child_process';
 
 vi.mock('child_process', () => ({
@@ -29,29 +34,61 @@ describe('resolveCaliber', () => {
     vi.restoreAllMocks();
   });
 
-  it('returns npx command when argv[1] contains _npx', () => {
+  it('returns bare npx command when argv[1] contains _npx and caliber/npx not on PATH', () => {
     process.argv[1] = '/home/user/.npm/_npx/abc123/node_modules/.bin/caliber';
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('not found');
+    });
     const result = resolveCaliber();
     expect(result).toBe('npx --yes @rely-ai/caliber');
   });
 
-  it('returns npx command when npm_execpath contains npx', () => {
+  it('returns absolute npx path when in npx context and npx is on PATH but caliber is not', () => {
+    process.argv[1] = '/home/user/.npm/_npx/abc123/node_modules/.bin/caliber';
+    mockedExecSync.mockImplementation((cmd: string) => {
+      if (cmd.includes('which caliber') || cmd.includes('where caliber'))
+        throw new Error('not found');
+      if (cmd.includes('which npx') || cmd.includes('where npx')) return '/opt/homebrew/bin/npx\n';
+      throw new Error('unexpected');
+    });
+    const result = resolveCaliber();
+    expect(result).toBe('/opt/homebrew/bin/npx --yes @rely-ai/caliber');
+  });
+
+  it('returns absolute caliber path when in npx context but caliber is globally installed', () => {
+    process.argv[1] = '/home/user/.npm/_npx/abc123/node_modules/.bin/caliber';
+    mockedExecSync.mockImplementation((cmd: string) => {
+      if (cmd.includes('which caliber') || cmd.includes('where caliber'))
+        return '/opt/homebrew/bin/caliber\n';
+      throw new Error('unexpected');
+    });
+    const result = resolveCaliber();
+    expect(result).toBe('/opt/homebrew/bin/caliber');
+  });
+
+  it('returns npx command when npm_execpath contains npx and caliber/npx not on PATH', () => {
     process.argv[1] = '/some/path/caliber';
     process.env.npm_execpath = '/usr/local/lib/node_modules/npm/bin/npx-cli.js';
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('not found');
+    });
     const result = resolveCaliber();
     expect(result).toBe('npx --yes @rely-ai/caliber');
   });
 
-  it('returns bare caliber when found on PATH', () => {
+  it('returns absolute path when caliber is found on PATH', () => {
     process.argv[1] = '/usr/local/bin/caliber';
     delete process.env.npm_execpath;
     mockedExecSync.mockReturnValue('/usr/local/bin/caliber\n');
     const result = resolveCaliber();
-    expect(result).toBe('caliber');
+    expect(result).toBe('/usr/local/bin/caliber');
   });
 
   it('caches the result across calls', () => {
     process.argv[1] = '/home/user/.npm/_npx/abc/node_modules/.bin/caliber';
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('not found');
+    });
     resolveCaliber();
     process.argv[1] = '/usr/local/bin/caliber';
     expect(resolveCaliber()).toBe('npx --yes @rely-ai/caliber');
@@ -59,13 +96,16 @@ describe('resolveCaliber', () => {
 
   it('resetResolvedCaliber clears the cache', () => {
     process.argv[1] = '/home/user/.npm/_npx/abc/node_modules/.bin/caliber';
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('not found');
+    });
     expect(resolveCaliber()).toBe('npx --yes @rely-ai/caliber');
 
     resetResolvedCaliber();
     process.argv[1] = '/usr/local/bin/caliber';
     delete process.env.npm_execpath;
     mockedExecSync.mockReturnValue('/usr/local/bin/caliber\n');
-    expect(resolveCaliber()).toBe('caliber');
+    expect(resolveCaliber()).toBe('/usr/local/bin/caliber');
   });
 });
 
@@ -78,12 +118,26 @@ describe('isNpxResolution', () => {
     vi.restoreAllMocks();
   });
 
-  it('returns true when resolved to npx', () => {
+  it('returns true when resolved to bare npx', () => {
     process.argv[1] = '/home/user/.npm/_npx/abc/node_modules/.bin/caliber';
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('not found');
+    });
     expect(isNpxResolution()).toBe(true);
   });
 
-  it('returns false when resolved to bare caliber', () => {
+  it('returns true when resolved to absolute-path npx', () => {
+    process.argv[1] = '/home/user/.npm/_npx/abc/node_modules/.bin/caliber';
+    mockedExecSync.mockImplementation((cmd: string) => {
+      if (cmd.includes('which caliber') || cmd.includes('where caliber'))
+        throw new Error('not found');
+      if (cmd.includes('which npx') || cmd.includes('where npx')) return '/opt/homebrew/bin/npx\n';
+      throw new Error('unexpected');
+    });
+    expect(isNpxResolution()).toBe(true);
+  });
+
+  it('returns false when resolved to absolute caliber path', () => {
     process.argv[1] = '/usr/local/bin/caliber';
     delete process.env.npm_execpath;
     mockedExecSync.mockReturnValue('/usr/local/bin/caliber\n');
@@ -97,11 +151,15 @@ describe('isCaliberCommand', () => {
   });
 
   it('matches absolute path', () => {
-    expect(isCaliberCommand('/usr/local/bin/caliber refresh --quiet', 'refresh --quiet')).toBe(true);
+    expect(isCaliberCommand('/usr/local/bin/caliber refresh --quiet', 'refresh --quiet')).toBe(
+      true,
+    );
   });
 
   it('matches npx --yes form', () => {
-    expect(isCaliberCommand('npx --yes @rely-ai/caliber refresh --quiet', 'refresh --quiet')).toBe(true);
+    expect(isCaliberCommand('npx --yes @rely-ai/caliber refresh --quiet', 'refresh --quiet')).toBe(
+      true,
+    );
   });
 
   it('matches npx without --yes', () => {

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -107,12 +107,14 @@ export function removeHook(): { removed: boolean; notFound: boolean } {
 interface ScriptHookConfig {
   eventName: string;
   scriptPath: string;
-  scriptContent: string;
+  scriptContent: string | (() => string);
   description: string;
 }
 
 function createScriptHook(config: ScriptHookConfig) {
-  const { eventName, scriptPath, scriptContent, description } = config;
+  const { eventName, scriptPath, description } = config;
+  const getContent = () =>
+    typeof config.scriptContent === 'function' ? config.scriptContent() : config.scriptContent;
 
   const hasHook = (matchers: HookMatcher[]) =>
     matchers.some((entry) => entry.hooks?.some((h) => h.description === description));
@@ -134,7 +136,7 @@ function createScriptHook(config: ScriptHookConfig) {
 
     const scriptDir = path.dirname(scriptPath);
     if (!fs.existsSync(scriptDir)) fs.mkdirSync(scriptDir, { recursive: true });
-    fs.writeFileSync(scriptPath, scriptContent);
+    fs.writeFileSync(scriptPath, getContent());
     fs.chmodSync(scriptPath, 0o755);
 
     if (!Array.isArray(settings.hooks[eventName])) {
@@ -205,7 +207,9 @@ export const removeStopHook = stopHook.remove;
 
 // ── Freshness check script ───────────────────────────────────────────
 
-const FRESHNESS_SCRIPT = `#!/bin/sh
+function getFreshnessScript(): string {
+  const bin = resolveCaliber();
+  return `#!/bin/sh
 STATE_FILE=".caliber/.caliber-state.json"
 [ ! -f "$STATE_FILE" ] && exit 0
 LAST_SHA=$(grep -o '"lastRefreshSha":"[^"]*"' "$STATE_FILE" 2>/dev/null | cut -d'"' -f4)
@@ -214,16 +218,17 @@ CURRENT_SHA=$(git rev-parse HEAD 2>/dev/null)
 [ "$LAST_SHA" = "$CURRENT_SHA" ] && exit 0
 COMMITS_BEHIND=$(git rev-list --count "$LAST_SHA".."$CURRENT_SHA" 2>/dev/null || echo 0)
 if [ "$COMMITS_BEHIND" -gt 15 ]; then
-  printf '{"systemMessage":"Caliber: agent configs are %s commits behind. Run caliber refresh to sync."}' "$COMMITS_BEHIND"
+  printf '{"systemMessage":"Caliber: agent configs are %s commits behind. Run ${bin} refresh to sync."}' "$COMMITS_BEHIND"
 fi
 `;
+}
 
 // ── SessionStart hook (freshness check on session start) ────────────
 
 const sessionStartHook = createScriptHook({
   eventName: 'SessionStart',
   scriptPath: path.join('.claude', 'hooks', 'caliber-session-freshness.sh'),
-  scriptContent: FRESHNESS_SCRIPT,
+  scriptContent: getFreshnessScript,
   description: 'Caliber: check config freshness on session start',
 });
 
@@ -236,7 +241,7 @@ export const removeSessionStartHook = sessionStartHook.remove;
 const notificationHook = createScriptHook({
   eventName: 'Notification',
   scriptPath: path.join('.claude', 'hooks', 'caliber-freshness-notify.sh'),
-  scriptContent: FRESHNESS_SCRIPT,
+  scriptContent: getFreshnessScript,
   description: 'Caliber: warn when agent configs are stale',
 });
 

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -250,15 +250,34 @@ const PRECOMMIT_START = '# caliber:pre-commit:start';
 const PRECOMMIT_END = '# caliber:pre-commit:end';
 
 function getPrecommitBlock(): string {
-  const bin = resolveCaliber();
+  const cmd = resolveCaliber();
   const npx = isNpxResolution();
 
-  // npx is multi-word — cannot be quoted as a single token in shell.
-  // Use `command -v npx` as guard and leave unquoted so the shell word-splits correctly.
-  const guard = npx
-    ? 'command -v npx >/dev/null 2>&1'
-    : `[ -x "${bin}" ] || command -v "${bin}" >/dev/null 2>&1`;
-  const invoke = npx ? bin : `"${bin}"`;
+  let guard: string;
+  let invoke: string;
+
+  if (npx) {
+    // cmd is either 'npx --yes @rely-ai/caliber' (bare) or '/abs/path/npx --yes @rely-ai/caliber'
+    const npxBin = cmd.split(' ')[0];
+    if (npxBin.startsWith('/')) {
+      // Absolute path — guard on the binary directly, no $PATH lookup needed
+      guard = `[ -x "${npxBin}" ]`;
+      const npxArgs = cmd.slice(npxBin.length); // ' --yes @rely-ai/caliber'
+      invoke = `"${npxBin}"${npxArgs}`;
+    } else {
+      // Bare 'npx' — fall back to PATH-based check; leave unquoted for word-splitting
+      guard = 'command -v npx >/dev/null 2>&1';
+      invoke = cmd;
+    }
+  } else {
+    // cmd is an absolute path (e.g. /opt/homebrew/bin/caliber) or bare 'caliber' as last resort
+    if (cmd.startsWith('/')) {
+      guard = `[ -x "${cmd}" ]`;
+    } else {
+      guard = `[ -x "${cmd}" ] || command -v "${cmd}" >/dev/null 2>&1`;
+    }
+    invoke = `"${cmd}"`;
+  }
 
   return `${PRECOMMIT_START}
 if ${guard}; then

--- a/src/lib/resolve-caliber.ts
+++ b/src/lib/resolve-caliber.ts
@@ -6,29 +6,64 @@ let _resolved: string | null = null;
 /**
  * Resolve the absolute path to the `caliber` binary.
  * Caches the result so the lookup happens at most once per process.
+ *
+ * Always returns an absolute path when possible so that hook commands
+ * embedded in .git/hooks/pre-commit or .claude/settings.json continue
+ * to work even when the hook executor runs with a stripped $PATH
+ * (e.g. Claude Code hooks use /usr/bin:/bin:/usr/sbin:/sbin on macOS).
  */
 export function resolveCaliber(): string {
   if (_resolved) return _resolved;
 
-  // 0. Detect npx context — temp paths become stale after the npx process exits,
-  //    so use `npx --yes @rely-ai/caliber` which always resolves correctly.
-  const isNpx =
-    process.argv[1]?.includes('_npx') ||
-    process.env.npm_execpath?.includes('npx');
+  const whichCmd = process.platform === 'win32' ? 'where caliber' : 'which caliber';
+  const whichNpxCmd = process.platform === 'win32' ? 'where npx' : 'which npx';
+
+  // 0. Detect npx context — temp paths become stale after the npx process exits.
+  //    Prefer a globally-installed caliber (stable absolute path). If not found,
+  //    resolve npx to an absolute path so the hook command survives restricted $PATH.
+  const isNpx = process.argv[1]?.includes('_npx') || process.env.npm_execpath?.includes('npx');
   if (isNpx) {
+    // Prefer a globally-installed caliber over the ephemeral npx invocation
+    try {
+      const out = execSync(whichCmd, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+      const caliberPath = out.split('\n')[0].trim();
+      if (caliberPath) {
+        _resolved = caliberPath;
+        return _resolved;
+      }
+    } catch {
+      // not globally installed — fall through to npx
+    }
+    // Resolve npx to an absolute path so hooks don't depend on $PATH at runtime
+    try {
+      const out = execSync(whichNpxCmd, {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+      }).trim();
+      const npxPath = out.split('\n')[0].trim();
+      if (npxPath) {
+        _resolved = `${npxPath} --yes @rely-ai/caliber`;
+        return _resolved;
+      }
+    } catch {
+      // npx not found on PATH — fall back to bare name
+    }
     _resolved = 'npx --yes @rely-ai/caliber';
     return _resolved;
   }
 
-  // 1. Try to find caliber on PATH — use bare command to stay portable
+  // 1. Find caliber on PATH — capture the absolute path so hook commands work
+  //    in restricted $PATH environments (git hooks, Claude Code hooks, CI).
   try {
-    const whichCmd = process.platform === 'win32' ? 'where caliber' : 'which caliber';
-    execSync(whichCmd, {
+    const out = execSync(whichCmd, {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
-    });
-    _resolved = 'caliber';
-    return _resolved;
+    }).trim();
+    const caliberPath = out.split('\n')[0].trim();
+    if (caliberPath) {
+      _resolved = caliberPath;
+      return _resolved;
+    }
   } catch {
     // not on PATH — fall through
   }
@@ -47,9 +82,10 @@ export function resolveCaliber(): string {
   return _resolved;
 }
 
-/** True when the resolved binary is a multi-word npx invocation. */
+/** True when the resolved binary is a multi-word npx invocation (bare or absolute path). */
 export function isNpxResolution(): boolean {
-  return resolveCaliber().startsWith('npx ');
+  const r = resolveCaliber();
+  return r === 'npx --yes @rely-ai/caliber' || r.endsWith('/npx --yes @rely-ai/caliber');
 }
 
 /** Reset cached resolution — only for tests. */
@@ -69,8 +105,11 @@ export function isCaliberCommand(command: string, subcommandTail: string): boole
   if (command === `caliber ${subcommandTail}`) return true;
   // Absolute-path match: ends with /caliber <tail>
   if (command.endsWith(`/caliber ${subcommandTail}`)) return true;
-  // npx match: `npx --yes @rely-ai/caliber <tail>` or `npx @rely-ai/caliber <tail>`
+  // Bare npx match
   if (command === `npx --yes @rely-ai/caliber ${subcommandTail}`) return true;
   if (command === `npx @rely-ai/caliber ${subcommandTail}`) return true;
+  // Absolute-path npx match: '/abs/path/npx --yes @rely-ai/caliber <tail>'
+  if (command.endsWith(`/npx --yes @rely-ai/caliber ${subcommandTail}`)) return true;
+  if (command.endsWith(`/npx @rely-ai/caliber ${subcommandTail}`)) return true;
   return false;
 }

--- a/src/llm/__tests__/claude-cli.test.ts
+++ b/src/llm/__tests__/claude-cli.test.ts
@@ -223,6 +223,68 @@ describe('ClaudeCliProvider', () => {
     }
   });
 
+  it('call() surfaces auth error from stdout when stderr is empty', async () => {
+    let closeCb: (code: number) => void;
+    spawn.mockReturnValue({
+      stdin: { end: vi.fn() },
+      stdout: {
+        on: vi.fn((ev: string, fn: (c: Buffer) => void) => {
+          if (ev === 'data')
+            setTimeout(() => fn(Buffer.from('Not logged in · Please run /login')), 0);
+        }),
+      },
+      stderr: { on: vi.fn() },
+      on: vi.fn((ev: string, fn: (code: number) => void) => {
+        if (ev === 'close') closeCb = fn;
+      }),
+      kill: vi.fn(),
+    });
+
+    const provider = new ClaudeCliProvider({ provider: 'claude-cli', model: 'default' });
+    const resultPromise = provider.call({ system: 'S', prompt: 'P' });
+
+    await new Promise((r) => setTimeout(r, 10));
+    closeCb!(1);
+
+    await expect(resultPromise).rejects.toThrow(/Not logged in/);
+    // Should use friendly message, not raw stdout
+    await expect(resultPromise).rejects.not.toThrow('Please run /login');
+  });
+
+  it('stream() surfaces auth error from stdout when stderr is empty', async () => {
+    let closeCb: (code: number) => void;
+    spawn.mockReturnValue({
+      stdin: { end: vi.fn() },
+      stdout: {
+        on: vi.fn((ev: string, fn: (c: Buffer) => void) => {
+          if (ev === 'data')
+            setTimeout(() => fn(Buffer.from('Not logged in · Please run /login')), 0);
+        }),
+      },
+      stderr: { on: vi.fn() },
+      on: vi.fn((ev: string, fn: (code: number) => void) => {
+        if (ev === 'close') closeCb = fn;
+      }),
+      kill: vi.fn(),
+    });
+
+    const provider = new ClaudeCliProvider({ provider: 'claude-cli', model: 'default' });
+    const onError = vi.fn();
+    const streamPromise = provider.stream(
+      { system: 'S', prompt: 'P' },
+      { onText: vi.fn(), onEnd: vi.fn(), onError },
+    );
+
+    await new Promise((r) => setTimeout(r, 10));
+    closeCb!(1);
+    await streamPromise.catch(() => {});
+
+    expect(onError).toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringMatching(/Not logged in/) }),
+    );
+    expect(onError.mock.calls[0][0].message).not.toContain('Please run /login');
+  });
+
   it('uses CALIBER_CLAUDE_CLI_TIMEOUT_MS when set', () => {
     const orig = process.env.CALIBER_CLAUDE_CLI_TIMEOUT_MS;
     process.env.CALIBER_CLAUDE_CLI_TIMEOUT_MS = '120000';

--- a/src/llm/__tests__/claude-cli.test.ts
+++ b/src/llm/__tests__/claude-cli.test.ts
@@ -1,19 +1,35 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { ClaudeCliProvider, isClaudeCliAvailable, isClaudeCliLoggedIn, resetClaudeCliLoginCache } from '../claude-cli.js';
+import {
+  ClaudeCliProvider,
+  isClaudeCliAvailable,
+  isClaudeCliLoggedIn,
+  resetClaudeCliLoginCache,
+  resetClaudeCliBin,
+} from '../claude-cli.js';
 import type { LLMConfig } from '../types.js';
 
 const IS_WINDOWS = process.platform === 'win32';
 const spawn = vi.fn();
 const execSync = vi.fn();
+const existsSync = vi.fn(() => false);
 
 vi.mock('node:child_process', () => ({
   spawn: (...args: unknown[]) => spawn(...args),
   execSync: (...args: unknown[]) => execSync(...args),
 }));
 
+vi.mock('node:fs', async () => {
+  const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
+  return {
+    ...actual,
+    default: { ...actual, existsSync: (...args: unknown[]) => existsSync(...args) },
+  };
+});
+
 describe('ClaudeCliProvider', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetClaudeCliBin();
   });
 
   it('call() spawns claude -p and pipes combined prompt via stdin', async () => {
@@ -49,12 +65,14 @@ describe('ClaudeCliProvider', () => {
     expect(result).toBe('Hello from Claude.');
     if (IS_WINDOWS) {
       expect(spawn.mock.calls[0][0]).toBe('claude -p');
-      expect(spawn.mock.calls[0][1]).toEqual(expect.objectContaining({ cwd: process.cwd(), shell: true }));
+      expect(spawn.mock.calls[0][1]).toEqual(
+        expect.objectContaining({ cwd: process.cwd(), shell: true }),
+      );
     } else {
       expect(spawn).toHaveBeenCalledWith(
         'claude',
         expect.arrayContaining(['-p']),
-        expect.objectContaining({ cwd: process.cwd() })
+        expect.objectContaining({ cwd: process.cwd() }),
       );
       const args = spawn.mock.calls[0][1];
       expect(args).not.toContain(expect.stringContaining('[[System]]'));
@@ -85,7 +103,7 @@ describe('ClaudeCliProvider', () => {
 
     const streamPromise = provider.stream(
       { system: 'S', prompt: 'P' },
-      { onText, onEnd, onError: vi.fn() }
+      { onText, onEnd, onError: vi.fn() },
     );
 
     await new Promise((r) => setTimeout(r, 10));
@@ -187,7 +205,7 @@ describe('ClaudeCliProvider', () => {
     const provider = new ClaudeCliProvider({ provider: 'claude-cli', model: 'default' });
     const streamPromise = provider.stream(
       { system: 'S', prompt: 'P', model: 'claude-haiku-4-5' },
-      { onText: vi.fn(), onEnd: vi.fn(), onError: vi.fn() }
+      { onText: vi.fn(), onEnd: vi.fn(), onError: vi.fn() },
     );
 
     await new Promise((r) => setTimeout(r, 10));
@@ -217,15 +235,18 @@ describe('ClaudeCliProvider', () => {
 describe('isClaudeCliAvailable', () => {
   beforeEach(() => {
     execSync.mockReset();
+    existsSync.mockReturnValue(false);
+    resetClaudeCliBin();
   });
 
   it('returns true when claude is on PATH', () => {
     execSync.mockReturnValue(undefined);
     expect(isClaudeCliAvailable()).toBe(true);
-    expect(execSync).toHaveBeenCalled();
-    const cmd = execSync.mock.calls[0][0];
-    expect(cmd).toContain('claude');
-    expect(execSync.mock.calls[0][1]).toEqual({ stdio: 'ignore' });
+    // resolveClaudeBin() makes one call (which claude), then isClaudeCliAvailable()
+    // makes a second call (which claude --stdio:ignore) as the PATH check
+    const lastCall = execSync.mock.calls[execSync.mock.calls.length - 1];
+    expect(lastCall[0]).toContain('claude');
+    expect(lastCall[1]).toEqual({ stdio: 'ignore' });
   });
 
   it('returns false when claude is not found', () => {
@@ -253,7 +274,9 @@ describe('isClaudeCliLoggedIn', () => {
   });
 
   it('returns false when auth status command fails', () => {
-    execSync.mockImplementation(() => { throw new Error('exit code 1'); });
+    execSync.mockImplementation(() => {
+      throw new Error('exit code 1');
+    });
     expect(isClaudeCliLoggedIn()).toBe(false);
   });
 

--- a/src/llm/__tests__/claude-cli.test.ts
+++ b/src/llm/__tests__/claude-cli.test.ts
@@ -11,6 +11,7 @@ import type { LLMConfig } from '../types.js';
 const IS_WINDOWS = process.platform === 'win32';
 const spawn = vi.fn();
 const execSync = vi.fn();
+const execFileSync = vi.fn();
 // accessSync mock: default throws (not executable) — tests override as needed
 const accessSync = vi.fn<(path: import('fs').PathLike | number, mode?: number) => void>(() => {
   throw new Error('not found');
@@ -19,6 +20,7 @@ const accessSync = vi.fn<(path: import('fs').PathLike | number, mode?: number) =
 vi.mock('node:child_process', () => ({
   spawn: (...args: unknown[]) => spawn(...args),
   execSync: (...args: unknown[]) => execSync(...args),
+  execFileSync: (...args: unknown[]) => execFileSync(...args),
 }));
 
 vi.mock('node:fs', async () => {
@@ -329,42 +331,42 @@ describe('isClaudeCliAvailable', () => {
 
 describe('isClaudeCliLoggedIn', () => {
   beforeEach(() => {
-    execSync.mockReset();
+    execFileSync.mockReset();
     resetClaudeCliLoginCache();
   });
 
   it('returns true when auth status reports loggedIn true', () => {
-    execSync.mockReturnValue(Buffer.from(JSON.stringify({ loggedIn: true })));
+    execFileSync.mockReturnValue(Buffer.from(JSON.stringify({ loggedIn: true })));
     expect(isClaudeCliLoggedIn()).toBe(true);
   });
 
   it('returns false when auth status reports loggedIn false', () => {
-    execSync.mockReturnValue(Buffer.from(JSON.stringify({ loggedIn: false })));
+    execFileSync.mockReturnValue(Buffer.from(JSON.stringify({ loggedIn: false })));
     expect(isClaudeCliLoggedIn()).toBe(false);
   });
 
   it('returns false when auth status command fails', () => {
-    execSync.mockImplementation(() => {
+    execFileSync.mockImplementation(() => {
       throw new Error('exit code 1');
     });
     expect(isClaudeCliLoggedIn()).toBe(false);
   });
 
   it('returns true for non-JSON output without not logged in', () => {
-    execSync.mockReturnValue(Buffer.from('some unexpected output'));
+    execFileSync.mockReturnValue(Buffer.from('some unexpected output'));
     expect(isClaudeCliLoggedIn()).toBe(true);
   });
 
   it('returns false for non-JSON output containing not logged in', () => {
-    execSync.mockReturnValue(Buffer.from('not logged in'));
+    execFileSync.mockReturnValue(Buffer.from('not logged in'));
     expect(isClaudeCliLoggedIn()).toBe(false);
   });
 
   it('caches the result across calls', () => {
-    execSync.mockReturnValue(Buffer.from(JSON.stringify({ loggedIn: true })));
+    execFileSync.mockReturnValue(Buffer.from(JSON.stringify({ loggedIn: true })));
     expect(isClaudeCliLoggedIn()).toBe(true);
-    execSync.mockReset();
+    execFileSync.mockReset();
     expect(isClaudeCliLoggedIn()).toBe(true);
-    expect(execSync).not.toHaveBeenCalled();
+    expect(execFileSync).not.toHaveBeenCalled();
   });
 });

--- a/src/llm/__tests__/claude-cli.test.ts
+++ b/src/llm/__tests__/claude-cli.test.ts
@@ -11,7 +11,10 @@ import type { LLMConfig } from '../types.js';
 const IS_WINDOWS = process.platform === 'win32';
 const spawn = vi.fn();
 const execSync = vi.fn();
-const existsSync = vi.fn(() => false);
+// accessSync mock: default throws (not executable) — tests override as needed
+const accessSync = vi.fn<(path: import('fs').PathLike | number, mode?: number) => void>(() => {
+  throw new Error('not found');
+});
 
 vi.mock('node:child_process', () => ({
   spawn: (...args: unknown[]) => spawn(...args),
@@ -22,7 +25,10 @@ vi.mock('node:fs', async () => {
   const actual = await vi.importActual<typeof import('node:fs')>('node:fs');
   return {
     ...actual,
-    default: { ...actual, existsSync: (...args: unknown[]) => existsSync(...args) },
+    default: {
+      ...actual,
+      accessSync: (...args: Parameters<typeof actual.accessSync>) => accessSync(...args),
+    },
   };
 });
 
@@ -297,7 +303,9 @@ describe('ClaudeCliProvider', () => {
 describe('isClaudeCliAvailable', () => {
   beforeEach(() => {
     execSync.mockReset();
-    existsSync.mockReturnValue(false);
+    accessSync.mockImplementation(() => {
+      throw new Error('not found');
+    });
     resetClaudeCliBin();
   });
 

--- a/src/llm/claude-cli.ts
+++ b/src/llm/claude-cli.ts
@@ -72,7 +72,11 @@ export function resetClaudeCliBin(): void {
 
 function spawnClaude(args: string[]): ChildProcess {
   const bin = resolveClaudeBin();
-  const env = { ...process.env, CLAUDE_CODE_SIMPLE: '1' };
+  // Do NOT forward CLAUDE_CODE_SIMPLE — newer Claude Code uses it to change the
+  // auth pathway, which causes "Not logged in" when set in child claude processes.
+  // The -p flag already handles headless/print mode; this var is redundant and harmful.
+  const { CLAUDE_CODE_SIMPLE: _stripped, ...parentEnv } = process.env;
+  const env = parentEnv;
   return IS_WINDOWS
     ? spawn([bin, ...args].join(' '), {
         cwd: process.cwd(),

--- a/src/llm/claude-cli.ts
+++ b/src/llm/claude-cli.ts
@@ -171,8 +171,9 @@ export class ClaudeCliProvider implements LLMProvider {
         callbacks.onEnd({ stopReason: 'end_turn' });
       } else {
         const stderr = Buffer.concat(stderrChunks).toString('utf-8').trim();
-        const friendly = parseSeatBasedError(stderr, code);
         const stdout = Buffer.concat(chunks).toString('utf-8').trim();
+        // claude CLI may write auth errors to stdout rather than stderr — check both
+        const friendly = parseSeatBasedError(stderr || stdout, code);
         const base = signal
           ? `Claude CLI killed (${signal})`
           : code != null
@@ -224,7 +225,8 @@ export class ClaudeCliProvider implements LLMProvider {
           resolve(stdout);
         } else {
           const stderr = Buffer.concat(stderrChunks).toString('utf-8').trim();
-          const friendly = parseSeatBasedError(stderr, code);
+          // claude CLI may write auth errors to stdout rather than stderr — check both
+          const friendly = parseSeatBasedError(stderr || stdout, code);
           const base = signal
             ? `Claude CLI killed (${signal})`
             : code != null

--- a/src/llm/claude-cli.ts
+++ b/src/llm/claude-cli.ts
@@ -10,9 +10,27 @@ import { parseSeatBasedError } from './seat-based-errors.js';
 import { trackUsage } from './usage.js';
 import { estimateTokens } from './utils.js';
 
-const CLAUDE_CLI_BIN = 'claude';
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
 const IS_WINDOWS = process.platform === 'win32';
+
+/**
+ * Resolve the `claude` binary to an absolute path so spawn and execSync calls
+ * work even when $PATH is stripped (e.g. Claude Code hook subprocesses on macOS
+ * only have /usr/bin:/bin:/usr/sbin:/sbin).  Resolved once and cached.
+ */
+function resolveClaudeBin(): string {
+  try {
+    const whichCmd = IS_WINDOWS ? 'where claude' : 'which claude';
+    const out = execSync(whichCmd, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+    const p = out.split('\n')[0].trim();
+    if (p) return p;
+  } catch {
+    // not on PATH — fall back to bare name
+  }
+  return 'claude';
+}
+
+const CLAUDE_CLI_BIN = resolveClaudeBin();
 
 function spawnClaude(args: string[]): ChildProcess {
   const env = { ...process.env, CLAUDE_CODE_SIMPLE: '1' };
@@ -190,12 +208,13 @@ export class ClaudeCliProvider implements LLMProvider {
   }
 }
 
-/** Whether the Claude Code CLI is on PATH (user has installed it and can run `claude -p`). */
+/** Whether the Claude Code CLI is available (resolved to absolute path or on PATH). */
 export function isClaudeCliAvailable(): boolean {
+  // resolveClaudeBin() returns an absolute path when `which claude` succeeded,
+  // or falls back to bare 'claude'. If we got an absolute path, the binary exists.
+  if (CLAUDE_CLI_BIN !== 'claude') return true;
   try {
-    const cmd =
-      process.platform === 'win32' ? `where ${CLAUDE_CLI_BIN}` : `which ${CLAUDE_CLI_BIN}`;
-    execSync(cmd, { stdio: 'ignore' });
+    execSync(IS_WINDOWS ? 'where claude' : 'which claude', { stdio: 'ignore' });
     return true;
   } catch {
     return false;

--- a/src/llm/claude-cli.ts
+++ b/src/llm/claude-cli.ts
@@ -55,9 +55,12 @@ function resolveClaudeBin(): string {
 
   // 2. Probe well-known install locations (PATH-independent — works in hook subprocesses)
   for (const candidate of candidateClaudePaths()) {
-    if (fs.existsSync(candidate)) {
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
       _claudeBin = candidate;
       return _claudeBin;
+    } catch {
+      // not executable or not found — try next candidate
     }
   }
 

--- a/src/llm/claude-cli.ts
+++ b/src/llm/claude-cli.ts
@@ -1,4 +1,5 @@
-import { spawn, execSync, type ChildProcess } from 'node:child_process';
+import fs from 'node:fs';
+import { spawn, execSync, execFileSync, type ChildProcess } from 'node:child_process';
 import type {
   LLMProvider,
   LLMCallOptions,
@@ -14,34 +15,72 @@ const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
 const IS_WINDOWS = process.platform === 'win32';
 
 /**
+ * Known installation paths for the Claude Code CLI binary, in probe order.
+ * Claude Code's installer places the binary at ~/.local/bin/claude on macOS/Linux,
+ * which is a user-space location that is NOT added to PATH by hooks or subprocesses
+ * that skip shell profile files (.zshrc, .bashrc).
+ */
+function candidateClaudePaths(): string[] {
+  if (IS_WINDOWS) return [];
+  const home = process.env.HOME ?? process.env.USERPROFILE ?? '';
+  return [
+    `${home}/.local/bin/claude`, // Claude Code default installer path
+    '/usr/local/bin/claude', // Homebrew / manual install
+    '/opt/homebrew/bin/claude', // Apple Silicon Homebrew
+  ].filter(Boolean);
+}
+
+let _claudeBin: string | null = null;
+
+/**
  * Resolve the `claude` binary to an absolute path so spawn and execSync calls
  * work even when $PATH is stripped (e.g. Claude Code hook subprocesses on macOS
- * only have /usr/bin:/bin:/usr/sbin:/sbin).  Resolved once and cached.
+ * only have /usr/bin:/bin:/usr/sbin:/sbin).  Result is cached after first call.
  */
 function resolveClaudeBin(): string {
+  if (_claudeBin !== null) return _claudeBin;
+
+  // 1. Try PATH first — covers cases where the user has a custom install location
   try {
     const whichCmd = IS_WINDOWS ? 'where claude' : 'which claude';
     const out = execSync(whichCmd, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
     const p = out.split('\n')[0].trim();
-    if (p) return p;
+    if (p) {
+      _claudeBin = p;
+      return _claudeBin;
+    }
   } catch {
-    // not on PATH — fall back to bare name
+    // not on PATH
   }
-  return 'claude';
+
+  // 2. Probe well-known install locations (PATH-independent — works in hook subprocesses)
+  for (const candidate of candidateClaudePaths()) {
+    if (fs.existsSync(candidate)) {
+      _claudeBin = candidate;
+      return _claudeBin;
+    }
+  }
+
+  _claudeBin = 'claude';
+  return _claudeBin;
 }
 
-const CLAUDE_CLI_BIN = resolveClaudeBin();
+/** Reset cached resolution — only for tests. */
+export function resetClaudeCliBin(): void {
+  _claudeBin = null;
+}
 
 function spawnClaude(args: string[]): ChildProcess {
+  const bin = resolveClaudeBin();
   const env = { ...process.env, CLAUDE_CODE_SIMPLE: '1' };
   return IS_WINDOWS
-    ? spawn([CLAUDE_CLI_BIN, ...args].join(' '), {
+    ? spawn([bin, ...args].join(' '), {
         cwd: process.cwd(),
         stdio: ['pipe', 'pipe', 'pipe'] as const,
         env,
         shell: true,
       })
-    : spawn(CLAUDE_CLI_BIN, args, {
+    : spawn(bin, args, {
         cwd: process.cwd(),
         stdio: ['pipe', 'pipe', 'pipe'],
         env,
@@ -212,7 +251,7 @@ export class ClaudeCliProvider implements LLMProvider {
 export function isClaudeCliAvailable(): boolean {
   // resolveClaudeBin() returns an absolute path when `which claude` succeeded,
   // or falls back to bare 'claude'. If we got an absolute path, the binary exists.
-  if (CLAUDE_CLI_BIN !== 'claude') return true;
+  if (resolveClaudeBin() !== 'claude') return true;
   try {
     execSync(IS_WINDOWS ? 'where claude' : 'which claude', { stdio: 'ignore' });
     return true;
@@ -232,7 +271,7 @@ export function resetClaudeCliLoginCache(): void {
 export function isClaudeCliLoggedIn(): boolean {
   if (cachedLoggedIn !== null) return cachedLoggedIn;
   try {
-    const result = execSync(`${CLAUDE_CLI_BIN} auth status`, {
+    const result = execFileSync(resolveClaudeBin(), ['auth', 'status'], {
       input: '',
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 5000,

--- a/src/llm/cursor-acp.ts
+++ b/src/llm/cursor-acp.ts
@@ -11,8 +11,25 @@ import { parseSeatBasedError, isRateLimitError } from './seat-based-errors.js';
 import { trackUsage } from './usage.js';
 import { estimateTokens } from './utils.js';
 
-const AGENT_BIN = 'agent';
 const IS_WINDOWS = process.platform === 'win32';
+
+/**
+ * Resolve the Cursor `agent` binary to an absolute path so it works even when
+ * $PATH is stripped (e.g. Claude Code hook subprocesses on macOS).
+ */
+function resolveAgentBin(): string {
+  try {
+    const whichCmd = IS_WINDOWS ? 'where agent' : 'which agent';
+    const out = execSync(whichCmd, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+    const p = out.split('\n')[0].trim();
+    if (p) return p;
+  } catch {
+    // not on PATH
+  }
+  return 'agent';
+}
+
+const AGENT_BIN = resolveAgentBin();
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
 const SIGKILL_DELAY_MS = 5000;
 const STDERR_MAX_BYTES = 10 * 1024;
@@ -363,9 +380,10 @@ export class CursorAcpProvider implements LLMProvider {
 
 /** Check if Cursor agent CLI is available. */
 export function isCursorAgentAvailable(): boolean {
+  // resolveAgentBin() returns an absolute path when `which agent` succeeded.
+  if (AGENT_BIN !== 'agent') return true;
   try {
-    const cmd = IS_WINDOWS ? `where ${AGENT_BIN}` : `which ${AGENT_BIN}`;
-    execSync(cmd, { stdio: 'ignore' });
+    execSync(IS_WINDOWS ? 'where agent' : 'which agent', { stdio: 'ignore' });
     return true;
   } catch {
     return false;

--- a/src/llm/cursor-acp.ts
+++ b/src/llm/cursor-acp.ts
@@ -1,4 +1,4 @@
-import { spawn, execSync, type ChildProcess } from 'node:child_process';
+import { spawn, execSync, execFileSync, type ChildProcess } from 'node:child_process';
 import os from 'node:os';
 import type {
   LLMProvider,
@@ -13,23 +13,34 @@ import { estimateTokens } from './utils.js';
 
 const IS_WINDOWS = process.platform === 'win32';
 
+let _agentBin: string | null = null;
+
 /**
  * Resolve the Cursor `agent` binary to an absolute path so it works even when
  * $PATH is stripped (e.g. Claude Code hook subprocesses on macOS).
+ * Result is cached after first call.
  */
 function resolveAgentBin(): string {
+  if (_agentBin !== null) return _agentBin;
   try {
     const whichCmd = IS_WINDOWS ? 'where agent' : 'which agent';
     const out = execSync(whichCmd, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
     const p = out.split('\n')[0].trim();
-    if (p) return p;
+    if (p) {
+      _agentBin = p;
+      return _agentBin;
+    }
   } catch {
     // not on PATH
   }
-  return 'agent';
+  _agentBin = 'agent';
+  return _agentBin;
 }
 
-const AGENT_BIN = resolveAgentBin();
+/** Reset cached resolution — only for tests. */
+export function resetAgentBin(): void {
+  _agentBin = null;
+}
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
 const SIGKILL_DELAY_MS = 5000;
 const STDERR_MAX_BYTES = 10 * 1024;
@@ -99,7 +110,7 @@ export class CursorAcpProvider implements LLMProvider {
     if (this.warmProcess && !this.warmProcess.killed && this.warmModel === targetModel) return;
 
     const args = this.buildArgs(targetModel, false);
-    this.warmProcess = spawn(AGENT_BIN, args, {
+    this.warmProcess = spawn(resolveAgentBin(), args, {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...process.env, ...(this.cursorApiKey && { CURSOR_API_KEY: this.cursorApiKey }) },
       ...(IS_WINDOWS && { shell: true }),
@@ -158,7 +169,7 @@ export class CursorAcpProvider implements LLMProvider {
     }
 
     const args = this.buildArgs(model, streaming);
-    const child = spawn(AGENT_BIN, args, {
+    const child = spawn(resolveAgentBin(), args, {
       stdio: ['pipe', 'pipe', 'pipe'],
       env: { ...process.env, ...(this.cursorApiKey && { CURSOR_API_KEY: this.cursorApiKey }) },
       ...(IS_WINDOWS && { shell: true }),
@@ -381,7 +392,7 @@ export class CursorAcpProvider implements LLMProvider {
 /** Check if Cursor agent CLI is available. */
 export function isCursorAgentAvailable(): boolean {
   // resolveAgentBin() returns an absolute path when `which agent` succeeded.
-  if (AGENT_BIN !== 'agent') return true;
+  if (resolveAgentBin() !== 'agent') return true;
   try {
     execSync(IS_WINDOWS ? 'where agent' : 'which agent', { stdio: 'ignore' });
     return true;
@@ -393,7 +404,7 @@ export function isCursorAgentAvailable(): boolean {
 /** Check if user is logged in to Cursor agent. */
 export function isCursorLoggedIn(): boolean {
   try {
-    const result = execSync(`${AGENT_BIN} status`, {
+    const result = execFileSync(resolveAgentBin(), ['status'], {
       input: '',
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 5000,

--- a/src/llm/cursor-acp.ts
+++ b/src/llm/cursor-acp.ts
@@ -41,6 +41,7 @@ function resolveAgentBin(): string {
 export function resetAgentBin(): void {
   _agentBin = null;
 }
+
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
 const SIGKILL_DELAY_MS = 5000;
 const STDERR_MAX_BYTES = 10 * 1024;

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -2,6 +2,8 @@ import chalk from 'chalk';
 import readline from 'readline';
 
 export function promptInput(question: string): Promise<string> {
+  // readline hangs indefinitely in non-TTY contexts (git hooks, CI, subprocess pipes)
+  if (!process.stdin.isTTY) return Promise.resolve('');
   const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
   return new Promise((resolve) => {
     rl.question(chalk.cyan(`${question} `), (answer) => {

--- a/src/utils/review.ts
+++ b/src/utils/review.ts
@@ -16,6 +16,7 @@ interface FileInfo {
 }
 
 export async function promptWantsReview(): Promise<boolean> {
+  if (!process.stdin.isTTY) return false;
   return select({
     message: 'Would you like to review the diffs before deciding?',
     choices: [
@@ -28,12 +29,16 @@ export async function promptWantsReview(): Promise<boolean> {
 export async function promptReviewMethod(): Promise<ReviewMethod> {
   const available = detectAvailableEditors();
   if (available.length === 1) return 'terminal';
+  if (!process.stdin.isTTY) return 'terminal';
 
-  const choices = available.map(method => {
+  const choices = available.map((method) => {
     switch (method) {
-      case 'cursor': return { name: 'Cursor (diff view)', value: 'cursor' as const };
-      case 'vscode': return { name: 'VS Code (diff view)', value: 'vscode' as const };
-      case 'terminal': return { name: 'Terminal', value: 'terminal' as const };
+      case 'cursor':
+        return { name: 'Cursor (diff view)', value: 'cursor' as const };
+      case 'vscode':
+        return { name: 'VS Code (diff view)', value: 'vscode' as const };
+      case 'terminal':
+        return { name: 'Terminal', value: 'terminal' as const };
     }
   });
 
@@ -42,15 +47,18 @@ export async function promptReviewMethod(): Promise<ReviewMethod> {
 
 export async function openReview(method: ReviewMethod, stagedFiles: StagedFile[]): Promise<void> {
   if (method === 'cursor' || method === 'vscode') {
-    openDiffsInEditor(method, stagedFiles.map(f => ({
-      originalPath: f.originalPath,
-      proposedPath: f.proposedPath,
-    })));
+    openDiffsInEditor(
+      method,
+      stagedFiles.map((f) => ({
+        originalPath: f.originalPath,
+        proposedPath: f.proposedPath,
+      })),
+    );
     console.log(chalk.dim('  Diffs opened in your editor.\n'));
     return;
   }
 
-  const fileInfos = stagedFiles.map(file => {
+  const fileInfos = stagedFiles.map((file) => {
     const proposed = fs.readFileSync(file.proposedPath, 'utf-8');
     const current = file.currentPath ? fs.readFileSync(file.currentPath, 'utf-8') : '';
     const patch = createTwoFilesPatch(
@@ -59,7 +67,8 @@ export async function openReview(method: ReviewMethod, stagedFiles: StagedFile[]
       current,
       proposed,
     );
-    let added = 0, removed = 0;
+    let added = 0,
+      removed = 0;
     for (const line of patch.split('\n')) {
       if (line.startsWith('+') && !line.startsWith('+++')) added++;
       if (line.startsWith('-') && !line.startsWith('---')) removed++;

--- a/src/writers/__tests__/pre-commit-block.test.ts
+++ b/src/writers/__tests__/pre-commit-block.test.ts
@@ -28,6 +28,9 @@ describe('pre-commit-block', () => {
   describe('appendPreCommitBlock', () => {
     it('uses npx command in doc block when in npx context', async () => {
       process.argv[1] = '/home/user/.npm/_npx/abc/node_modules/.bin/caliber';
+      mockedExecSync.mockImplementation(() => {
+        throw new Error('not found');
+      });
 
       const { appendPreCommitBlock } = await import('../pre-commit-block.js');
       const result = appendPreCommitBlock('# My Project');
@@ -50,6 +53,9 @@ describe('pre-commit-block', () => {
 
     it('does not duplicate the block', async () => {
       process.argv[1] = '/home/user/.npm/_npx/abc/node_modules/.bin/caliber';
+      mockedExecSync.mockImplementation(() => {
+        throw new Error('not found');
+      });
 
       const { appendPreCommitBlock } = await import('../pre-commit-block.js');
       const first = appendPreCommitBlock('# My Project');
@@ -134,6 +140,9 @@ describe('pre-commit-block', () => {
   describe('getCursorPreCommitRule', () => {
     it('uses npx command in Cursor rule when in npx context', async () => {
       process.argv[1] = '/home/user/.npm/_npx/abc/node_modules/.bin/caliber';
+      mockedExecSync.mockImplementation(() => {
+        throw new Error('not found');
+      });
 
       const { getCursorPreCommitRule } = await import('../pre-commit-block.js');
       const rule = getCursorPreCommitRule();


### PR DESCRIPTION
## Summary

- Replaces the sequential per-directory `for` loop in `refreshSingleRepo` with `Promise.allSettled` across all dirs that have changes
- Caps concurrency at 4 with `p-limit` to prevent rate-limit storms (concurrent retries amplify the problem on lower-tier plans)
- Uses a single top-level `ora` spinner in interactive mode — multiple concurrent spinners corrupt the terminal via racing ANSI sequences
- Suppresses per-dir spinners (`quiet: true`) and buffers output, printing results sequentially after all promises settle
- Pre-filters dirs with no changes before spawning parallel work (avoids unnecessary `Promise` overhead)
- `Promise.allSettled` ensures one failing dir doesn't block others; failed dirs are logged and state SHA is not advanced (retry on next run)

Combines and supersedes #131 and #132. Addresses all review feedback from both PRs: spinner corruption, missing concurrency cap, and the suggestion to buffer output.

Closes #131
Closes #132

## Test plan

- [ ] Run `caliber refresh` in a monorepo with multiple config directories — confirm single spinner, sequential output after completion
- [ ] Introduce an error in one dir's LLM call — confirm other dirs complete and the failed dir is reported without blocking
- [ ] Verify rate limit behavior on a lower-tier plan with many dirs (>4) — confirm at most 4 concurrent LLM calls
- [ ] Run all tests: `npm run test` (850 passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)