### PR TITLE
feat: add MiniMax provider support

### DIFF
--- a/src/commands/interactive-provider-setup.ts
+++ b/src/commands/interactive-provider-setup.ts
@@ -15,6 +15,7 @@ const PROVIDER_CHOICES: Array<{ name: string; value: ProviderType }> = [
   { name: 'Anthropic — API key from console.anthropic.com', value: 'anthropic' },
   { name: 'Google Vertex AI — Claude models via GCP', value: 'vertex' },
   { name: 'OpenAI — or any OpenAI-compatible endpoint', value: 'openai' },
+  { name: 'MiniMax — API key from platform.minimax.io', value: 'minimax' },
 ];
 
 /**
@@ -38,17 +39,30 @@ export async function runInteractiveProviderSetup(options?: {
       config.model = 'default';
       if (!isClaudeCliAvailable()) {
         console.log(chalk.yellow('\n  Claude Code CLI not found.'));
-        console.log(chalk.dim('  Install it: ') + chalk.hex('#83D1EB')('npm install -g @anthropic-ai/claude-code'));
-        console.log(chalk.dim('  Then run ') + chalk.hex('#83D1EB')('claude') + chalk.dim(' once to log in.\n'));
+        console.log(
+          chalk.dim('  Install it: ') +
+            chalk.hex('#83D1EB')('npm install -g @anthropic-ai/claude-code'),
+        );
+        console.log(
+          chalk.dim('  Then run ') +
+            chalk.hex('#83D1EB')('claude') +
+            chalk.dim(' once to log in.\n'),
+        );
         const proceed = await confirm({ message: 'Continue anyway?' });
         if (!proceed) throw new Error('__exit__');
       } else if (!isClaudeCliLoggedIn()) {
         console.log(chalk.yellow('\n  Claude Code CLI found but not logged in.'));
-        console.log(chalk.dim('  Run ') + chalk.hex('#83D1EB')('claude') + chalk.dim(' once to log in.\n'));
+        console.log(
+          chalk.dim('  Run ') + chalk.hex('#83D1EB')('claude') + chalk.dim(' once to log in.\n'),
+        );
         const proceed = await confirm({ message: 'Continue anyway?' });
         if (!proceed) throw new Error('__exit__');
       } else {
-        console.log(chalk.dim("  Run `claude` once and log in with your Pro/Max/Team account if you haven't."));
+        console.log(
+          chalk.dim(
+            "  Run `claude` once and log in with your Pro/Max/Team account if you haven't.",
+          ),
+        );
       }
       break;
     }
@@ -56,31 +70,56 @@ export async function runInteractiveProviderSetup(options?: {
       if (!isCursorAgentAvailable()) {
         console.log(chalk.yellow('\n  Cursor Agent CLI not found.'));
         if (IS_WINDOWS) {
-          console.log(chalk.dim('  Install it from: ') + chalk.hex('#83D1EB')('https://www.cursor.com/downloads'));
-          console.log(chalk.dim('  Then run ') + chalk.hex('#83D1EB')('agent login') + chalk.dim(' in PowerShell to authenticate.\n'));
+          console.log(
+            chalk.dim('  Install it from: ') +
+              chalk.hex('#83D1EB')('https://www.cursor.com/downloads'),
+          );
+          console.log(
+            chalk.dim('  Then run ') +
+              chalk.hex('#83D1EB')('agent login') +
+              chalk.dim(' in PowerShell to authenticate.\n'),
+          );
         } else {
-          console.log(chalk.dim('  Install it: ') + chalk.hex('#83D1EB')('curl https://cursor.com/install -fsS | bash'));
-          console.log(chalk.dim('  Then run ') + chalk.hex('#83D1EB')('agent login') + chalk.dim(' to authenticate.\n'));
+          console.log(
+            chalk.dim('  Install it: ') +
+              chalk.hex('#83D1EB')('curl https://cursor.com/install -fsS | bash'),
+          );
+          console.log(
+            chalk.dim('  Then run ') +
+              chalk.hex('#83D1EB')('agent login') +
+              chalk.dim(' to authenticate.\n'),
+          );
         }
         const proceed = await confirm({ message: 'Continue anyway?' });
         if (!proceed) throw new Error('__exit__');
       } else if (!isCursorLoggedIn()) {
         console.log(chalk.yellow('\n  Cursor Agent CLI found but not logged in.'));
-        console.log(chalk.dim('  Run ') + chalk.hex('#83D1EB')('agent login') + chalk.dim(' to authenticate.\n'));
+        console.log(
+          chalk.dim('  Run ') +
+            chalk.hex('#83D1EB')('agent login') +
+            chalk.dim(' to authenticate.\n'),
+        );
         const proceed = await confirm({ message: 'Continue anyway?' });
         if (!proceed) throw new Error('__exit__');
       }
-      config.model = await promptInput(`Model (default: ${DEFAULT_MODELS.cursor}):`) || DEFAULT_MODELS.cursor;
+      config.model =
+        (await promptInput(`Model (default: ${DEFAULT_MODELS.cursor}):`)) || DEFAULT_MODELS.cursor;
       break;
     }
     case 'anthropic': {
-      console.log(chalk.dim('  Get a key at https://console.anthropic.com (same account as Claude Pro/Team/Max).'));
+      console.log(
+        chalk.dim(
+          '  Get a key at https://console.anthropic.com (same account as Claude Pro/Team/Max).',
+        ),
+      );
       config.apiKey = await promptInput('Anthropic API key:');
       if (!config.apiKey) {
         console.log(chalk.red('API key is required.'));
         throw new Error('__exit__');
       }
-      config.model = await promptInput(`Model (default: ${DEFAULT_MODELS.anthropic}):`) || DEFAULT_MODELS.anthropic;
+      config.model =
+        (await promptInput(`Model (default: ${DEFAULT_MODELS.anthropic}):`)) ||
+        DEFAULT_MODELS.anthropic;
       break;
     }
     case 'vertex': {
@@ -89,9 +128,12 @@ export async function runInteractiveProviderSetup(options?: {
         console.log(chalk.red('Project ID is required.'));
         throw new Error('__exit__');
       }
-      config.vertexRegion = await promptInput('Region (default: us-east5):') || 'us-east5';
-      config.vertexCredentials = await promptInput('Service account credentials JSON (or leave empty for ADC):') || undefined;
-      config.model = await promptInput(`Model (default: ${DEFAULT_MODELS.vertex}):`) || DEFAULT_MODELS.vertex;
+      config.vertexRegion = (await promptInput('Region (default: us-east5):')) || 'us-east5';
+      config.vertexCredentials =
+        (await promptInput('Service account credentials JSON (or leave empty for ADC):')) ||
+        undefined;
+      config.model =
+        (await promptInput(`Model (default: ${DEFAULT_MODELS.vertex}):`)) || DEFAULT_MODELS.vertex;
       break;
     }
     case 'openai': {
@@ -100,8 +142,23 @@ export async function runInteractiveProviderSetup(options?: {
         console.log(chalk.red('API key is required.'));
         throw new Error('__exit__');
       }
-      config.baseUrl = await promptInput('Base URL (leave empty for OpenAI, or enter custom endpoint):') || undefined;
-      config.model = await promptInput(`Model (default: ${DEFAULT_MODELS.openai}):`) || DEFAULT_MODELS.openai;
+      config.baseUrl =
+        (await promptInput('Base URL (leave empty for OpenAI, or enter custom endpoint):')) ||
+        undefined;
+      config.model =
+        (await promptInput(`Model (default: ${DEFAULT_MODELS.openai}):`)) || DEFAULT_MODELS.openai;
+      break;
+    }
+    case 'minimax': {
+      console.log(chalk.dim('  Get a key at https://platform.minimax.io'));
+      config.apiKey = await promptInput('MiniMax API key:');
+      if (!config.apiKey) {
+        console.log(chalk.red('API key is required.'));
+        throw new Error('__exit__');
+      }
+      config.model =
+        (await promptInput(`Model (default: ${DEFAULT_MODELS.minimax}):`)) ||
+        DEFAULT_MODELS.minimax;
       break;
     }
   }

--- a/src/llm/__tests__/minimax.test.ts
+++ b/src/llm/__tests__/minimax.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { MiniMaxProvider } from '../minimax.js';
+import type { LLMConfig } from '../types.js';
+
+const createMock = vi.fn();
+
+vi.mock('openai', () => {
+  return {
+    default: class MockOpenAI {
+      chat = { completions: { create: createMock } };
+      models = { list: vi.fn() };
+      constructor(public opts: Record<string, unknown>) {}
+    },
+  };
+});
+
+vi.mock('../usage.js', () => ({ trackUsage: vi.fn() }));
+
+import OpenAI from 'openai';
+
+const BASE_CONFIG: LLMConfig = { provider: 'minimax', model: 'MiniMax-M2.7', apiKey: 'test-key' };
+
+describe('MiniMaxProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('constructor passes apiKey and MiniMax base URL to OpenAI client', () => {
+    const provider = new MiniMaxProvider(BASE_CONFIG);
+    const instance = (provider as unknown as { client: InstanceType<typeof OpenAI> }).client;
+    const opts = (instance as unknown as { opts: Record<string, unknown> }).opts;
+    expect(opts.apiKey).toBe('test-key');
+    expect(opts.baseURL).toBe('https://api.minimax.io/v1');
+  });
+
+  it('constructor uses MINIMAX_API_KEY env var when config has no apiKey', () => {
+    const orig = process.env.MINIMAX_API_KEY;
+    process.env.MINIMAX_API_KEY = 'env-key';
+    const provider = new MiniMaxProvider({ provider: 'minimax', model: 'MiniMax-M2.7' });
+    const instance = (provider as unknown as { client: InstanceType<typeof OpenAI> }).client;
+    const opts = (instance as unknown as { opts: Record<string, unknown> }).opts;
+    expect(opts.apiKey).toBe('env-key');
+    if (orig !== undefined) process.env.MINIMAX_API_KEY = orig;
+    else delete process.env.MINIMAX_API_KEY;
+  });
+
+  it('constructor uses MINIMAX_BASE_URL env var when config has no baseUrl', () => {
+    const orig = process.env.MINIMAX_BASE_URL;
+    process.env.MINIMAX_BASE_URL = 'https://custom.minimax.io/v2';
+    const provider = new MiniMaxProvider(BASE_CONFIG);
+    const instance = (provider as unknown as { client: InstanceType<typeof OpenAI> }).client;
+    const opts = (instance as unknown as { opts: Record<string, unknown> }).opts;
+    expect(opts.baseURL).toBe('https://custom.minimax.io/v2');
+    if (orig !== undefined) process.env.MINIMAX_BASE_URL = orig;
+    else delete process.env.MINIMAX_BASE_URL;
+  });
+
+  it('call() sends temperature 1.0', async () => {
+    createMock.mockResolvedValue({
+      choices: [{ message: { content: 'hello' } }],
+      usage: { prompt_tokens: 10, completion_tokens: 5 },
+    });
+    const provider = new MiniMaxProvider(BASE_CONFIG);
+    await provider.call({ system: 'S', prompt: 'P' });
+    expect(createMock).toHaveBeenCalledWith(expect.objectContaining({ temperature: 1.0 }));
+  });
+
+  it('call() returns response content', async () => {
+    createMock.mockResolvedValue({
+      choices: [{ message: { content: 'world' } }],
+      usage: { prompt_tokens: 10, completion_tokens: 5 },
+    });
+    const provider = new MiniMaxProvider(BASE_CONFIG);
+    const result = await provider.call({ system: 'S', prompt: 'P' });
+    expect(result).toBe('world');
+  });
+
+  it('stream() sends temperature 1.0', async () => {
+    const asyncIter = {
+      async *[Symbol.asyncIterator]() {
+        yield { choices: [{ delta: { content: 'hi' }, finish_reason: null }] };
+        yield { choices: [{ delta: { content: null }, finish_reason: 'stop' }] };
+      },
+    };
+    createMock.mockResolvedValue(asyncIter);
+    const provider = new MiniMaxProvider(BASE_CONFIG);
+    const onText = vi.fn();
+    const onEnd = vi.fn();
+    await provider.stream({ system: 'S', prompt: 'P' }, { onText, onEnd, onError: vi.fn() });
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({ temperature: 1.0, stream: true }),
+    );
+    expect(onText).toHaveBeenCalledWith('hi');
+    expect(onEnd).toHaveBeenCalled();
+  });
+
+  it('listModels() returns hardcoded MiniMax models', async () => {
+    const provider = new MiniMaxProvider(BASE_CONFIG);
+    const models = await provider.listModels();
+    expect(models).toEqual(['MiniMax-M2.7', 'MiniMax-M2.7-highspeed']);
+  });
+});

--- a/src/llm/config.ts
+++ b/src/llm/config.ts
@@ -10,6 +10,7 @@ export const DEFAULT_MODELS: Record<ProviderType, string> = {
   anthropic: 'claude-sonnet-4-6',
   vertex: 'claude-sonnet-4-6',
   openai: 'gpt-5.4-mini',
+  minimax: 'MiniMax-M2.7',
   cursor: 'sonnet-4.6',
   'claude-cli': 'default',
 };
@@ -23,6 +24,8 @@ export const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   'gpt-4o': 128_000,
   'gpt-4o-mini': 128_000,
   'sonnet-4.6': 200_000,
+  'MiniMax-M2.7': 1_000_000,
+  'MiniMax-M2.7-highspeed': 1_000_000,
 };
 
 const DEFAULT_CONTEXT_WINDOW = 200_000;
@@ -44,6 +47,7 @@ export const DEFAULT_FAST_MODELS: Partial<Record<ProviderType, string>> = {
   anthropic: 'claude-haiku-4-5-20251001',
   vertex: 'claude-haiku-4-5-20251001',
   openai: 'gpt-5.4-mini',
+  minimax: 'MiniMax-M2.7-highspeed',
   cursor: 'gpt-5.3-codex-fast',
 };
 
@@ -85,6 +89,15 @@ export function resolveFromEnv(): LLMConfig | null {
     };
   }
 
+  if (process.env.MINIMAX_API_KEY) {
+    return {
+      provider: 'minimax',
+      apiKey: process.env.MINIMAX_API_KEY,
+      model: process.env.CALIBER_MODEL || DEFAULT_MODELS.minimax,
+      baseUrl: process.env.MINIMAX_BASE_URL,
+    };
+  }
+
   // Prefer Cursor seat when explicitly requested (no API key; uses agent acp + agent login)
   if (
     process.env.CALIBER_USE_CURSOR_SEAT === '1' ||
@@ -114,7 +127,9 @@ export function readConfigFile(): LLMConfig | null {
     const parsed = JSON.parse(raw) as Record<string, unknown>;
     if (
       !parsed.provider ||
-      !['anthropic', 'vertex', 'openai', 'cursor', 'claude-cli'].includes(parsed.provider as string)
+      !['anthropic', 'vertex', 'openai', 'minimax', 'cursor', 'claude-cli'].includes(
+        parsed.provider as string,
+      )
     ) {
       return null;
     }

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -3,6 +3,7 @@ import { loadConfig } from './config.js';
 import { AnthropicProvider } from './anthropic.js';
 import { VertexProvider } from './vertex.js';
 import { OpenAICompatProvider } from './openai-compat.js';
+import { MiniMaxProvider } from './minimax.js';
 import { CursorAcpProvider, isCursorAgentAvailable, isCursorLoggedIn } from './cursor-acp.js';
 import { ClaudeCliProvider, isClaudeCliAvailable, isClaudeCliLoggedIn } from './claude-cli.js';
 import { parseJsonResponse, extractJson, estimateTokens } from './utils.js';
@@ -30,15 +31,17 @@ function createProvider(config: LLMConfig): LLMProvider {
       return new VertexProvider(config);
     case 'openai':
       return new OpenAICompatProvider(config);
+    case 'minimax':
+      return new MiniMaxProvider(config);
     case 'cursor': {
       if (!isCursorAgentAvailable()) {
         throw new Error(
-          'Cursor provider requires the Cursor Agent CLI. Install it from https://cursor.com/install then run `agent login`. Alternatively set ANTHROPIC_API_KEY or another provider.'
+          'Cursor provider requires the Cursor Agent CLI. Install it from https://cursor.com/install then run `agent login`. Alternatively set ANTHROPIC_API_KEY or another provider.',
         );
       }
       if (!isCursorLoggedIn()) {
         throw new Error(
-          'Cursor Agent CLI is installed but not logged in. Run `agent login` in your terminal to authenticate, then retry.'
+          'Cursor Agent CLI is installed but not logged in. Run `agent login` in your terminal to authenticate, then retry.',
         );
       }
       return new CursorAcpProvider(config);
@@ -46,12 +49,12 @@ function createProvider(config: LLMConfig): LLMProvider {
     case 'claude-cli': {
       if (!isClaudeCliAvailable()) {
         throw new Error(
-          'Claude Code provider requires the Claude Code CLI. Install it from https://claude.ai/install (or run `claude` once and log in). Alternatively set ANTHROPIC_API_KEY or choose another provider.'
+          'Claude Code provider requires the Claude Code CLI. Install it from https://claude.ai/install (or run `claude` once and log in). Alternatively set ANTHROPIC_API_KEY or choose another provider.',
         );
       }
       if (!isClaudeCliLoggedIn()) {
         throw new Error(
-          'Claude Code CLI is installed but not logged in. Run `claude` in your terminal to log in, then retry.'
+          'Claude Code CLI is installed but not logged in. Run `claude` in your terminal to log in, then retry.',
         );
       }
       return new ClaudeCliProvider(config);
@@ -67,7 +70,7 @@ export function getProvider(): LLMProvider {
   const config = loadConfig();
   if (!config) {
     throw new Error(
-      `No LLM provider configured. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or VERTEX_PROJECT_ID; or run \`${resolveCaliber()} config\` and choose Cursor or Claude Code; or set CALIBER_USE_CURSOR_SEAT=1 / CALIBER_USE_CLAUDE_CLI=1.`
+      `No LLM provider configured. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, MINIMAX_API_KEY, or VERTEX_PROJECT_ID; or run \`${resolveCaliber()} config\` and choose Cursor or Claude Code; or set CALIBER_USE_CURSOR_SEAT=1 / CALIBER_USE_CLAUDE_CLI=1.`,
     );
   }
 
@@ -82,7 +85,7 @@ export function getConfig(): LLMConfig {
   const config = loadConfig();
   if (!config) {
     throw new Error(
-      `No LLM provider configured. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, or VERTEX_PROJECT_ID; or run \`${resolveCaliber()} config\` and choose Cursor or Claude Code; or set CALIBER_USE_CURSOR_SEAT=1 / CALIBER_USE_CLAUDE_CLI=1.`
+      `No LLM provider configured. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, MINIMAX_API_KEY, or VERTEX_PROJECT_ID; or run \`${resolveCaliber()} config\` and choose Cursor or Claude Code; or set CALIBER_USE_CURSOR_SEAT=1 / CALIBER_USE_CLAUDE_CLI=1.`,
     );
   }
 
@@ -95,12 +98,18 @@ export function resetProvider(): void {
   cachedConfig = null;
 }
 
-export const TRANSIENT_ERRORS = ['terminated', 'ECONNRESET', 'ETIMEDOUT', 'socket hang up', 'other side closed'];
+export const TRANSIENT_ERRORS = [
+  'terminated',
+  'ECONNRESET',
+  'ETIMEDOUT',
+  'socket hang up',
+  'other side closed',
+];
 const MAX_RETRIES = 3;
 
 function isTransientError(error: Error): boolean {
   const msg = error.message.toLowerCase();
-  return TRANSIENT_ERRORS.some(e => msg.includes(e.toLowerCase()));
+  return TRANSIENT_ERRORS.some((e) => msg.includes(e.toLowerCase()));
 }
 
 function isOverloaded(err: unknown): boolean {
@@ -130,17 +139,17 @@ export async function llmCall(options: LLMCallOptions): Promise<string> {
       }
 
       if (isOverloaded(error) && attempt < MAX_RETRIES) {
-        await new Promise(r => setTimeout(r, 1000 * Math.pow(2, attempt - 1)));
+        await new Promise((r) => setTimeout(r, 1000 * Math.pow(2, attempt - 1)));
         continue;
       }
 
       if (isRateLimitError(error.message) && attempt < MAX_RETRIES) {
-        await new Promise(r => setTimeout(r, 2000 * Math.pow(2, attempt - 1)));
+        await new Promise((r) => setTimeout(r, 2000 * Math.pow(2, attempt - 1)));
         continue;
       }
 
       if (isTransientError(error) && attempt < MAX_RETRIES) {
-        await new Promise(r => setTimeout(r, 1000 * Math.pow(2, attempt - 1)));
+        await new Promise((r) => setTimeout(r, 1000 * Math.pow(2, attempt - 1)));
         continue;
       }
 

--- a/src/llm/minimax.ts
+++ b/src/llm/minimax.ts
@@ -1,0 +1,23 @@
+import type { LLMConfig } from './types.js';
+import { OpenAICompatProvider } from './openai-compat.js';
+
+const MINIMAX_DEFAULT_BASE_URL = 'https://api.minimax.io/v1';
+
+export class MiniMaxProvider extends OpenAICompatProvider {
+  constructor(config: LLMConfig) {
+    super(
+      {
+        ...config,
+        apiKey: config.apiKey ?? process.env.MINIMAX_API_KEY,
+        baseUrl: config.baseUrl ?? process.env.MINIMAX_BASE_URL ?? MINIMAX_DEFAULT_BASE_URL,
+      },
+      // MiniMax requires temperature in (0.0, 1.0] — 1.0 is the only safe default.
+      { temperature: 1.0 },
+    );
+  }
+
+  // MiniMax API doesn't support model listing; return known models statically.
+  override async listModels(): Promise<string[]> {
+    return ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed'];
+  }
+}

--- a/src/llm/model-recovery.ts
+++ b/src/llm/model-recovery.ts
@@ -25,6 +25,7 @@ const KNOWN_MODELS: Record<ProviderType, string[]> = {
     'claude-opus-4-1-20250620',
   ],
   openai: ['gpt-5.4-mini', 'gpt-4o', 'gpt-4o-mini', 'o3-mini'],
+  minimax: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
   cursor: ['auto', 'composer-1.5'],
   'claude-cli': [],
 };

--- a/src/llm/openai-compat.ts
+++ b/src/llm/openai-compat.ts
@@ -1,23 +1,33 @@
 import OpenAI from 'openai';
-import type { LLMProvider, LLMCallOptions, LLMStreamOptions, LLMStreamCallbacks, LLMConfig, TokenUsage } from './types.js';
+import type {
+  LLMProvider,
+  LLMCallOptions,
+  LLMStreamOptions,
+  LLMStreamCallbacks,
+  LLMConfig,
+  TokenUsage,
+} from './types.js';
 import { trackUsage } from './usage.js';
 
 export class OpenAICompatProvider implements LLMProvider {
-  private client: OpenAI;
-  private defaultModel: string;
+  protected client: OpenAI;
+  protected defaultModel: string;
+  protected temperature: number | undefined;
 
-  constructor(config: LLMConfig) {
+  constructor(config: LLMConfig, options?: { temperature?: number }) {
     this.client = new OpenAI({
       apiKey: config.apiKey,
       ...(config.baseUrl && { baseURL: config.baseUrl }),
     });
     this.defaultModel = config.model;
+    this.temperature = options?.temperature;
   }
 
   async call(options: LLMCallOptions): Promise<string> {
     const response = await this.client.chat.completions.create({
       model: options.model || this.defaultModel,
       max_tokens: options.maxTokens || 4096,
+      ...(this.temperature !== undefined && { temperature: this.temperature }),
       messages: [
         { role: 'system', content: options.system },
         { role: 'user', content: options.prompt },
@@ -59,6 +69,7 @@ export class OpenAICompatProvider implements LLMProvider {
     const stream = await this.client.chat.completions.create({
       model: options.model || this.defaultModel,
       max_tokens: options.maxTokens || 10240,
+      ...(this.temperature !== undefined && { temperature: this.temperature }),
       messages,
       stream: true,
     });

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -1,4 +1,4 @@
-export type ProviderType = 'anthropic' | 'vertex' | 'openai' | 'cursor' | 'claude-cli';
+export type ProviderType = 'anthropic' | 'vertex' | 'openai' | 'minimax' | 'cursor' | 'claude-cli';
 
 const SEAT_BASED_PROVIDERS: ReadonlySet<ProviderType> = new Set(['cursor', 'claude-cli']);
 


### PR DESCRIPTION
## Summary

Adds MiniMax as an LLM provider, extending `OpenAICompatProvider` to avoid code duplication.

- `MiniMaxProvider` extends `OpenAICompatProvider` with temperature constraint (MiniMax requires `(0.0, 1.0]`) and hardcoded model listing (API doesn't support it)
- `OpenAICompatProvider` fields changed from `private` to `protected`, constructor accepts optional `temperature`
- Full integration: types, config (env vars, default/fast models, context windows), provider factory, interactive setup, model recovery
- 7 tests covering constructor, env var fallbacks, temperature enforcement, streaming, and model listing

Based on @octo-patch's work in #136, refactored per review feedback to eliminate code duplication.

Closes #136

## Changes

| File | What |
|---|---|
| `src/llm/minimax.ts` | New provider (25 lines vs 97 in original) |
| `src/llm/openai-compat.ts` | `private` → `protected`, optional `temperature` in constructor |
| `src/llm/types.ts` | Added `minimax` to `ProviderType` |
| `src/llm/config.ts` | Default model, fast model, context windows, env var detection |
| `src/llm/index.ts` | Provider factory case, error messages mention `MINIMAX_API_KEY` |
| `src/llm/model-recovery.ts` | Known models for minimax |
| `src/commands/interactive-provider-setup.ts` | MiniMax in provider picker |
| `src/llm/__tests__/minimax.test.ts` | 7 tests |

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run test` — 881/881 tests pass
- [x] MiniMax tests verify temperature, env vars, constructor, streaming, listModels