### PR TITLE
fix: use max_completion_tokens for OpenAI provider

### DIFF
--- a/src/llm/openai-compat.ts
+++ b/src/llm/openai-compat.ts
@@ -26,7 +26,7 @@ export class OpenAICompatProvider implements LLMProvider {
   async call(options: LLMCallOptions): Promise<string> {
     const response = await this.client.chat.completions.create({
       model: options.model || this.defaultModel,
-      max_tokens: options.maxTokens || 4096,
+      max_completion_tokens: options.maxTokens || 4096,
       ...(this.temperature !== undefined && { temperature: this.temperature }),
       messages: [
         { role: 'system', content: options.system },
@@ -68,7 +68,7 @@ export class OpenAICompatProvider implements LLMProvider {
 
     const stream = await this.client.chat.completions.create({
       model: options.model || this.defaultModel,
-      max_tokens: options.maxTokens || 10240,
+      max_completion_tokens: options.maxTokens || 10240,
       ...(this.temperature !== undefined && { temperature: this.temperature }),
       messages,
       stream: true,


### PR DESCRIPTION
## Summary

- Replaces deprecated `max_tokens` with `max_completion_tokens` in the OpenAI compatible provider (`src/llm/openai-compat.ts`)
- Fixes compatibility with newer OpenAI models (gpt-5.4-mini, o1, etc.) that reject `max_tokens` in chat completions
- `max_completion_tokens` is supported by the OpenAI Node.js SDK and works for both old and new models

Closes #155