### PR TITLE
fix: resolve prompt hang on Windows Git Bash (#135)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@anthropic-ai/vertex-sdk": "^0.14.4",
         "@inquirer/checkbox": "^5.1.0",
         "@inquirer/confirm": "^6.0.8",
+        "@inquirer/input": "^5.0.11",
         "@inquirer/select": "^5.1.0",
         "chalk": "^5.4.0",
         "commander": "^13.0.0",
@@ -769,9 +770,9 @@
       }
     },
     "node_modules/@inquirer/ansi": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.3.tgz",
-      "integrity": "sha512-g44zhR3NIKVs0zUesa4iMzExmZpLUdTLRMCStqX3GE5NT6VkPcxQGJ+uC8tDgBUC/vB1rUhUd55cOf++4NZcmw==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/ansi/-/ansi-2.0.5.tgz",
+      "integrity": "sha512-doc2sWgJpbFQ64UflSVd17ibMGDuxO1yKgOgLMwavzESnXjFWJqUeG8saYosqKpHp4kWiM5x1nXvEjbpx90gzw==",
       "license": "MIT",
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
@@ -822,14 +823,14 @@
       }
     },
     "node_modules/@inquirer/core": {
-      "version": "11.1.5",
-      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.5.tgz",
-      "integrity": "sha512-QQPAX+lka8GyLcZ7u7Nb1h6q72iZ/oy0blilC3IB2nSt1Qqxp7akt94Jqhi/DzARuN3Eo9QwJRvtl4tmVe4T5A==",
+      "version": "11.1.8",
+      "resolved": "https://registry.npmjs.org/@inquirer/core/-/core-11.1.8.tgz",
+      "integrity": "sha512-/u+yJk2pOKNDOh1ZgdUH2RQaRx6OOH4I0uwL95qPvTFTIL38YBsuSC4r1yXBB3Q6JvNqFFc202gk0Ew79rrcjA==",
       "license": "MIT",
       "dependencies": {
-        "@inquirer/ansi": "^2.0.3",
-        "@inquirer/figures": "^2.0.3",
-        "@inquirer/type": "^4.0.3",
+        "@inquirer/ansi": "^2.0.5",
+        "@inquirer/figures": "^2.0.5",
+        "@inquirer/type": "^4.0.5",
         "cli-width": "^4.1.0",
         "fast-wrap-ansi": "^0.2.0",
         "mute-stream": "^3.0.0",
@@ -848,12 +849,33 @@
       }
     },
     "node_modules/@inquirer/figures": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.3.tgz",
-      "integrity": "sha512-y09iGt3JKoOCBQ3w4YrSJdokcD8ciSlMIWsD+auPu+OZpfxLuyz+gICAQ6GCBOmJJt4KEQGHuZSVff2jiNOy7g==",
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/figures/-/figures-2.0.5.tgz",
+      "integrity": "sha512-NsSs4kzfm12lNetHwAn3GEuH317IzpwrMCbOuMIVytpjnJ90YYHNwdRgYGuKmVxwuIqSgqk3M5qqQt1cDk0tGQ==",
       "license": "MIT",
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      }
+    },
+    "node_modules/@inquirer/input": {
+      "version": "5.0.11",
+      "resolved": "https://registry.npmjs.org/@inquirer/input/-/input-5.0.11.tgz",
+      "integrity": "sha512-twUWidn4ocPO8qi6fRM7tNWt7W1FOnOZqQ+/+PsfLUacMR5rFLDPK9ql0nBPwxi0oELbo8T5NhRs8B2+qQEqFQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/core": "^11.1.8",
+        "@inquirer/type": "^4.0.5"
+      },
+      "engines": {
+        "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"
+      },
+      "peerDependencies": {
+        "@types/node": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        }
       }
     },
     "node_modules/@inquirer/select": {
@@ -880,9 +902,9 @@
       }
     },
     "node_modules/@inquirer/type": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.3.tgz",
-      "integrity": "sha512-cKZN7qcXOpj1h+1eTTcGDVLaBIHNMT1Rz9JqJP5MnEJ0JhgVWllx7H/tahUp5YEK1qaByH2Itb8wLG/iScD5kw==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-4.0.5.tgz",
+      "integrity": "sha512-aetVUNeKNc/VriqXlw1NRSW0zhMBB0W4bNbWRJgzRl/3d0QNDQFfk0GO5SDdtjMZVg6o8ZKEiadd7SCCzoOn5Q==",
       "license": "MIT",
       "engines": {
         "node": ">=23.5.0 || ^22.13.0 || ^21.7.0 || ^20.12.0"

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@anthropic-ai/vertex-sdk": "^0.14.4",
     "@inquirer/checkbox": "^5.1.0",
     "@inquirer/confirm": "^6.0.8",
+    "@inquirer/input": "^5.0.11",
     "@inquirer/select": "^5.1.0",
     "chalk": "^5.4.0",
     "commander": "^13.0.0",

--- a/src/commands/__tests__/interactive-provider-setup.test.ts
+++ b/src/commands/__tests__/interactive-provider-setup.test.ts
@@ -1,14 +1,15 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 
-const { mockSelect, mockConfirm, mockWriteConfigFile, mockQuestion } = vi.hoisted(() => ({
+const { mockSelect, mockConfirm, mockWriteConfigFile, mockInput } = vi.hoisted(() => ({
   mockSelect: vi.fn(),
   mockConfirm: vi.fn().mockResolvedValue(true),
   mockWriteConfigFile: vi.fn(),
-  mockQuestion: vi.fn(),
+  mockInput: vi.fn(),
 }));
 
 vi.mock('@inquirer/select', () => ({ default: mockSelect }));
 vi.mock('@inquirer/confirm', () => ({ default: mockConfirm }));
+vi.mock('@inquirer/input', () => ({ default: mockInput }));
 vi.mock('../../llm/cursor-acp.js', () => ({ isCursorAgentAvailable: () => false }));
 vi.mock('../../llm/claude-cli.js', () => ({ isClaudeCliAvailable: () => false }));
 vi.mock('../../llm/config.js', () => ({
@@ -19,15 +20,6 @@ vi.mock('../../llm/config.js', () => ({
     openai: 'gpt-5.4-mini',
     cursor: 'default',
     'claude-cli': 'default',
-  },
-}));
-
-vi.mock('readline', () => ({
-  default: {
-    createInterface: () => ({
-      question: (_q: string, cb: (answer: string) => void) => mockQuestion(_q, cb),
-      close: vi.fn(),
-    }),
   },
 }));
 
@@ -60,7 +52,7 @@ describe('runInteractiveProviderSetup', () => {
 
   it('configures cursor provider with default model', async () => {
     mockSelect.mockResolvedValue('cursor');
-    mockQuestion.mockImplementationOnce((_q: string, cb: (answer: string) => void) => cb(''));
+    mockInput.mockResolvedValueOnce('');
 
     const config = await runInteractiveProviderSetup();
 
@@ -74,7 +66,7 @@ describe('runInteractiveProviderSetup', () => {
 
   it('configures cursor provider with custom model', async () => {
     mockSelect.mockResolvedValue('cursor');
-    mockQuestion.mockImplementationOnce((_q: string, cb: (answer: string) => void) => cb('auto'));
+    mockInput.mockResolvedValueOnce('auto');
 
     const config = await runInteractiveProviderSetup();
 
@@ -87,9 +79,7 @@ describe('runInteractiveProviderSetup', () => {
 
   it('configures anthropic provider with API key and model', async () => {
     mockSelect.mockResolvedValue('anthropic');
-    mockQuestion
-      .mockImplementationOnce((_q: string, cb: (answer: string) => void) => cb('sk-ant-test123'))
-      .mockImplementationOnce((_q: string, cb: (answer: string) => void) => cb(''));
+    mockInput.mockResolvedValueOnce('sk-ant-test123').mockResolvedValueOnce('');
 
     const config = await runInteractiveProviderSetup();
 
@@ -101,7 +91,7 @@ describe('runInteractiveProviderSetup', () => {
 
   it('throws __exit__ when anthropic API key is empty', async () => {
     mockSelect.mockResolvedValue('anthropic');
-    mockQuestion.mockImplementation((_q: string, cb: (answer: string) => void) => cb(''));
+    mockInput.mockResolvedValue('');
 
     await expect(runInteractiveProviderSetup()).rejects.toThrow('__exit__');
     expect(mockWriteConfigFile).not.toHaveBeenCalled();
@@ -109,12 +99,10 @@ describe('runInteractiveProviderSetup', () => {
 
   it('configures openai provider with API key and custom base URL', async () => {
     mockSelect.mockResolvedValue('openai');
-    mockQuestion
-      .mockImplementationOnce((_q: string, cb: (answer: string) => void) => cb('sk-openai-test'))
-      .mockImplementationOnce((_q: string, cb: (answer: string) => void) =>
-        cb('http://localhost:11434/v1'),
-      )
-      .mockImplementationOnce((_q: string, cb: (answer: string) => void) => cb(''));
+    mockInput
+      .mockResolvedValueOnce('sk-openai-test')
+      .mockResolvedValueOnce('http://localhost:11434/v1')
+      .mockResolvedValueOnce('');
 
     const config = await runInteractiveProviderSetup();
 
@@ -126,18 +114,18 @@ describe('runInteractiveProviderSetup', () => {
 
   it('throws __exit__ when openai API key is empty', async () => {
     mockSelect.mockResolvedValue('openai');
-    mockQuestion.mockImplementation((_q: string, cb: (answer: string) => void) => cb(''));
+    mockInput.mockResolvedValue('');
 
     await expect(runInteractiveProviderSetup()).rejects.toThrow('__exit__');
   });
 
   it('configures vertex provider with project ID and region', async () => {
     mockSelect.mockResolvedValue('vertex');
-    mockQuestion
-      .mockImplementationOnce((_q: string, cb: (answer: string) => void) => cb('my-gcp-project'))
-      .mockImplementationOnce((_q: string, cb: (answer: string) => void) => cb(''))
-      .mockImplementationOnce((_q: string, cb: (answer: string) => void) => cb(''))
-      .mockImplementationOnce((_q: string, cb: (answer: string) => void) => cb(''));
+    mockInput
+      .mockResolvedValueOnce('my-gcp-project')
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('');
 
     const config = await runInteractiveProviderSetup();
 
@@ -149,7 +137,7 @@ describe('runInteractiveProviderSetup', () => {
 
   it('throws __exit__ when vertex project ID is empty', async () => {
     mockSelect.mockResolvedValue('vertex');
-    mockQuestion.mockImplementation((_q: string, cb: (answer: string) => void) => cb(''));
+    mockInput.mockResolvedValue('');
 
     await expect(runInteractiveProviderSetup()).rejects.toThrow('__exit__');
   });
@@ -166,7 +154,7 @@ describe('runInteractiveProviderSetup', () => {
 
   it('uses default select message when none provided', async () => {
     mockSelect.mockResolvedValue('cursor');
-    mockQuestion.mockImplementationOnce((_q: string, cb: (answer: string) => void) => cb(''));
+    mockInput.mockResolvedValueOnce('');
 
     await runInteractiveProviderSetup();
 

--- a/src/utils/prompt.ts
+++ b/src/utils/prompt.ts
@@ -1,14 +1,11 @@
-import chalk from 'chalk';
-import readline from 'readline';
+import input from '@inquirer/input';
 
-export function promptInput(question: string): Promise<string> {
-  // readline hangs indefinitely in non-TTY contexts (git hooks, CI, subprocess pipes)
-  if (!process.stdin.isTTY) return Promise.resolve('');
-  const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
-  return new Promise((resolve) => {
-    rl.question(chalk.cyan(`${question} `), (answer) => {
-      rl.close();
-      resolve(answer.trim());
-    });
-  });
+export async function promptInput(question: string): Promise<string> {
+  if (!process.stdin.isTTY) return '';
+  try {
+    const answer = await input({ message: question });
+    return answer.trim();
+  } catch {
+    return '';
+  }
 }


### PR DESCRIPTION
## Summary

- Replace `readline.createInterface` in `src/utils/prompt.ts` with `@inquirer/input` to fix prompt hangs on Windows Git Bash
- The root cause was mixing `@inquirer/*` prompts (which set TTY raw mode) with `readline` prompts (which expect normal TTY mode), causing readline to hang indefinitely after inquirer left the TTY in raw mode
- All prompts now use the `@inquirer/*` family consistently, ensuring unified TTY state management

Closes #135

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] `npm run test` passes (1 pre-existing unrelated failure in `recommend.test.ts`)
- [ ] Verify `caliber init` no longer hangs at Y/n prompts on Windows Git Bash