### PR TITLE
feat: make telemetry opt-in by default (#146)

### DIFF
--- a/src/telemetry/__tests__/telemetry.test.ts
+++ b/src/telemetry/__tests__/telemetry.test.ts
@@ -41,16 +41,31 @@ vi.mock('child_process', () => ({
 }));
 
 describe('telemetry', () => {
+  const savedEnv: Record<string, string | undefined> = {};
+
   beforeEach(() => {
     vi.resetModules();
     mockCapture.mockClear();
     mockIdentify.mockClear();
     mockShutdown.mockClear();
+    savedEnv.CALIBER_TELEMETRY_DISABLED = process.env.CALIBER_TELEMETRY_DISABLED;
+    savedEnv.CALIBER_TELEMETRY_ENABLED = process.env.CALIBER_TELEMETRY_ENABLED;
     delete process.env.CALIBER_TELEMETRY_DISABLED;
+    delete process.env.CALIBER_TELEMETRY_ENABLED;
+    for (const key of Object.keys(mockConfig)) delete mockConfig[key];
   });
 
   afterEach(() => {
-    delete process.env.CALIBER_TELEMETRY_DISABLED;
+    if (savedEnv.CALIBER_TELEMETRY_DISABLED === undefined) {
+      delete process.env.CALIBER_TELEMETRY_DISABLED;
+    } else {
+      process.env.CALIBER_TELEMETRY_DISABLED = savedEnv.CALIBER_TELEMETRY_DISABLED;
+    }
+    if (savedEnv.CALIBER_TELEMETRY_ENABLED === undefined) {
+      delete process.env.CALIBER_TELEMETRY_ENABLED;
+    } else {
+      process.env.CALIBER_TELEMETRY_ENABLED = savedEnv.CALIBER_TELEMETRY_ENABLED;
+    }
   });
 
   describe('config', () => {
@@ -67,22 +82,59 @@ describe('telemetry', () => {
       expect(hash).toBe(expected);
     });
 
-    it('isTelemetryDisabled respects env var', async () => {
+    it('isTelemetryDisabled returns true by default (opt-in)', async () => {
+      const { isTelemetryDisabled } = await import('../config.js');
+      expect(isTelemetryDisabled()).toBe(true);
+    });
+
+    it('isTelemetryDisabled respects CALIBER_TELEMETRY_DISABLED env var', async () => {
       process.env.CALIBER_TELEMETRY_DISABLED = '1';
       const { isTelemetryDisabled } = await import('../config.js');
       expect(isTelemetryDisabled()).toBe(true);
     });
 
+    it('isTelemetryDisabled returns false when CALIBER_TELEMETRY_ENABLED is set', async () => {
+      process.env.CALIBER_TELEMETRY_ENABLED = '1';
+      const { isTelemetryDisabled } = await import('../config.js');
+      expect(isTelemetryDisabled()).toBe(false);
+    });
+
+    it('CALIBER_TELEMETRY_DISABLED takes precedence over CALIBER_TELEMETRY_ENABLED', async () => {
+      process.env.CALIBER_TELEMETRY_DISABLED = '1';
+      process.env.CALIBER_TELEMETRY_ENABLED = '1';
+      const { isTelemetryDisabled } = await import('../config.js');
+      expect(isTelemetryDisabled()).toBe(true);
+    });
+
+    it('isTelemetryDisabled returns false when telemetryConsent is true in config', async () => {
+      mockConfig.telemetryConsent = true;
+      const { isTelemetryDisabled } = await import('../config.js');
+      expect(isTelemetryDisabled()).toBe(false);
+    });
+
     it('setTelemetryDisabled sets runtime flag', async () => {
+      process.env.CALIBER_TELEMETRY_ENABLED = '1';
       const { isTelemetryDisabled, setTelemetryDisabled } = await import('../config.js');
       setTelemetryDisabled(true);
       expect(isTelemetryDisabled()).toBe(true);
       setTelemetryDisabled(false);
     });
+
+    it('setTelemetryConsent persists consent to config', async () => {
+      const fs = await import('fs');
+      const { setTelemetryConsent } = await import('../config.js');
+      setTelemetryConsent(true);
+      expect(fs.default.writeFileSync).toHaveBeenCalledWith(
+        expect.stringContaining('config.json'),
+        expect.stringContaining('"telemetryConsent": true'),
+        expect.any(Object),
+      );
+    });
   });
 
   describe('trackEvent', () => {
-    it('captures events after init', async () => {
+    it('captures events after init when opted in', async () => {
+      process.env.CALIBER_TELEMETRY_ENABLED = '1';
       const { initTelemetry, trackEvent } = await import('../index.js');
       initTelemetry();
       trackEvent('test_event', { foo: 'bar' });
@@ -94,7 +146,14 @@ describe('telemetry', () => {
       );
     });
 
-    it('is a no-op when disabled', async () => {
+    it('is a no-op when not opted in (default)', async () => {
+      const { initTelemetry, trackEvent } = await import('../index.js');
+      initTelemetry();
+      trackEvent('test_event', { foo: 'bar' });
+      expect(mockCapture).not.toHaveBeenCalled();
+    });
+
+    it('is a no-op when explicitly disabled', async () => {
       process.env.CALIBER_TELEMETRY_DISABLED = '1';
       const { initTelemetry, trackEvent } = await import('../index.js');
       initTelemetry();
@@ -105,6 +164,7 @@ describe('telemetry', () => {
 
   describe('flushTelemetry', () => {
     it('calls shutdown on client', async () => {
+      process.env.CALIBER_TELEMETRY_ENABLED = '1';
       const { initTelemetry, flushTelemetry } = await import('../index.js');
       initTelemetry();
       await flushTelemetry();
@@ -112,6 +172,7 @@ describe('telemetry', () => {
     });
 
     it('does not throw if shutdown fails', async () => {
+      process.env.CALIBER_TELEMETRY_ENABLED = '1';
       mockShutdown.mockRejectedValueOnce(new Error('network error'));
       const { initTelemetry, flushTelemetry } = await import('../index.js');
       initTelemetry();
@@ -121,6 +182,7 @@ describe('telemetry', () => {
 
   describe('event helpers', () => {
     it('trackInitProviderSelected captures correct event', async () => {
+      process.env.CALIBER_TELEMETRY_ENABLED = '1';
       const { initTelemetry } = await import('../index.js');
       const { trackInitProviderSelected } = await import('../events.js');
       initTelemetry();
@@ -134,6 +196,7 @@ describe('telemetry', () => {
     });
 
     it('trackScoreComputed captures correct event', async () => {
+      process.env.CALIBER_TELEMETRY_ENABLED = '1';
       const { initTelemetry } = await import('../index.js');
       const { trackScoreComputed } = await import('../events.js');
       initTelemetry();

--- a/src/telemetry/config.ts
+++ b/src/telemetry/config.ts
@@ -12,6 +12,7 @@ let runtimeDisabled = false;
 interface CaliberConfig {
   machineId?: string;
   telemetryNoticeShown?: boolean;
+  telemetryConsent?: boolean;
   [key: string]: unknown;
 }
 
@@ -100,12 +101,20 @@ export function getRepoHash(): string | undefined {
 
 export function isTelemetryDisabled(): boolean {
   if (runtimeDisabled) return true;
-  const envVal = process.env.CALIBER_TELEMETRY_DISABLED;
-  return envVal === '1' || envVal === 'true';
+  const disabledVal = process.env.CALIBER_TELEMETRY_DISABLED;
+  if (disabledVal === '1' || disabledVal === 'true') return true;
+  const enabledVal = process.env.CALIBER_TELEMETRY_ENABLED;
+  if (enabledVal === '1' || enabledVal === 'true') return false;
+  return readConfig().telemetryConsent !== true;
 }
 
 export function setTelemetryDisabled(disabled: boolean): void {
   runtimeDisabled = disabled;
+}
+
+export function setTelemetryConsent(consent: boolean): void {
+  const config = readConfig();
+  writeConfig({ ...config, telemetryConsent: consent });
 }
 
 export function wasNoticeShown(): boolean {

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -27,10 +27,9 @@ export function initTelemetry(): void {
     flushInterval: 10000,
   });
 
-  // Show first-run notice
   if (!wasNoticeShown()) {
     console.log(
-      chalk.dim('  Caliber collects anonymous usage data to improve the product.') +
+      chalk.dim('  Caliber telemetry is enabled. Thank you for helping improve the product!') +
       '\n' +
       chalk.dim('  Disable with --no-traces or CALIBER_TELEMETRY_DISABLED=1\n')
     );


### PR DESCRIPTION
## Summary

- Telemetry is now **opt-in by default** instead of opt-out. No data is collected unless the user explicitly enables it.
- Users can opt in via `CALIBER_TELEMETRY_ENABLED=1` env var or `telemetryConsent: true` in `~/.caliber/config.json`.
- `CALIBER_TELEMETRY_DISABLED=1` continues to work as an explicit override.
- New `setTelemetryConsent()` function for programmatic consent management.
- Updated first-run notice to reflect opt-in behavior.
- Tests updated with full coverage for the new opt-in/opt-out matrix.

Closes #146

## Test plan

- [x] `npx tsc --noEmit` passes (no new type errors)
- [x] `npx vitest run src/telemetry/__tests__/telemetry.test.ts` -- all 16 tests pass
- [x] `npm run test` -- no regressions (3 pre-existing failures unrelated to this change)
- [x] Verified default behavior: telemetry disabled when no env var or config is set
- [x] Verified `CALIBER_TELEMETRY_ENABLED=1` enables telemetry
- [x] Verified `CALIBER_TELEMETRY_DISABLED=1` takes precedence over enabled
- [x] Verified `telemetryConsent: true` in config enables telemetry