### PR TITLE
fix: prevent prompt-too-long errors in caliber refresh

### DIFF
--- a/src/ai/__tests__/refresh.test.ts
+++ b/src/ai/__tests__/refresh.test.ts
@@ -244,5 +244,24 @@ describe('refreshDocs', () => {
       expect(prompt).toContain('[AGENTS.md]');
       expect(prompt).toContain('[.claude/skills/my-skill]');
     });
+
+    it('preserves at least MIN_CHARS_PER_ENTRY for small docs alongside huge ones', async () => {
+      // MIN_CHARS_PER_ENTRY = 2_000; a tiny CLAUDE.md next to a massive skill
+      // should not be truncated below the floor.
+      const HUGE_SKILL = 'y'.repeat(400_000);
+      const SMALL_CLAUDE = 'z'.repeat(1_500);
+      const prompt = await getRefreshPrompt({
+        claudeMd: SMALL_CLAUDE,
+        claudeSkills: [{ filename: 'giant-skill', content: HUGE_SKILL }],
+      });
+      expect(prompt).toContain('[CLAUDE.md]');
+      // CLAUDE.md content should be fully preserved (1500 < 2000 floor)
+      const claudeSection = prompt.slice(
+        prompt.indexOf('[CLAUDE.md]') + '[CLAUDE.md]'.length,
+        prompt.indexOf('[.claude/skills/giant-skill]'),
+      );
+      expect(claudeSection).toContain(SMALL_CLAUDE);
+      expect(claudeSection).not.toContain('[truncated]');
+    });
   });
 });

--- a/src/ai/__tests__/refresh.test.ts
+++ b/src/ai/__tests__/refresh.test.ts
@@ -202,4 +202,47 @@ describe('refreshDocs', () => {
 
     // getFastModel() auto-resolves to provider default when no env var is set
   });
+
+  describe('existing docs size budget', () => {
+    // MAX_EXISTING_DOCS_CHARS = 60_000; generate content clearly over the limit.
+    const OVER_BUDGET = 'x'.repeat(70_000);
+    const SMALL = 'small content';
+
+    it('does not truncate when existing docs are within budget', async () => {
+      const prompt = await getRefreshPrompt({ claudeMd: SMALL, agentsMd: SMALL });
+      expect(prompt).toContain(SMALL);
+      expect(prompt).not.toContain('[truncated]');
+    });
+
+    it('truncates existing doc content when total exceeds budget', async () => {
+      const prompt = await getRefreshPrompt({ claudeMd: OVER_BUDGET });
+      // Header must still appear
+      expect(prompt).toContain('[CLAUDE.md]');
+      // Content must be shorter than the original
+      const claudeMdSection = prompt.slice(prompt.indexOf('[CLAUDE.md]'));
+      expect(claudeMdSection.length).toBeLessThan(OVER_BUDGET.length);
+      expect(prompt).toContain('[truncated]');
+    });
+
+    it('truncates proportionally across multiple large docs', async () => {
+      const prompt = await getRefreshPrompt({ claudeMd: OVER_BUDGET, agentsMd: OVER_BUDGET });
+      // Both headers must be present
+      expect(prompt).toContain('[CLAUDE.md]');
+      expect(prompt).toContain('[AGENTS.md]');
+      // Total existing docs section must be within budget (with some slack for headers/markers)
+      const docsSection = prompt.slice(prompt.indexOf('--- Current Documentation ---'));
+      expect(docsSection.length).toBeLessThan(70_000);
+    });
+
+    it('still includes all doc headers even when content is truncated', async () => {
+      const prompt = await getRefreshPrompt({
+        claudeMd: OVER_BUDGET,
+        agentsMd: OVER_BUDGET,
+        claudeSkills: [{ filename: 'my-skill', content: OVER_BUDGET }],
+      });
+      expect(prompt).toContain('[CLAUDE.md]');
+      expect(prompt).toContain('[AGENTS.md]');
+      expect(prompt).toContain('[.claude/skills/my-skill]');
+    });
+  });
 });

--- a/src/ai/refresh.ts
+++ b/src/ai/refresh.ts
@@ -10,6 +10,7 @@ import { CALIBER_MANAGED_PREFIX } from '../fingerprint/existing-config.js';
 // Skills can reach hundreds of KB in large projects; without a cap the combined prompt
 // exceeds Claude's input token limit and the CLI exits with "prompt is too long".
 const MAX_EXISTING_DOCS_CHARS = 60_000;
+const MIN_CHARS_PER_ENTRY = 2_000;
 
 function truncateAtLineEnd(text: string, maxChars: number): string {
   if (text.length <= maxChars) return text;
@@ -196,11 +197,14 @@ function buildRefreshPrompt(
   }
 
   // Apply size budget: proportionally truncate each entry's content if total exceeds limit.
+  // A per-entry minimum prevents a single huge skill from starving CLAUDE.md to near-zero.
   const totalDocChars = docEntries.reduce((sum, e) => sum + e.content.length, 0);
   if (totalDocChars > MAX_EXISTING_DOCS_CHARS) {
     const ratio = MAX_EXISTING_DOCS_CHARS / totalDocChars;
     for (const entry of docEntries) {
-      entry.content = truncateAtLineEnd(entry.content, Math.floor(entry.content.length * ratio));
+      const proportional = Math.floor(entry.content.length * ratio);
+      const floor = Math.min(MIN_CHARS_PER_ENTRY, entry.content.length);
+      entry.content = truncateAtLineEnd(entry.content, Math.max(proportional, floor));
     }
   }
 

--- a/src/ai/refresh.ts
+++ b/src/ai/refresh.ts
@@ -6,6 +6,17 @@ import { formatSourcesForPrompt } from '../fingerprint/sources.js';
 import { stripManagedBlocks } from '../writers/pre-commit-block.js';
 import { CALIBER_MANAGED_PREFIX } from '../fingerprint/existing-config.js';
 
+// Budget for existing doc content (CLAUDE.md, skills, rules, etc.) passed to the LLM.
+// Skills can reach hundreds of KB in large projects; without a cap the combined prompt
+// exceeds Claude's input token limit and the CLI exits with "prompt is too long".
+const MAX_EXISTING_DOCS_CHARS = 60_000;
+
+function truncateAtLineEnd(text: string, maxChars: number): string {
+  if (text.length <= maxChars) return text;
+  const cut = text.lastIndexOf('\n', maxChars);
+  return (cut === -1 ? text.slice(0, maxChars) : text.slice(0, cut)) + '\n...[truncated]';
+}
+
 interface RefreshDiff {
   committed: string;
   staged: string;
@@ -135,51 +146,67 @@ function buildRefreshPrompt(
 
   parts.push('\n--- Current Documentation ---');
 
-  if (existingDocs.agentsMd) {
-    parts.push('\n[AGENTS.md]');
-    parts.push(stripManagedBlocks(existingDocs.agentsMd));
-  }
-  if (existingDocs.claudeMd) {
-    parts.push('\n[CLAUDE.md]');
-    parts.push(stripManagedBlocks(existingDocs.claudeMd));
-  }
-  if (existingDocs.readmeMd) {
-    parts.push('\n[README.md]');
-    parts.push(existingDocs.readmeMd);
-  }
-  if (existingDocs.cursorrules) {
-    parts.push('\n[.cursorrules]');
-    parts.push(existingDocs.cursorrules);
-  }
+  // Collect existing doc entries as {header, content} pairs so we can apply a
+  // combined size budget before joining — prevents "prompt is too long" errors
+  // in projects with many large skills or rules files.
+  type DocEntry = { header: string; content: string };
+  const docEntries: DocEntry[] = [];
+
+  if (existingDocs.agentsMd)
+    docEntries.push({
+      header: '\n[AGENTS.md]',
+      content: stripManagedBlocks(existingDocs.agentsMd),
+    });
+  if (existingDocs.claudeMd)
+    docEntries.push({
+      header: '\n[CLAUDE.md]',
+      content: stripManagedBlocks(existingDocs.claudeMd),
+    });
+  if (existingDocs.readmeMd)
+    docEntries.push({ header: '\n[README.md]', content: existingDocs.readmeMd });
+  if (existingDocs.cursorrules)
+    docEntries.push({ header: '\n[.cursorrules]', content: existingDocs.cursorrules });
   if (existingDocs.claudeSkills?.length) {
-    for (const skill of existingDocs.claudeSkills) {
-      parts.push(`\n[.claude/skills/${skill.filename}]`);
-      parts.push(skill.content);
-    }
+    for (const skill of existingDocs.claudeSkills)
+      docEntries.push({ header: `\n[.claude/skills/${skill.filename}]`, content: skill.content });
   }
   if (existingDocs.claudeRules?.length) {
     for (const rule of existingDocs.claudeRules) {
       if (rule.filename.startsWith(CALIBER_MANAGED_PREFIX)) continue;
-      parts.push(`\n[.claude/rules/${rule.filename}]`);
-      parts.push(rule.content);
+      docEntries.push({ header: `\n[.claude/rules/${rule.filename}]`, content: rule.content });
     }
   }
   if (existingDocs.cursorRules?.length) {
     for (const rule of existingDocs.cursorRules) {
       if (rule.filename.startsWith(CALIBER_MANAGED_PREFIX)) continue;
-      parts.push(`\n[.cursor/rules/${rule.filename}]`);
-      parts.push(rule.content);
+      docEntries.push({ header: `\n[.cursor/rules/${rule.filename}]`, content: rule.content });
     }
   }
-  if (existingDocs.copilotInstructions) {
-    parts.push('\n[.github/copilot-instructions.md]');
-    parts.push(stripManagedBlocks(existingDocs.copilotInstructions));
-  }
+  if (existingDocs.copilotInstructions)
+    docEntries.push({
+      header: '\n[.github/copilot-instructions.md]',
+      content: stripManagedBlocks(existingDocs.copilotInstructions),
+    });
   if (existingDocs.copilotInstructionFiles?.length) {
-    for (const file of existingDocs.copilotInstructionFiles) {
-      parts.push(`\n[.github/instructions/${file.filename}]`);
-      parts.push(file.content);
+    for (const file of existingDocs.copilotInstructionFiles)
+      docEntries.push({
+        header: `\n[.github/instructions/${file.filename}]`,
+        content: file.content,
+      });
+  }
+
+  // Apply size budget: proportionally truncate each entry's content if total exceeds limit.
+  const totalDocChars = docEntries.reduce((sum, e) => sum + e.content.length, 0);
+  if (totalDocChars > MAX_EXISTING_DOCS_CHARS) {
+    const ratio = MAX_EXISTING_DOCS_CHARS / totalDocChars;
+    for (const entry of docEntries) {
+      entry.content = truncateAtLineEnd(entry.content, Math.floor(entry.content.length * ratio));
     }
+  }
+
+  for (const { header, content } of docEntries) {
+    parts.push(header);
+    parts.push(content);
   }
 
   if (existingDocs.includableDocs?.length) {

--- a/src/lib/__tests__/git-diff.test.ts
+++ b/src/lib/__tests__/git-diff.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('child_process', () => ({
+  execSync: vi.fn(),
+}));
+
+import { execSync } from 'child_process';
+import { collectDiff } from '../git-diff.js';
+
+const mockedExecSync = vi.mocked(execSync);
+
+function makeExecSync(overrides: Record<string, string> = {}) {
+  return (cmd: unknown) => {
+    const c = String(cmd);
+    for (const [pattern, result] of Object.entries(overrides)) {
+      if (c.includes(pattern)) return result;
+    }
+    return '';
+  };
+}
+
+describe('collectDiff', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('caps changedFiles at 500 when untracked files are numerous', () => {
+    const manyUntrackedFiles = Array.from({ length: 2000 }, (_, i) => `build/output-${i}.o`).join(
+      '\n',
+    );
+
+    mockedExecSync.mockImplementation(
+      makeExecSync({
+        '--name-only': 'src/index.ts\nsrc/utils.ts',
+        '--others': manyUntrackedFiles,
+        '--cached --name-only': '',
+        '--cached': '',
+      }) as ReturnType<typeof vi.fn>,
+    );
+
+    const result = collectDiff(null);
+    expect(result.changedFiles.length).toBeLessThanOrEqual(500);
+  });
+
+  it('deduplicates files before applying the cap', () => {
+    // Same file repeated across committed, staged, unstaged, and untracked lists
+    const repeated = Array.from({ length: 600 }, (_, i) => `src/file-${i}.ts`).join('\n');
+
+    mockedExecSync.mockImplementation(
+      makeExecSync({
+        '--name-only': repeated,
+        '--others': repeated,
+        '--cached --name-only': repeated,
+        '--cached': '',
+      }) as ReturnType<typeof vi.fn>,
+    );
+
+    const result = collectDiff(null);
+    // Dedup runs before cap, so result should have at most 500 unique entries
+    expect(result.changedFiles.length).toBeLessThanOrEqual(500);
+    const unique = new Set(result.changedFiles);
+    expect(unique.size).toBe(result.changedFiles.length);
+  });
+
+  it('excludes doc patterns from changedFiles', () => {
+    mockedExecSync.mockImplementation(
+      makeExecSync({
+        '--name-only': 'CLAUDE.md\nAGENTS.md\nsrc/index.ts',
+        '--others': '',
+        '--cached --name-only': '',
+        '--cached': '',
+      }) as ReturnType<typeof vi.fn>,
+    );
+
+    const result = collectDiff(null);
+    expect(result.changedFiles).not.toContain('CLAUDE.md');
+    expect(result.changedFiles).not.toContain('AGENTS.md');
+    expect(result.changedFiles).toContain('src/index.ts');
+  });
+
+  it('reports hasChanges=true when changedFiles are present', () => {
+    mockedExecSync.mockImplementation(
+      makeExecSync({
+        '--name-only': 'src/app.ts',
+        '--others': '',
+        '--cached --name-only': '',
+        '--cached': '',
+      }) as ReturnType<typeof vi.fn>,
+    );
+
+    const result = collectDiff(null);
+    expect(result.hasChanges).toBe(true);
+  });
+});

--- a/src/lib/__tests__/git-diff.test.ts
+++ b/src/lib/__tests__/git-diff.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { execSync as ExecSyncType } from 'child_process';
 
 vi.mock('child_process', () => ({
   execSync: vi.fn(),
@@ -9,14 +10,14 @@ import { collectDiff } from '../git-diff.js';
 
 const mockedExecSync = vi.mocked(execSync);
 
-function makeExecSync(overrides: Record<string, string> = {}) {
-  return (cmd: unknown) => {
+function makeExecSync(overrides: Record<string, string> = {}): typeof ExecSyncType {
+  return ((cmd: unknown) => {
     const c = String(cmd);
     for (const [pattern, result] of Object.entries(overrides)) {
       if (c.includes(pattern)) return result;
     }
     return '';
-  };
+  }) as unknown as typeof ExecSyncType;
 }
 
 describe('collectDiff', () => {
@@ -35,7 +36,7 @@ describe('collectDiff', () => {
         '--others': manyUntrackedFiles,
         '--cached --name-only': '',
         '--cached': '',
-      }) as ReturnType<typeof vi.fn>,
+      }),
     );
 
     const result = collectDiff(null);
@@ -52,7 +53,7 @@ describe('collectDiff', () => {
         '--others': repeated,
         '--cached --name-only': repeated,
         '--cached': '',
-      }) as ReturnType<typeof vi.fn>,
+      }),
     );
 
     const result = collectDiff(null);
@@ -69,7 +70,7 @@ describe('collectDiff', () => {
         '--others': '',
         '--cached --name-only': '',
         '--cached': '',
-      }) as ReturnType<typeof vi.fn>,
+      }),
     );
 
     const result = collectDiff(null);
@@ -85,7 +86,7 @@ describe('collectDiff', () => {
         '--others': '',
         '--cached --name-only': '',
         '--cached': '',
-      }) as ReturnType<typeof vi.fn>,
+      }),
     );
 
     const result = collectDiff(null);

--- a/src/lib/git-diff.ts
+++ b/src/lib/git-diff.ts
@@ -1,6 +1,10 @@
 import { execSync } from 'child_process';
 
 const MAX_DIFF_BYTES = 100_000;
+// Large projects can have tens of thousands of untracked build artifacts.
+// The changed-files list is joined into the prompt; cap it to prevent it from
+// dominating the token budget before the LLM even sees the actual diffs.
+const MAX_CHANGED_FILES = 500;
 
 const DOC_PATTERNS = [
   'CLAUDE.md',
@@ -81,9 +85,9 @@ export function collectDiff(lastSha: string | null): DiffResult {
     changedFiles.push(...untrackedFiles.split('\n').filter(Boolean));
   }
 
-  changedFiles = [...new Set(changedFiles)].filter(
-    (f) => !DOC_PATTERNS.some((p) => f === p || f.startsWith(p)),
-  );
+  changedFiles = [...new Set(changedFiles)]
+    .filter((f) => !DOC_PATTERNS.some((p) => f === p || f.startsWith(p)))
+    .slice(0, MAX_CHANGED_FILES);
 
   const totalSize = committedDiff.length + stagedDiff.length + unstagedDiff.length;
   if (totalSize > MAX_DIFF_BYTES) {


### PR DESCRIPTION
## Problem

`caliber refresh` fails with `Claude CLI exited with code 1. Prompt is too long` in two scenarios that can compound:

### 1. Unbounded `changedFiles` list (8MB+ from untracked files)

`collectDiff` in `git-diff.ts` includes all untracked files via `git ls-files --others --exclude-standard`. Projects with large build artifact trees (e.g. 76K untracked `.o` files not in `.gitignore`) produce a `changedFiles` array that, when joined with `", "`, generates 8MB+ of text — before the LLM even sees the diffs.

### 2. Unbounded existing docs (hundreds of KB from skills)

The existing docs section fed into `buildRefreshPrompt` had no size cap. Projects with many large skill files (e.g. 44 skills at ~11KB each = 488KB) push the combined prompt past Claude's 200K token input limit.

The git diff itself was already capped at 100KB in `git-diff.ts`, but neither the changed-files list nor the existing docs had limits.

## Fix

**`src/lib/git-diff.ts`** — cap `changedFiles` at 500 entries after deduplication and doc-pattern filtering. 500 files is more than enough for the LLM's informational use and monorepo scoping.

**`src/ai/refresh.ts`** — add `MAX_EXISTING_DOCS_CHARS = 60_000` and apply it as a proportional budget across all existing doc entries (CLAUDE.md, AGENTS.md, skills, rules, copilot instructions) before joining them into the prompt. Doc headers are always preserved so the LLM knows which files exist. Mirrors the proportional-truncation pattern already used for diff content.

## Tests

- `src/lib/__tests__/git-diff.test.ts` (new) — 4 tests: cap at 500, dedup before cap, doc-pattern exclusion, hasChanges flag
- `src/ai/__tests__/refresh.test.ts` — 4 new tests: no truncation under budget, truncation over budget, proportional truncation, all headers preserved

Closes #174

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>