### PR TITLE
fix: add settled guard to runClaudePrint() to prevent double-reject

### DIFF
--- a/src/llm/__tests__/claude-cli.test.ts
+++ b/src/llm/__tests__/claude-cli.test.ts
@@ -212,6 +212,35 @@ describe('ClaudeCliProvider', () => {
     expect(provider).toBeDefined();
     process.env.CALIBER_CLAUDE_CLI_TIMEOUT_MS = orig;
   });
+
+  it('call() does not double-reject when both error and close events fire', async () => {
+    let errorCb: (err: Error) => void;
+    let closeCb: (code: number | null) => void;
+
+    spawn.mockReturnValue({
+      stdin: { end: vi.fn() },
+      stdout: { on: vi.fn() },
+      stderr: { on: vi.fn() },
+      on: vi.fn((ev: string, fn: unknown) => {
+        if (ev === 'error') errorCb = fn as (err: Error) => void;
+        if (ev === 'close') closeCb = fn as (code: number | null) => void;
+      }),
+      kill: vi.fn(),
+    });
+
+    const provider = new ClaudeCliProvider({ provider: 'claude-cli', model: 'default' });
+    const rejectSpy = vi.fn();
+
+    const resultPromise = provider.call({ system: 'S', prompt: 'P' }).catch(rejectSpy);
+
+    await new Promise((r) => setTimeout(r, 10));
+    errorCb!(new Error('spawn ENOENT'));
+    closeCb!(1);
+    await resultPromise;
+
+    expect(rejectSpy).toHaveBeenCalledTimes(1);
+    expect(rejectSpy).toHaveBeenCalledWith(new Error('spawn ENOENT'));
+  });
 });
 
 describe('isClaudeCliAvailable', () => {

--- a/src/llm/claude-cli.ts
+++ b/src/llm/claude-cli.ts
@@ -127,18 +127,37 @@ export class ClaudeCliProvider implements LLMProvider {
       const child = spawnClaude(args);
       child.stdin!.end(combinedPrompt);
 
+      let settled = false;
       const chunks: Buffer[] = [];
       const stderrChunks: Buffer[] = [];
 
       child.stdout!.on('data', (chunk: Buffer) => chunks.push(chunk));
       child.stderr!.on('data', (chunk: Buffer) => stderrChunks.push(chunk));
 
+      const timer = setTimeout(() => {
+        child.kill('SIGTERM');
+        if (!settled) {
+          settled = true;
+          reject(
+            new Error(
+              `Claude CLI timed out after ${this.timeoutMs / 1000}s. Set CALIBER_CLAUDE_CLI_TIMEOUT_MS to increase.`
+            )
+          );
+        }
+      }, this.timeoutMs);
+
       child.on('error', (err) => {
         clearTimeout(timer);
-        reject(err);
+        if (!settled) {
+          settled = true;
+          reject(err);
+        }
       });
+
       child.on('close', (code, signal) => {
         clearTimeout(timer);
+        if (settled) return;
+        settled = true;
         const stdout = Buffer.concat(chunks).toString('utf-8').trim();
         if (code === 0) {
           resolve(stdout);
@@ -154,15 +173,6 @@ export class ClaudeCliProvider implements LLMProvider {
           reject(new Error(detail ? `${base}. ${detail}` : base));
         }
       });
-
-      const timer = setTimeout(() => {
-        child.kill('SIGTERM');
-        reject(
-          new Error(
-            `Claude CLI timed out after ${this.timeoutMs / 1000}s. Set CALIBER_CLAUDE_CLI_TIMEOUT_MS to increase.`
-          )
-        );
-      }, this.timeoutMs);
     });
   }
 }


### PR DESCRIPTION
## Problem

`runClaudePrint()` in `src/llm/claude-cli.ts` had two structural issues:

1. **No `settled` flag** — In Node.js, when a spawned process emits `error`, the `close` event always fires afterward. With no guard, both event handlers could call `reject()` independently. The second call is silently ignored by the Promise runtime, but both handlers still execute fully, which is fragile.

2. **`const timer` declared after event handler registrations** — The `clearTimeout(timer)` call in the `error` handler referenced `timer` before its `const` declaration. Node.js async semantics mean this never causes a TDZ crash in practice, but it is fragile and misleading — especially for anyone reading the code linearly.

Fixes #140.

## Changes

- Added `settled` boolean flag to `runClaudePrint()` — mirrors the existing pattern already used in `stream()`
- Moved `const timer = setTimeout(...)` before event handler registrations
- Added `settled` guard to the timeout handler itself

## Test

Added a test case that simulates Node.js behaviour where `error` fires then `close` fires, verifying the `catch` spy is called exactly once.