### PR TITLE
fix: strip CLAUDECODE env vars from claude subprocess to prevent auth failure

### DIFF
--- a/src/llm/__tests__/claude-cli.test.ts
+++ b/src/llm/__tests__/claude-cli.test.ts
@@ -212,6 +212,48 @@ describe('ClaudeCliProvider', () => {
     expect(provider).toBeDefined();
     process.env.CALIBER_CLAUDE_CLI_TIMEOUT_MS = orig;
   });
+
+  it('strips CLAUDECODE and CLAUDE_CODE_ENTRYPOINT from subprocess env', async () => {
+    // Root cause: when caliber runs inside Claude Code, these vars are set in process.env.
+    // Passing them to the claude subprocess triggers its anti-recursion check, causing
+    // exit code 1 with "Not logged in" even when the user IS authenticated.
+    const origClaudeCode = process.env.CLAUDECODE;
+    const origEntrypoint = process.env.CLAUDE_CODE_ENTRYPOINT;
+    process.env.CLAUDECODE = '1';
+    process.env.CLAUDE_CODE_ENTRYPOINT = 'cli';
+
+    let closeCb: (code: number) => void;
+    spawn.mockReturnValue({
+      stdin: { end: vi.fn() },
+      stdout: { on: vi.fn((ev: string, fn: (c: Buffer) => void) => {
+        if (ev === 'data') setTimeout(() => fn(Buffer.from('ok')), 0);
+      }) },
+      stderr: { on: vi.fn() },
+      on: vi.fn((ev: string, fn: (code: number) => void) => {
+        if (ev === 'close') closeCb = fn;
+      }),
+      kill: vi.fn(),
+    });
+
+    const provider = new ClaudeCliProvider({ provider: 'claude-cli', model: 'default' });
+    const resultPromise = provider.call({ system: 'S', prompt: 'P' });
+    await new Promise((r) => setTimeout(r, 10));
+    closeCb!(0);
+    await resultPromise;
+
+    // The env passed to spawn must NOT contain the Claude Code session markers
+    const spawnedEnv = IS_WINDOWS
+      ? spawn.mock.calls[0][1].env
+      : spawn.mock.calls[0][2].env;
+    expect(spawnedEnv).not.toHaveProperty('CLAUDECODE');
+    expect(spawnedEnv).not.toHaveProperty('CLAUDE_CODE_ENTRYPOINT');
+
+    // Restore
+    if (origClaudeCode === undefined) delete process.env.CLAUDECODE;
+    else process.env.CLAUDECODE = origClaudeCode;
+    if (origEntrypoint === undefined) delete process.env.CLAUDE_CODE_ENTRYPOINT;
+    else process.env.CLAUDE_CODE_ENTRYPOINT = origEntrypoint;
+  });
 });
 
 describe('isClaudeCliAvailable', () => {

--- a/src/llm/claude-cli.ts
+++ b/src/llm/claude-cli.ts
@@ -7,17 +7,25 @@ const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
 const IS_WINDOWS = process.platform === 'win32';
 
 function spawnClaude(args: string[]): ChildProcess {
+  // Strip Claude Code's session markers before spawning. When caliber runs inside
+  // a Claude Code session, CLAUDECODE=1 and CLAUDE_CODE_ENTRYPOINT are set.
+  // The claude subprocess inherits these and its anti-recursion check fires,
+  // causing it to exit with code 1 ("Not logged in") even though the user is
+  // authenticated. Removing them lets the subprocess authenticate normally.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { CLAUDECODE, CLAUDE_CODE_ENTRYPOINT, ...safeEnv } = process.env;
+
   return IS_WINDOWS
     ? spawn([CLAUDE_CLI_BIN, ...args].join(' '), {
         cwd: process.cwd(),
         stdio: ['pipe', 'pipe', 'pipe'] as const,
-        env: process.env,
+        env: safeEnv,
         shell: true,
       })
     : spawn(CLAUDE_CLI_BIN, args, {
         cwd: process.cwd(),
         stdio: ['pipe', 'pipe', 'pipe'],
-        env: process.env,
+        env: safeEnv,
       });
 }
 


### PR DESCRIPTION
## Root Cause

When `caliber` runs inside a Claude Code session (terminal, IDE integration, hooks), Claude Code injects two environment variables:

```
CLAUDECODE=1
CLAUDE_CODE_ENTRYPOINT=cli
```

`spawnClaude()` in `src/llm/claude-cli.ts` passes `env: process.env` directly to the spawned subprocess. The `claude` child process inherits `CLAUDECODE=1`, its **anti-recursion check** fires, and it exits with code 1 — reported as `Not logged in · Please run /login` even though the user is fully authenticated.

This is confirmed by running `claude -p test` directly from the same terminal immediately after — it works, because the shell runs it with the same environment but the anti-recursion check behaves differently for direct TTY invocations vs piped subprocesses.

Fixes #138. Also resolves the Windows variant of the same bug (same env vars are set on all platforms).

## Fix

Strip `CLAUDECODE` and `CLAUDE_CODE_ENTRYPOINT` from the subprocess environment before spawning:

```typescript
const { CLAUDECODE, CLAUDE_CODE_ENTRYPOINT, ...safeEnv } = process.env;
// use safeEnv instead of process.env
```

This lets the `claude` subprocess authenticate normally without triggering the recursion guard.

## Test

Added a regression test that:
1. Sets `CLAUDECODE=1` and `CLAUDE_CODE_ENTRYPOINT=cli` in `process.env` (simulating a Claude Code session)
2. Calls `provider.call()` which triggers `spawnClaude()`
3. Asserts the spawned process env does **not** contain either var