### PR TITLE
fix: Windows incremental learn finalize spawn (#166)

### DIFF
--- a/src/commands/learn.ts
+++ b/src/commands/learn.ts
@@ -164,10 +164,25 @@ export async function learnObserveCommand(options: { failure?: boolean; prompt?:
         const [exe, binArgs] = isNpxResolution()
           ? [bin.slice(0, -NPX_SUFFIX.length) || 'npx', ['--yes', '@rely-ai/caliber']]
           : [bin, []];
-        spawn(exe, [...binArgs, 'learn', 'finalize', '--auto', '--incremental'], {
+        // Windows requires shell:true to spawn .cmd/.bat (CVE-2024-27980 hardening).
+        const child = spawn(exe, [...binArgs, 'learn', 'finalize', '--auto', '--incremental'], {
           detached: true,
           stdio: ['ignore', logFd, logFd],
-        }).unref();
+          ...(process.platform === 'win32' && { shell: true }),
+        });
+        // If spawn fails the child never advances lastAnalysisEventCount, so without
+        // this guard every subsequent observe call past the threshold re-fires the
+        // broken spawn. Bump the counter on error to back off until the next interval.
+        child.on('error', () => {
+          try {
+            const s = readState();
+            s.lastAnalysisEventCount = s.eventCount;
+            writeState(s);
+          } catch {
+            // Best effort
+          }
+        });
+        child.unref();
         fs.closeSync(logFd);
       } catch {
         // Best effort — don't block the hook

--- a/src/commands/learn.ts
+++ b/src/commands/learn.ts
@@ -164,12 +164,20 @@ export async function learnObserveCommand(options: { failure?: boolean; prompt?:
         const [exe, binArgs] = isNpxResolution()
           ? [bin.slice(0, -NPX_SUFFIX.length) || 'npx', ['--yes', '@rely-ai/caliber']]
           : [bin, []];
-        // Windows requires shell:true to spawn .cmd/.bat (CVE-2024-27980 hardening).
-        const child = spawn(exe, [...binArgs, 'learn', 'finalize', '--auto', '--incremental'], {
-          detached: true,
-          stdio: ['ignore', logFd, logFd],
-          ...(process.platform === 'win32' && { shell: true }),
-        });
+        // Windows requires shell:true to spawn .cmd/.bat (CVE-2024-27980 hardening),
+        // and shell:true skips Node's exe quoting — quote here so paths like
+        // `C:\Users\First Last\AppData\Roaming\npm\caliber.cmd` survive cmd.exe parsing.
+        const isWin = process.platform === 'win32';
+        const spawnExe = isWin ? `"${exe}"` : exe;
+        const child = spawn(
+          spawnExe,
+          [...binArgs, 'learn', 'finalize', '--auto', '--incremental'],
+          {
+            detached: true,
+            stdio: ['ignore', logFd, logFd],
+            ...(isWin && { shell: true }),
+          },
+        );
         // If spawn fails the child never advances lastAnalysisEventCount, so without
         // this guard every subsequent observe call past the threshold re-fires the
         // broken spawn. Bump the counter on error to back off until the next interval.

--- a/src/lib/__tests__/resolve-caliber.test.ts
+++ b/src/lib/__tests__/resolve-caliber.test.ts
@@ -4,8 +4,19 @@ import {
   isNpxResolution,
   resetResolvedCaliber,
   isCaliberCommand,
+  pickExecutable,
 } from '../resolve-caliber.js';
 import { execSync } from 'child_process';
+
+function withPlatform(platform: NodeJS.Platform, fn: () => void): void {
+  const original = process.platform;
+  Object.defineProperty(process, 'platform', { value: platform, configurable: true });
+  try {
+    fn();
+  } finally {
+    Object.defineProperty(process, 'platform', { value: original, configurable: true });
+  }
+}
 
 vi.mock('child_process', () => ({
   execSync: vi.fn(),
@@ -142,6 +153,79 @@ describe('isNpxResolution', () => {
     delete process.env.npm_execpath;
     mockedExecSync.mockReturnValue('/usr/local/bin/caliber\n');
     expect(isNpxResolution()).toBe(false);
+  });
+});
+
+describe('pickExecutable', () => {
+  it('returns the first line on POSIX', () => {
+    withPlatform('linux', () => {
+      expect(pickExecutable('/usr/local/bin/caliber\n/opt/bin/caliber')).toBe(
+        '/usr/local/bin/caliber',
+      );
+    });
+  });
+
+  it('prefers .cmd over the POSIX shim on Windows', () => {
+    withPlatform('win32', () => {
+      const out =
+        'C:\\Users\\dev\\AppData\\Roaming\\npm\\caliber\nC:\\Users\\dev\\AppData\\Roaming\\npm\\caliber.cmd';
+      expect(pickExecutable(out)).toBe('C:\\Users\\dev\\AppData\\Roaming\\npm\\caliber.cmd');
+    });
+  });
+
+  it('prefers .exe / .bat over extensionless on Windows', () => {
+    withPlatform('win32', () => {
+      expect(pickExecutable('C:\\bin\\foo\nC:\\bin\\foo.exe')).toBe('C:\\bin\\foo.exe');
+      expect(pickExecutable('C:\\bin\\foo\nC:\\bin\\foo.bat')).toBe('C:\\bin\\foo.bat');
+    });
+  });
+
+  it('falls back to first line on Windows when no .cmd/.exe/.bat present', () => {
+    withPlatform('win32', () => {
+      expect(pickExecutable('C:\\bin\\foo\nC:\\bin\\bar')).toBe('C:\\bin\\foo');
+    });
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(pickExecutable('')).toBe('');
+    expect(pickExecutable('\n\n')).toBe('');
+  });
+});
+
+describe('resolveCaliber on Windows', () => {
+  beforeEach(() => {
+    resetResolvedCaliber();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('selects caliber.cmd over the POSIX shim', () => {
+    withPlatform('win32', () => {
+      process.argv[1] = 'C:\\Users\\dev\\AppData\\Roaming\\npm\\caliber';
+      delete process.env.npm_execpath;
+      mockedExecSync.mockReturnValue(
+        'C:\\Users\\dev\\AppData\\Roaming\\npm\\caliber\nC:\\Users\\dev\\AppData\\Roaming\\npm\\caliber.cmd\n',
+      );
+      expect(resolveCaliber()).toBe('C:\\Users\\dev\\AppData\\Roaming\\npm\\caliber.cmd');
+    });
+  });
+
+  it('selects npx.cmd over the POSIX shim in npx context', () => {
+    withPlatform('win32', () => {
+      process.argv[1] =
+        'C:\\Users\\dev\\AppData\\Local\\npm-cache\\_npx\\abc\\node_modules\\.bin\\caliber';
+      mockedExecSync.mockImplementation((cmd: string) => {
+        if (cmd.includes('where caliber')) throw new Error('not found');
+        if (cmd.includes('where npx'))
+          return 'C:\\Users\\dev\\AppData\\Roaming\\npm\\npx\nC:\\Users\\dev\\AppData\\Roaming\\npm\\npx.cmd\n';
+        throw new Error('unexpected');
+      });
+      const result = resolveCaliber();
+      expect(result).toBe('C:\\Users\\dev\\AppData\\Roaming\\npm\\npx.cmd --yes @rely-ai/caliber');
+      expect(isNpxResolution()).toBe(true);
+    });
   });
 });
 

--- a/src/lib/__tests__/resolve-caliber.test.ts
+++ b/src/lib/__tests__/resolve-caliber.test.ts
@@ -190,6 +190,21 @@ describe('pickExecutable', () => {
     expect(pickExecutable('')).toBe('');
     expect(pickExecutable('\n\n')).toBe('');
   });
+
+  it('handles CRLF line endings from Windows `where`', () => {
+    withPlatform('win32', () => {
+      expect(pickExecutable('C:\\bin\\foo\r\nC:\\bin\\foo.cmd\r\n')).toBe('C:\\bin\\foo.cmd');
+    });
+  });
+
+  it('matches the extension only — not `cmd` substrings in directory names', () => {
+    withPlatform('win32', () => {
+      expect(pickExecutable('C:\\cmd-tools\\bin\\caliber')).toBe('C:\\cmd-tools\\bin\\caliber');
+      expect(pickExecutable('C:\\cmd-tools\\bin\\caliber\nC:\\cmd-tools\\bin\\caliber.cmd')).toBe(
+        'C:\\cmd-tools\\bin\\caliber.cmd',
+      );
+    });
+  });
 });
 
 describe('resolveCaliber on Windows', () => {

--- a/src/lib/resolve-caliber.ts
+++ b/src/lib/resolve-caliber.ts
@@ -4,6 +4,24 @@ import { execSync } from 'child_process';
 let _resolved: string | null = null;
 
 /**
+ * Pick the best executable from `where`/`which` output.
+ *
+ * On Windows, npm installs both an extensionless POSIX shell shim and a
+ * `.cmd` shim. `where` lists the POSIX shim first, but Node cannot exec it
+ * directly — only `.cmd`/`.exe`/`.bat` are spawnable on Windows.
+ */
+export function pickExecutable(out: string): string {
+  const lines = out
+    .split('\n')
+    .map((l) => l.trim())
+    .filter(Boolean);
+  if (process.platform === 'win32') {
+    return lines.find((l) => /\.(cmd|exe|bat)$/i.test(l)) ?? lines[0] ?? '';
+  }
+  return lines[0] ?? '';
+}
+
+/**
  * Resolve the absolute path to the `caliber` binary.
  * Caches the result so the lookup happens at most once per process.
  *
@@ -26,7 +44,7 @@ export function resolveCaliber(): string {
     // Prefer a globally-installed caliber over the ephemeral npx invocation
     try {
       const out = execSync(whichCmd, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
-      const caliberPath = out.split('\n')[0].trim();
+      const caliberPath = pickExecutable(out);
       if (caliberPath) {
         _resolved = caliberPath;
         return _resolved;
@@ -40,7 +58,7 @@ export function resolveCaliber(): string {
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
       }).trim();
-      const npxPath = out.split('\n')[0].trim();
+      const npxPath = pickExecutable(out);
       if (npxPath) {
         _resolved = `${npxPath} --yes @rely-ai/caliber`;
         return _resolved;
@@ -59,7 +77,7 @@ export function resolveCaliber(): string {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
     }).trim();
-    const caliberPath = out.split('\n')[0].trim();
+    const caliberPath = pickExecutable(out);
     if (caliberPath) {
       _resolved = caliberPath;
       return _resolved;
@@ -85,7 +103,9 @@ export function resolveCaliber(): string {
 /** True when the resolved binary is a multi-word npx invocation (bare or absolute path). */
 export function isNpxResolution(): boolean {
   const r = resolveCaliber();
-  return r === 'npx --yes @rely-ai/caliber' || r.endsWith('/npx --yes @rely-ai/caliber');
+  if (r === 'npx --yes @rely-ai/caliber') return true;
+  // Match absolute paths on POSIX (/npx) and Windows (\npx, \npx.cmd, \npx.exe)
+  return /[\\/]npx(?:\.(?:cmd|exe|bat))? --yes @rely-ai\/caliber$/i.test(r);
 }
 
 /** Reset cached resolution — only for tests. */

--- a/src/lib/resolve-caliber.ts
+++ b/src/lib/resolve-caliber.ts
@@ -3,6 +3,9 @@ import { execSync } from 'child_process';
 
 let _resolved: string | null = null;
 
+const WINDOWS_EXEC_EXT = /\.(cmd|exe|bat)$/i;
+const NPX_RESOLUTION_RE = /[\\/]npx(?:\.(?:cmd|exe|bat))? --yes @rely-ai\/caliber$/i;
+
 /**
  * Pick the best executable from `where`/`which` output.
  *
@@ -16,7 +19,7 @@ export function pickExecutable(out: string): string {
     .map((l) => l.trim())
     .filter(Boolean);
   if (process.platform === 'win32') {
-    return lines.find((l) => /\.(cmd|exe|bat)$/i.test(l)) ?? lines[0] ?? '';
+    return lines.find((l) => WINDOWS_EXEC_EXT.test(l)) ?? lines[0] ?? '';
   }
   return lines[0] ?? '';
 }
@@ -105,7 +108,7 @@ export function isNpxResolution(): boolean {
   const r = resolveCaliber();
   if (r === 'npx --yes @rely-ai/caliber') return true;
   // Match absolute paths on POSIX (/npx) and Windows (\npx, \npx.cmd, \npx.exe)
-  return /[\\/]npx(?:\.(?:cmd|exe|bat))? --yes @rely-ai\/caliber$/i.test(r);
+  return NPX_RESOLUTION_RE.test(r);
 }
 
 /** Reset cached resolution — only for tests. */


### PR DESCRIPTION
## Summary

Fixes #166 — on Windows, `caliber learn observe` could not spawn its incremental `learn finalize` child once the 50-event threshold was crossed. Two compounding bugs:

1. **`resolveCaliber()` picked the wrong file.** `where caliber` lists the extensionless POSIX shim that npm installs *before* `caliber.cmd`. We took `[0]`, so we handed Node a sh script it cannot exec on Windows.
2. **The spawn lacked `shell: true`.** Even with `caliber.cmd`, modern Node (≥ 18.20 / 20.12 / 22 — CVE-2024-27980 hardening) refuses to spawn `.cmd`/`.bat` directly without a shell.

The cascade was the worst part: `state.lastAnalysisEventCount` only advances inside the *child* finalize process, so a failed spawn left the counter stuck and **every subsequent observe call past the threshold re-fired the broken spawn** — printing the `node:events:497` ENOENT trace on every Bash tool call instead of every 50th.

## Changes

- `src/lib/resolve-caliber.ts`
  - Add `pickExecutable()` helper that prefers `.cmd` / `.exe` / `.bat` over the POSIX shim on Windows, falls back to first line elsewhere.
  - Apply at all three `where` call sites (npx-context caliber lookup, npx lookup, and main caliber lookup).
  - Update `isNpxResolution()` to recognize Windows-style npx paths (`\npx.cmd`).
- `src/commands/learn.ts`
  - Pass `shell: true` on Windows when spawning the incremental finalize.
  - Attach an `error` listener that bumps `lastAnalysisEventCount` on spawn failure, so a future spawn failure can't cascade per-event.
- `src/lib/__tests__/resolve-caliber.test.ts` — 12 new tests covering POSIX behavior, Windows `.cmd`/`.exe`/`.bat` preference, fallback when only the shim exists, and end-to-end Windows resolution including the npx context.

## Test plan

- [x] `npm run test` — 926/926 pass
- [x] `npm run lint` — 0 errors
- [x] `npx tsc --noEmit` — clean
- [ ] On Windows: edit `.caliber/learning/state.json` so `eventCount - lastAnalysisEventCount >= 50`, pipe a synthetic event into `caliber learn observe`, confirm finalize child runs and counter advances.

## Out-of-scope follow-ups

`src/llm/cursor-acp.ts:28`, `src/llm/claude-cli.ts:45`, `src/llm/opencode.ts:27` use the same `where … | head -1` pattern and would benefit from the same picker. Different blast radius (interactive provider calls, not background spawns), so they don't pump errors per-event. Worth a follow-up issue — the `pickExecutable()` helper is exported and ready to be reused.