### PR TITLE
fix: surface skill generation failures with details (#142)

### DIFF
--- a/src/ai/generate.ts
+++ b/src/ai/generate.ts
@@ -171,15 +171,16 @@ export async function generateSetup(
     ),
   );
 
-  const { succeeded, failed: failedCount } = mergeSkillResults(skillResults, setup);
+  const { succeeded, failed: failedCount, failedNames } = mergeSkillResults(skillResults, setup);
 
   if (failedCount > 0 && callbacks) {
-    // Skills are supplementary — core CLAUDE.md/AGENTS.md is still valid even when skills fail.
-    // Route through onStatus (not onError) so callers don't treat this as a hard failure.
     const msg = succeeded === 0
       ? `${failedCount} skill${failedCount === 1 ? '' : 's'} failed to generate — config saved without skills`
       : `Warning: ${failedCount} of ${failedCount + succeeded} skill${failedCount === 1 ? '' : 's'} failed to generate`;
     callbacks.onStatus(msg);
+    for (const name of failedNames) {
+      callbacks.onStatus(`  → ${name}`);
+    }
   }
 
   return coreResult;
@@ -188,9 +189,10 @@ export async function generateSetup(
 function mergeSkillResults(
   results: PromiseSettledResult<{ platform: string; skill: GeneratedSkill }>[],
   setup: Record<string, unknown>,
-): { succeeded: number; failed: number } {
+): { succeeded: number; failed: number; failedNames: string[] } {
   let succeeded = 0;
   let failed = 0;
+  const failedNames: string[] = [];
 
   for (const result of results) {
     if (result.status === 'fulfilled') {
@@ -213,10 +215,12 @@ function mergeSkillResults(
       succeeded++;
     } else {
       failed++;
+      const reason = result.reason instanceof Error ? result.reason.message : String(result.reason);
+      failedNames.push(reason);
     }
   }
 
-  return { succeeded, failed };
+  return { succeeded, failed, failedNames };
 }
 
 const MAX_SKILL_TOPICS = 5;
@@ -637,8 +641,17 @@ export async function generateSkillsForSetup(
     ),
   );
 
-  const { succeeded, failed } = mergeSkillResults(skillResults, setup);
-  if (failed > 0) onStatus?.(`${succeeded} generated, ${failed} failed`);
+  const { succeeded, failed, failedNames } = mergeSkillResults(skillResults, setup);
+  if (failed > 0) {
+    const msg =
+      failed === skillTopics.length
+        ? `All ${failed} skills failed to generate`
+        : `${failed}/${skillTopics.length} skills failed to generate`;
+    onStatus?.(msg);
+    for (const name of failedNames) {
+      onStatus?.(`  → ${name}`);
+    }
+  }
 
   return succeeded;
 }


### PR DESCRIPTION
## Summary

- Updated `mergeSkillResults` to collect failure reasons from rejected promises, returning `failedNames` alongside counts
- Updated `generateSetup` caller to show contextual messages (partial vs total failure) and individual failure reasons
- Applied the same fix to `generateSkillsForSetup` which had the same silent-drop pattern

Closes #142

## Test plan

- [x] `npx tsc --noEmit` passes (on the worktree's pinned version)
- [x] `npx vitest run src/ai/__tests__/generate.test.ts src/ai/__tests__/generate-timeout.test.ts` -- all 63 tests pass
- [ ] Manual: trigger a skill generation failure (e.g. invalid API key for fast model) and verify failure reasons appear in CLI output