### PR TITLE
test: bump vitest timeout to 15s for Windows runner flake

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -6,6 +6,11 @@ export default defineConfig({
     globals: true,
     include: ['src/**/*.test.ts'],
     setupFiles: ['./src/test/setup.ts'],
+    // Default 5s is too tight for cold-start GitHub Windows runners — sync tests
+    // with no I/O occasionally time out. Bumping to 15s eliminates the flake
+    // without masking real hangs.
+    testTimeout: 15000,
+    hookTimeout: 15000,
     coverage: {
       provider: 'v8',
       exclude: ['src/test/**', 'src/bin.ts', 'src/cli.ts', 'src/commands/**', 'dist/**'],


### PR DESCRIPTION
## Summary

GitHub Windows runners occasionally hit the default 5s test/hook timeout on synchronous tests with no async I/O — pure cold-start variance, not real hangs. We just saw this on the master push for #167 (commit `170fb11`): three unrelated sync tests timed out, the same SHA had passed Windows CI on the PR in 1m24s, and a re-run of the master job passed cleanly.

Bumping `testTimeout` and `hookTimeout` to 15s is enough headroom to absorb the slowest cold-start observed without masking genuine hangs (those are typically tens of seconds or infinite).

## Test plan

- [x] `npm run test` — 928/928 pass locally
- [ ] Windows CI green on this PR