### PR TITLE
feat: add MiniMax provider support

### DIFF
--- a/src/ai/__tests__/generate.test.ts
+++ b/src/ai/__tests__/generate.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { buildGeneratePrompt, sampleFileTree } from '../generate.js';
 import type { Fingerprint } from '../../fingerprint/index.js';
 
@@ -13,7 +13,37 @@ function makeFingerprint(overrides: Partial<Fingerprint> = {}): Fingerprint {
   };
 }
 
+const API_KEY_VARS = [
+  'ANTHROPIC_API_KEY',
+  'OPENAI_API_KEY',
+  'MINIMAX_API_KEY',
+  'MINIMAX_BASE_URL',
+  'VERTEX_PROJECT_ID',
+  'GCP_PROJECT_ID',
+  'CALIBER_MODEL',
+  'CALIBER_USE_CURSOR_SEAT',
+  'CALIBER_USE_CLAUDE_CLI',
+];
+
 describe('buildGeneratePrompt', () => {
+  const savedEnv: Record<string, string | undefined> = {};
+
+  beforeEach(() => {
+    for (const key of API_KEY_VARS) {
+      savedEnv[key] = process.env[key];
+      delete process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const key of API_KEY_VARS) {
+      if (savedEnv[key] !== undefined) {
+        process.env[key] = savedEnv[key];
+      } else {
+        delete process.env[key];
+      }
+    }
+  });
   it('says "Generate initial" when no existing configs', () => {
     const prompt = buildGeneratePrompt(makeFingerprint(), ['claude']);
     expect(prompt).toContain('Generate an initial coding agent configuration');

--- a/src/commands/interactive-provider-setup.ts
+++ b/src/commands/interactive-provider-setup.ts
@@ -15,6 +15,7 @@ const PROVIDER_CHOICES: Array<{ name: string; value: ProviderType }> = [
   { name: 'Anthropic — API key from console.anthropic.com', value: 'anthropic' },
   { name: 'Google Vertex AI — Claude models via GCP', value: 'vertex' },
   { name: 'OpenAI — or any OpenAI-compatible endpoint', value: 'openai' },
+  { name: 'MiniMax — API key from platform.minimax.io', value: 'minimax' },
 ];
 
 /**
@@ -38,17 +39,30 @@ export async function runInteractiveProviderSetup(options?: {
       config.model = 'default';
       if (!isClaudeCliAvailable()) {
         console.log(chalk.yellow('\n  Claude Code CLI not found.'));
-        console.log(chalk.dim('  Install it: ') + chalk.hex('#83D1EB')('npm install -g @anthropic-ai/claude-code'));
-        console.log(chalk.dim('  Then run ') + chalk.hex('#83D1EB')('claude') + chalk.dim(' once to log in.\n'));
+        console.log(
+          chalk.dim('  Install it: ') +
+            chalk.hex('#83D1EB')('npm install -g @anthropic-ai/claude-code'),
+        );
+        console.log(
+          chalk.dim('  Then run ') +
+            chalk.hex('#83D1EB')('claude') +
+            chalk.dim(' once to log in.\n'),
+        );
         const proceed = await confirm({ message: 'Continue anyway?' });
         if (!proceed) throw new Error('__exit__');
       } else if (!isClaudeCliLoggedIn()) {
         console.log(chalk.yellow('\n  Claude Code CLI found but not logged in.'));
-        console.log(chalk.dim('  Run ') + chalk.hex('#83D1EB')('claude') + chalk.dim(' once to log in.\n'));
+        console.log(
+          chalk.dim('  Run ') + chalk.hex('#83D1EB')('claude') + chalk.dim(' once to log in.\n'),
+        );
         const proceed = await confirm({ message: 'Continue anyway?' });
         if (!proceed) throw new Error('__exit__');
       } else {
-        console.log(chalk.dim("  Run `claude` once and log in with your Pro/Max/Team account if you haven't."));
+        console.log(
+          chalk.dim(
+            "  Run `claude` once and log in with your Pro/Max/Team account if you haven't.",
+          ),
+        );
       }
       break;
     }
@@ -56,31 +70,56 @@ export async function runInteractiveProviderSetup(options?: {
       if (!isCursorAgentAvailable()) {
         console.log(chalk.yellow('\n  Cursor Agent CLI not found.'));
         if (IS_WINDOWS) {
-          console.log(chalk.dim('  Install it from: ') + chalk.hex('#83D1EB')('https://www.cursor.com/downloads'));
-          console.log(chalk.dim('  Then run ') + chalk.hex('#83D1EB')('agent login') + chalk.dim(' in PowerShell to authenticate.\n'));
+          console.log(
+            chalk.dim('  Install it from: ') +
+              chalk.hex('#83D1EB')('https://www.cursor.com/downloads'),
+          );
+          console.log(
+            chalk.dim('  Then run ') +
+              chalk.hex('#83D1EB')('agent login') +
+              chalk.dim(' in PowerShell to authenticate.\n'),
+          );
         } else {
-          console.log(chalk.dim('  Install it: ') + chalk.hex('#83D1EB')('curl https://cursor.com/install -fsS | bash'));
-          console.log(chalk.dim('  Then run ') + chalk.hex('#83D1EB')('agent login') + chalk.dim(' to authenticate.\n'));
+          console.log(
+            chalk.dim('  Install it: ') +
+              chalk.hex('#83D1EB')('curl https://cursor.com/install -fsS | bash'),
+          );
+          console.log(
+            chalk.dim('  Then run ') +
+              chalk.hex('#83D1EB')('agent login') +
+              chalk.dim(' to authenticate.\n'),
+          );
         }
         const proceed = await confirm({ message: 'Continue anyway?' });
         if (!proceed) throw new Error('__exit__');
       } else if (!isCursorLoggedIn()) {
         console.log(chalk.yellow('\n  Cursor Agent CLI found but not logged in.'));
-        console.log(chalk.dim('  Run ') + chalk.hex('#83D1EB')('agent login') + chalk.dim(' to authenticate.\n'));
+        console.log(
+          chalk.dim('  Run ') +
+            chalk.hex('#83D1EB')('agent login') +
+            chalk.dim(' to authenticate.\n'),
+        );
         const proceed = await confirm({ message: 'Continue anyway?' });
         if (!proceed) throw new Error('__exit__');
       }
-      config.model = await promptInput(`Model (default: ${DEFAULT_MODELS.cursor}):`) || DEFAULT_MODELS.cursor;
+      config.model =
+        (await promptInput(`Model (default: ${DEFAULT_MODELS.cursor}):`)) || DEFAULT_MODELS.cursor;
       break;
     }
     case 'anthropic': {
-      console.log(chalk.dim('  Get a key at https://console.anthropic.com (same account as Claude Pro/Team/Max).'));
+      console.log(
+        chalk.dim(
+          '  Get a key at https://console.anthropic.com (same account as Claude Pro/Team/Max).',
+        ),
+      );
       config.apiKey = await promptInput('Anthropic API key:');
       if (!config.apiKey) {
         console.log(chalk.red('API key is required.'));
         throw new Error('__exit__');
       }
-      config.model = await promptInput(`Model (default: ${DEFAULT_MODELS.anthropic}):`) || DEFAULT_MODELS.anthropic;
+      config.model =
+        (await promptInput(`Model (default: ${DEFAULT_MODELS.anthropic}):`)) ||
+        DEFAULT_MODELS.anthropic;
       break;
     }
     case 'vertex': {
@@ -89,9 +128,12 @@ export async function runInteractiveProviderSetup(options?: {
         console.log(chalk.red('Project ID is required.'));
         throw new Error('__exit__');
       }
-      config.vertexRegion = await promptInput('Region (default: us-east5):') || 'us-east5';
-      config.vertexCredentials = await promptInput('Service account credentials JSON (or leave empty for ADC):') || undefined;
-      config.model = await promptInput(`Model (default: ${DEFAULT_MODELS.vertex}):`) || DEFAULT_MODELS.vertex;
+      config.vertexRegion = (await promptInput('Region (default: us-east5):')) || 'us-east5';
+      config.vertexCredentials =
+        (await promptInput('Service account credentials JSON (or leave empty for ADC):')) ||
+        undefined;
+      config.model =
+        (await promptInput(`Model (default: ${DEFAULT_MODELS.vertex}):`)) || DEFAULT_MODELS.vertex;
       break;
     }
     case 'openai': {
@@ -100,8 +142,23 @@ export async function runInteractiveProviderSetup(options?: {
         console.log(chalk.red('API key is required.'));
         throw new Error('__exit__');
       }
-      config.baseUrl = await promptInput('Base URL (leave empty for OpenAI, or enter custom endpoint):') || undefined;
-      config.model = await promptInput(`Model (default: ${DEFAULT_MODELS.openai}):`) || DEFAULT_MODELS.openai;
+      config.baseUrl =
+        (await promptInput('Base URL (leave empty for OpenAI, or enter custom endpoint):')) ||
+        undefined;
+      config.model =
+        (await promptInput(`Model (default: ${DEFAULT_MODELS.openai}):`)) || DEFAULT_MODELS.openai;
+      break;
+    }
+    case 'minimax': {
+      console.log(chalk.dim('  Get a key at https://platform.minimax.io'));
+      config.apiKey = await promptInput('MiniMax API key:');
+      if (!config.apiKey) {
+        console.log(chalk.red('API key is required.'));
+        throw new Error('__exit__');
+      }
+      config.model =
+        (await promptInput(`Model (default: ${DEFAULT_MODELS.minimax}):`)) ||
+        DEFAULT_MODELS.minimax;
       break;
     }
   }

--- a/src/llm/__tests__/config.test.ts
+++ b/src/llm/__tests__/config.test.ts
@@ -27,6 +27,8 @@ describe('config', () => {
     process.env = { ...originalEnv };
     delete process.env.ANTHROPIC_API_KEY;
     delete process.env.OPENAI_API_KEY;
+    delete process.env.MINIMAX_API_KEY;
+    delete process.env.MINIMAX_BASE_URL;
     delete process.env.VERTEX_PROJECT_ID;
     delete process.env.GCP_PROJECT_ID;
     delete process.env.CALIBER_MODEL;

--- a/src/llm/__tests__/minimax.test.ts
+++ b/src/llm/__tests__/minimax.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { MockOpenAI } = vi.hoisted(() => {
+  const MockOpenAI = vi.fn().mockImplementation(function () {
+    return {
+      chat: {
+        completions: {
+          create: vi.fn(),
+        },
+      },
+      models: {
+        list: vi.fn(),
+      },
+    };
+  });
+  return { MockOpenAI };
+});
+
+vi.mock('openai', () => ({
+  default: MockOpenAI,
+}));
+
+vi.mock('../usage.js', () => ({
+  trackUsage: vi.fn(),
+}));
+
+import { MiniMaxProvider } from '../minimax.js';
+import { trackUsage } from '../usage.js';
+
+describe('MiniMaxProvider constructor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('creates client with default base URL', () => {
+    new MiniMaxProvider({ provider: 'minimax', model: 'MiniMax-M2.7', apiKey: 'test-key' });
+    expect(MockOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: 'test-key',
+        baseURL: 'https://api.minimax.io/v1',
+      }),
+    );
+  });
+
+  it('uses custom baseUrl when provided in config', () => {
+    new MiniMaxProvider({
+      provider: 'minimax',
+      model: 'MiniMax-M2.7',
+      apiKey: 'test-key',
+      baseUrl: 'https://custom.endpoint/v1',
+    });
+    expect(MockOpenAI).toHaveBeenCalledWith(
+      expect.objectContaining({ baseURL: 'https://custom.endpoint/v1' }),
+    );
+  });
+
+  it('falls back to MINIMAX_API_KEY env var when apiKey not in config', () => {
+    const originalEnv = process.env.MINIMAX_API_KEY;
+    process.env.MINIMAX_API_KEY = 'env-api-key';
+    try {
+      new MiniMaxProvider({ provider: 'minimax', model: 'MiniMax-M2.7' });
+      expect(MockOpenAI).toHaveBeenCalledWith(expect.objectContaining({ apiKey: 'env-api-key' }));
+    } finally {
+      process.env.MINIMAX_API_KEY = originalEnv;
+    }
+  });
+
+  it('falls back to MINIMAX_BASE_URL env var when baseUrl not in config', () => {
+    const originalEnv = process.env.MINIMAX_BASE_URL;
+    process.env.MINIMAX_BASE_URL = 'https://api.minimax.custom/v1';
+    try {
+      new MiniMaxProvider({ provider: 'minimax', model: 'MiniMax-M2.7', apiKey: 'test-key' });
+      expect(MockOpenAI).toHaveBeenCalledWith(
+        expect.objectContaining({ baseURL: 'https://api.minimax.custom/v1' }),
+      );
+    } finally {
+      process.env.MINIMAX_BASE_URL = originalEnv;
+    }
+  });
+});
+
+describe('MiniMaxProvider.listModels', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns only MiniMax-M2.7 and MiniMax-M2.7-highspeed', async () => {
+    const provider = new MiniMaxProvider({
+      provider: 'minimax',
+      model: 'MiniMax-M2.7',
+      apiKey: 'test-key',
+    });
+    const models = await provider.listModels();
+    expect(models).toEqual(['MiniMax-M2.7', 'MiniMax-M2.7-highspeed']);
+  });
+});
+
+describe('MiniMaxProvider.call', () => {
+  let provider: MiniMaxProvider;
+  let mockCreate: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new MiniMaxProvider({
+      provider: 'minimax',
+      model: 'MiniMax-M2.7',
+      apiKey: 'test-key',
+    });
+    const instance = MockOpenAI.mock.results[0].value;
+    mockCreate = instance.chat.completions.create;
+  });
+
+  it('sends request with temperature 1.0', async () => {
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content: 'Hello' } }],
+      usage: { prompt_tokens: 10, completion_tokens: 5 },
+    });
+
+    await provider.call({ system: 'You are helpful', prompt: 'Hi', model: 'MiniMax-M2.7' });
+
+    expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ temperature: 1.0 }));
+  });
+
+  it('returns response text', async () => {
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content: 'Test response' } }],
+      usage: { prompt_tokens: 10, completion_tokens: 5 },
+    });
+
+    const result = await provider.call({ system: 'sys', prompt: 'prompt' });
+    expect(result).toBe('Test response');
+  });
+
+  it('uses default model when model not specified in options', async () => {
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content: 'ok' } }],
+      usage: null,
+    });
+
+    await provider.call({ system: 'sys', prompt: 'prompt' });
+
+    expect(mockCreate).toHaveBeenCalledWith(expect.objectContaining({ model: 'MiniMax-M2.7' }));
+  });
+
+  it('tracks usage when usage is present', async () => {
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content: 'ok' } }],
+      usage: { prompt_tokens: 20, completion_tokens: 10 },
+    });
+
+    await provider.call({ system: 'sys', prompt: 'prompt', model: 'MiniMax-M2.7' });
+
+    expect(trackUsage).toHaveBeenCalledWith('MiniMax-M2.7', {
+      inputTokens: 20,
+      outputTokens: 10,
+    });
+  });
+
+  it('returns empty string when no content in response', async () => {
+    mockCreate.mockResolvedValue({
+      choices: [{ message: { content: null } }],
+      usage: null,
+    });
+
+    const result = await provider.call({ system: 'sys', prompt: 'prompt' });
+    expect(result).toBe('');
+  });
+});
+
+describe('MiniMaxProvider.stream', () => {
+  let provider: MiniMaxProvider;
+  let mockCreate: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    provider = new MiniMaxProvider({
+      provider: 'minimax',
+      model: 'MiniMax-M2.7',
+      apiKey: 'test-key',
+    });
+    const instance = MockOpenAI.mock.results[0].value;
+    mockCreate = instance.chat.completions.create;
+  });
+
+  it('streams text chunks to onText callback', async () => {
+    async function* fakeStream() {
+      yield { choices: [{ delta: { content: 'Hello' }, finish_reason: null }], usage: null };
+      yield { choices: [{ delta: { content: ' World' }, finish_reason: 'stop' }], usage: null };
+    }
+    mockCreate.mockResolvedValue(fakeStream());
+
+    const onText = vi.fn();
+    const onEnd = vi.fn();
+    const onError = vi.fn();
+
+    await provider.stream({ system: 'sys', prompt: 'prompt' }, { onText, onEnd, onError });
+
+    expect(onText).toHaveBeenCalledWith('Hello');
+    expect(onText).toHaveBeenCalledWith(' World');
+    expect(onEnd).toHaveBeenCalledWith({ stopReason: 'stop', usage: undefined });
+    expect(onError).not.toHaveBeenCalled();
+  });
+
+  it('sends request with temperature 1.0 in stream mode', async () => {
+    async function* fakeStream() {}
+    mockCreate.mockResolvedValue(fakeStream());
+
+    const onText = vi.fn();
+    const onEnd = vi.fn();
+    const onError = vi.fn();
+
+    await provider.stream({ system: 'sys', prompt: 'prompt' }, { onText, onEnd, onError });
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      expect.objectContaining({ temperature: 1.0, stream: true }),
+    );
+  });
+
+  it('calls onError when stream throws', async () => {
+    mockCreate.mockResolvedValue({
+      [Symbol.asyncIterator]: async function* () {
+        yield { choices: [{ delta: { content: 'partial' }, finish_reason: null }], usage: null };
+        throw new Error('network error');
+      },
+    });
+
+    const onText = vi.fn();
+    const onEnd = vi.fn();
+    const onError = vi.fn();
+
+    await provider.stream({ system: 'sys', prompt: 'prompt' }, { onText, onEnd, onError });
+
+    expect(onError).toHaveBeenCalledWith(expect.objectContaining({ message: 'network error' }));
+  });
+});

--- a/src/llm/config.ts
+++ b/src/llm/config.ts
@@ -10,6 +10,7 @@ export const DEFAULT_MODELS: Record<ProviderType, string> = {
   anthropic: 'claude-sonnet-4-6',
   vertex: 'claude-sonnet-4-6',
   openai: 'gpt-5.4-mini',
+  minimax: 'MiniMax-M2.7',
   cursor: 'sonnet-4.6',
   'claude-cli': 'default',
 };
@@ -23,6 +24,8 @@ export const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   'gpt-4o': 128_000,
   'gpt-4o-mini': 128_000,
   'sonnet-4.6': 200_000,
+  'MiniMax-M2.7': 1_000_000,
+  'MiniMax-M2.7-highspeed': 1_000_000,
 };
 
 const DEFAULT_CONTEXT_WINDOW = 200_000;
@@ -85,6 +88,15 @@ export function resolveFromEnv(): LLMConfig | null {
     };
   }
 
+  if (process.env.MINIMAX_API_KEY) {
+    return {
+      provider: 'minimax',
+      apiKey: process.env.MINIMAX_API_KEY,
+      model: process.env.CALIBER_MODEL || DEFAULT_MODELS.minimax,
+      baseUrl: process.env.MINIMAX_BASE_URL,
+    };
+  }
+
   // Prefer Cursor seat when explicitly requested (no API key; uses agent acp + agent login)
   if (
     process.env.CALIBER_USE_CURSOR_SEAT === '1' ||
@@ -114,7 +126,9 @@ export function readConfigFile(): LLMConfig | null {
     const parsed = JSON.parse(raw) as Record<string, unknown>;
     if (
       !parsed.provider ||
-      !['anthropic', 'vertex', 'openai', 'cursor', 'claude-cli'].includes(parsed.provider as string)
+      !['anthropic', 'vertex', 'openai', 'minimax', 'cursor', 'claude-cli'].includes(
+        parsed.provider as string,
+      )
     ) {
       return null;
     }

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -3,6 +3,7 @@ import { loadConfig } from './config.js';
 import { AnthropicProvider } from './anthropic.js';
 import { VertexProvider } from './vertex.js';
 import { OpenAICompatProvider } from './openai-compat.js';
+import { MiniMaxProvider } from './minimax.js';
 import { CursorAcpProvider, isCursorAgentAvailable, isCursorLoggedIn } from './cursor-acp.js';
 import { ClaudeCliProvider, isClaudeCliAvailable, isClaudeCliLoggedIn } from './claude-cli.js';
 import { parseJsonResponse, extractJson, estimateTokens } from './utils.js';
@@ -30,15 +31,17 @@ function createProvider(config: LLMConfig): LLMProvider {
       return new VertexProvider(config);
     case 'openai':
       return new OpenAICompatProvider(config);
+    case 'minimax':
+      return new MiniMaxProvider(config);
     case 'cursor': {
       if (!isCursorAgentAvailable()) {
         throw new Error(
-          'Cursor provider requires the Cursor Agent CLI. Install it from https://cursor.com/install then run `agent login`. Alternatively set ANTHROPIC_API_KEY or another provider.'
+          'Cursor provider requires the Cursor Agent CLI. Install it from https://cursor.com/install then run `agent login`. Alternatively set ANTHROPIC_API_KEY or another provider.',
         );
       }
       if (!isCursorLoggedIn()) {
         throw new Error(
-          'Cursor Agent CLI is installed but not logged in. Run `agent login` in your terminal to authenticate, then retry.'
+          'Cursor Agent CLI is installed but not logged in. Run `agent login` in your terminal to authenticate, then retry.',
         );
       }
       return new CursorAcpProvider(config);
@@ -46,12 +49,12 @@ function createProvider(config: LLMConfig): LLMProvider {
     case 'claude-cli': {
       if (!isClaudeCliAvailable()) {
         throw new Error(
-          'Claude Code provider requires the Claude Code CLI. Install it from https://claude.ai/install (or run `claude` once and log in). Alternatively set ANTHROPIC_API_KEY or choose another provider.'
+          'Claude Code provider requires the Claude Code CLI. Install it from https://claude.ai/install (or run `claude` once and log in). Alternatively set ANTHROPIC_API_KEY or choose another provider.',
         );
       }
       if (!isClaudeCliLoggedIn()) {
         throw new Error(
-          'Claude Code CLI is installed but not logged in. Run `claude` in your terminal to log in, then retry.'
+          'Claude Code CLI is installed but not logged in. Run `claude` in your terminal to log in, then retry.',
         );
       }
       return new ClaudeCliProvider(config);
@@ -67,7 +70,7 @@ export function getProvider(): LLMProvider {
   const config = loadConfig();
   if (!config) {
     throw new Error(
-      `No LLM provider configured. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or VERTEX_PROJECT_ID; or run \`${resolveCaliber()} config\` and choose Cursor or Claude Code; or set CALIBER_USE_CURSOR_SEAT=1 / CALIBER_USE_CLAUDE_CLI=1.`
+      `No LLM provider configured. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or VERTEX_PROJECT_ID; or run \`${resolveCaliber()} config\` and choose Cursor or Claude Code; or set CALIBER_USE_CURSOR_SEAT=1 / CALIBER_USE_CLAUDE_CLI=1.`,
     );
   }
 
@@ -82,7 +85,7 @@ export function getConfig(): LLMConfig {
   const config = loadConfig();
   if (!config) {
     throw new Error(
-      `No LLM provider configured. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or VERTEX_PROJECT_ID; or run \`${resolveCaliber()} config\` and choose Cursor or Claude Code; or set CALIBER_USE_CURSOR_SEAT=1 / CALIBER_USE_CLAUDE_CLI=1.`
+      `No LLM provider configured. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or VERTEX_PROJECT_ID; or run \`${resolveCaliber()} config\` and choose Cursor or Claude Code; or set CALIBER_USE_CURSOR_SEAT=1 / CALIBER_USE_CLAUDE_CLI=1.`,
     );
   }
 
@@ -95,12 +98,18 @@ export function resetProvider(): void {
   cachedConfig = null;
 }
 
-export const TRANSIENT_ERRORS = ['terminated', 'ECONNRESET', 'ETIMEDOUT', 'socket hang up', 'other side closed'];
+export const TRANSIENT_ERRORS = [
+  'terminated',
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'socket hang up',
+  'other side closed',
+];
 const MAX_RETRIES = 3;
 
 function isTransientError(error: Error): boolean {
   const msg = error.message.toLowerCase();
-  return TRANSIENT_ERRORS.some(e => msg.includes(e.toLowerCase()));
+  return TRANSIENT_ERRORS.some((e) => msg.includes(e.toLowerCase()));
 }
 
 function isOverloaded(err: unknown): boolean {
@@ -130,17 +139,17 @@ export async function llmCall(options: LLMCallOptions): Promise<string> {
       }
 
       if (isOverloaded(error) && attempt < MAX_RETRIES) {
-        await new Promise(r => setTimeout(r, 1000 * Math.pow(2, attempt - 1)));
+        await new Promise((r) => setTimeout(r, 1000 * Math.pow(2, attempt - 1)));
         continue;
       }
 
       if (isRateLimitError(error.message) && attempt < MAX_RETRIES) {
-        await new Promise(r => setTimeout(r, 2000 * Math.pow(2, attempt - 1)));
+        await new Promise((r) => setTimeout(r, 2000 * Math.pow(2, attempt - 1)));
         continue;
       }
 
       if (isTransientError(error) && attempt < MAX_RETRIES) {
-        await new Promise(r => setTimeout(r, 1000 * Math.pow(2, attempt - 1)));
+        await new Promise((r) => setTimeout(r, 1000 * Math.pow(2, attempt - 1)));
         continue;
       }
 

--- a/src/llm/minimax.ts
+++ b/src/llm/minimax.ts
@@ -1,0 +1,97 @@
+import OpenAI from 'openai';
+import type {
+  LLMProvider,
+  LLMCallOptions,
+  LLMStreamOptions,
+  LLMStreamCallbacks,
+  LLMConfig,
+  TokenUsage,
+} from './types.js';
+import { trackUsage } from './usage.js';
+
+const MINIMAX_DEFAULT_BASE_URL = 'https://api.minimax.io/v1';
+
+export class MiniMaxProvider implements LLMProvider {
+  private client: OpenAI;
+  private defaultModel: string;
+
+  constructor(config: LLMConfig) {
+    this.client = new OpenAI({
+      apiKey: config.apiKey ?? process.env.MINIMAX_API_KEY,
+      baseURL: config.baseUrl ?? process.env.MINIMAX_BASE_URL ?? MINIMAX_DEFAULT_BASE_URL,
+    });
+    this.defaultModel = config.model;
+  }
+
+  async call(options: LLMCallOptions): Promise<string> {
+    const response = await this.client.chat.completions.create({
+      model: options.model || this.defaultModel,
+      max_tokens: options.maxTokens || 4096,
+      temperature: 1.0,
+      messages: [
+        { role: 'system', content: options.system },
+        { role: 'user', content: options.prompt },
+      ],
+    });
+
+    const model = options.model || this.defaultModel;
+    if (response.usage) {
+      trackUsage(model, {
+        inputTokens: response.usage.prompt_tokens ?? 0,
+        outputTokens: response.usage.completion_tokens ?? 0,
+      });
+    }
+
+    return response.choices[0]?.message?.content || '';
+  }
+
+  async listModels(): Promise<string[]> {
+    return ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed'];
+  }
+
+  async stream(options: LLMStreamOptions, callbacks: LLMStreamCallbacks): Promise<void> {
+    const messages: OpenAI.ChatCompletionMessageParam[] = [
+      { role: 'system', content: options.system },
+    ];
+
+    if (options.messages) {
+      for (const msg of options.messages) {
+        messages.push({ role: msg.role, content: msg.content });
+      }
+    }
+
+    messages.push({ role: 'user', content: options.prompt });
+
+    const stream = await this.client.chat.completions.create({
+      model: options.model || this.defaultModel,
+      max_tokens: options.maxTokens || 10240,
+      temperature: 1.0,
+      messages,
+      stream: true,
+    });
+
+    try {
+      let stopReason: string | undefined;
+      let usage: TokenUsage | undefined;
+      const model = options.model || this.defaultModel;
+      for await (const chunk of stream) {
+        const delta = chunk.choices[0]?.delta?.content;
+        if (delta != null) callbacks.onText(delta);
+        const finishReason = chunk.choices[0]?.finish_reason;
+        if (finishReason) stopReason = finishReason === 'length' ? 'max_tokens' : finishReason;
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const chunkUsage = (chunk as any).usage;
+        if (chunkUsage) {
+          usage = {
+            inputTokens: chunkUsage.prompt_tokens ?? 0,
+            outputTokens: chunkUsage.completion_tokens ?? 0,
+          };
+          trackUsage(model, usage);
+        }
+      }
+      callbacks.onEnd({ stopReason, usage });
+    } catch (error) {
+      callbacks.onError(error instanceof Error ? error : new Error(String(error)));
+    }
+  }
+}

--- a/src/llm/model-recovery.ts
+++ b/src/llm/model-recovery.ts
@@ -25,6 +25,7 @@ const KNOWN_MODELS: Record<ProviderType, string[]> = {
     'claude-opus-4-1-20250620',
   ],
   openai: ['gpt-5.4-mini', 'gpt-4o', 'gpt-4o-mini', 'o3-mini'],
+  minimax: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
   cursor: ['auto', 'composer-1.5'],
   'claude-cli': [],
 };

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -1,4 +1,4 @@
-export type ProviderType = 'anthropic' | 'vertex' | 'openai' | 'cursor' | 'claude-cli';
+export type ProviderType = 'anthropic' | 'vertex' | 'openai' | 'minimax' | 'cursor' | 'claude-cli';
 
 const SEAT_BASED_PROVIDERS: ReadonlySet<ProviderType> = new Set(['cursor', 'claude-cli']);
 


### PR DESCRIPTION
## Summary

This PR adds [MiniMax](https://www.minimax.io/) as a new LLM provider to Caliber, using the OpenAI-compatible API.

### Changes

- **`src/llm/minimax.ts`** — New `MiniMaxProvider` class implementing `LLMProvider` (call, stream, listModels). Uses OpenAI SDK with MiniMax's base URL. Forces `temperature: 1.0` (MiniMax constraint: range must be `(0.0, 1.0]`).
- **`src/llm/types.ts`** — Added `'minimax'` to `ProviderType` union
- **`src/llm/index.ts`** — Imported `MiniMaxProvider` and added `case 'minimax'` to `createProvider`
- **`src/llm/config.ts`** — Added default model (`MiniMax-M2.7`), context window sizes for MiniMax models, `MINIMAX_API_KEY` env auto-detection, and `'minimax'` to the valid provider list in `readConfigFile`
- **`src/llm/model-recovery.ts`** — Added `minimax: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed']` to `KNOWN_MODELS`
- **`src/commands/interactive-provider-setup.ts`** — Added MiniMax to the provider picker with API key + model prompts
- **`src/llm/__tests__/minimax.test.ts`** — 13 unit tests covering constructor, listModels, call, and stream

### Configuration

Set `MINIMAX_API_KEY` to auto-configure, or run `caliber config` and select MiniMax from the provider list.

- Default base URL: `https://api.minimax.io/v1`
- Custom base URL: set `MINIMAX_BASE_URL`
- Default model: `MiniMax-M2.7`
- Available models: `MiniMax-M2.7`, `MiniMax-M2.7-highspeed`

### API Reference

- Chat (OpenAI Compatible): https://platform.minimax.io/docs/api-reference/text-openai-api