### PR TITLE
fix: strip Claude Code env vars preventing auth in nested sessions

### DIFF
--- a/src/llm/claude-cli.ts
+++ b/src/llm/claude-cli.ts
@@ -73,13 +73,26 @@ export function resetClaudeCliBin(): void {
   _claudeBin = null;
 }
 
+/**
+ * Build a clean copy of process.env with all Claude Code env vars removed.
+ * Claude Code sets CLAUDECODE, CLAUDE_CODE_ENTRYPOINT, CLAUDE_CODE_SESSION_ID,
+ * CLAUDE_CODE_SIMPLE, and others that trigger its anti-recursion detection,
+ * causing "Not logged in" errors when spawning `claude -p` from within a
+ * Claude Code session.
+ */
+function cleanClaudeEnv(): Record<string, string | undefined> {
+  const env = { ...process.env };
+  for (const key of Object.keys(env)) {
+    if (key === 'CLAUDE_CODE_SIMPLE' || key === 'CLAUDECODE' || key.startsWith('CLAUDE_CODE_')) {
+      delete env[key];
+    }
+  }
+  return env;
+}
+
 function spawnClaude(args: string[]): ChildProcess {
   const bin = resolveClaudeBin();
-  // Do NOT forward CLAUDE_CODE_SIMPLE — newer Claude Code uses it to change the
-  // auth pathway, which causes "Not logged in" when set in child claude processes.
-  // The -p flag already handles headless/print mode; this var is redundant and harmful.
-  const { CLAUDE_CODE_SIMPLE: _stripped, ...parentEnv } = process.env;
-  const env = parentEnv;
+  const env = cleanClaudeEnv();
   return IS_WINDOWS
     ? spawn([bin, ...args].join(' '), {
         cwd: process.cwd(),
@@ -228,8 +241,8 @@ export class ClaudeCliProvider implements LLMProvider {
           settled = true;
           reject(
             new Error(
-              `Claude CLI timed out after ${this.timeoutMs / 1000}s. Set CALIBER_CLAUDE_CLI_TIMEOUT_MS to increase.`
-            )
+              `Claude CLI timed out after ${this.timeoutMs / 1000}s. Set CALIBER_CLAUDE_CLI_TIMEOUT_MS to increase.`,
+            ),
           );
         }
       }, this.timeoutMs);
@@ -294,6 +307,7 @@ export function isClaudeCliLoggedIn(): boolean {
       input: '',
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 5000,
+      env: cleanClaudeEnv(),
     });
     const output = result.toString().trim();
     try {


### PR DESCRIPTION
## Summary

- Strips all Claude Code environment variables (`CLAUDECODE`, `CLAUDE_CODE_*`, `CLAUDE_CODE_SIMPLE`) when spawning `claude -p` subprocess, preventing anti-recursion detection from triggering false "Not logged in" errors
- Applies the same env cleaning to `isClaudeCliLoggedIn()` auth check so it also works correctly from within a Claude Code session
- Extracts shared `cleanClaudeEnv()` helper to avoid duplication

Fixes #147, #138, #152

## Root cause

When Caliber runs inside a Claude Code session (e.g. via pre-commit hook or direct invocation), Claude Code injects env vars like `CLAUDECODE`, `CLAUDE_CODE_ENTRYPOINT`, `CLAUDE_CODE_SESSION_ID`, etc. When Caliber then spawns `claude -p` as a subprocess, these env vars cause Claude to think it's being called recursively, and it exits with "Not logged in - Please run /login". The previous fix only stripped `CLAUDE_CODE_SIMPLE` but missed all the other anti-recursion env vars.

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] All 17 `claude-cli.test.ts` tests pass
- [x] Full test suite passes (895/895 tests)