### PR TITLE
docs(telemetry): document PostHog analytics and opt-out mechanisms in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,10 @@ Yes. Run `caliber init` from any directory. `caliber refresh` can update configs
 <details>
 <summary><strong>Does it send my code anywhere?</strong></summary>
 
-Scoring is fully local. Generation sends a project summary (languages, structure, dependencies — not source code) to whatever LLM provider you configure — the same provider your AI editor already uses. Anonymous usage analytics (no code, no file contents) can be disabled via `caliber config`.
+Scoring is fully local. Generation sends a project summary (languages, structure, dependencies — not source code) to whatever LLM provider you configure — the same provider your AI editor already uses. Anonymous usage analytics (command names, durations — no code, no file contents) are collected via PostHog. To opt out:
+
+- **Per-run**: `caliber --no-traces <command>`
+- **Persistent env var**: `export CALIBER_TELEMETRY_DISABLED=1`
 
 </details>
 


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## Issue

The README FAQ answer to "Does it send my code anywhere?" mentioned that anonymous usage analytics "can be disabled via `caliber config`", but did not:
1. Name the third-party analytics provider (PostHog, listed as a production dependency in `package.json`)
2. Document the specific opt-out mechanisms already built into the codebase

The existing `src/telemetry/config.ts` already implements two opt-out methods:
- `--no-traces` CLI flag (sets `runtimeDisabled = true` for that run)  
- `CALIBER_TELEMETRY_DISABLED=1` environment variable (persistent)

## Fix

Updated the FAQ answer to:
- Name PostHog explicitly as the analytics provider
- List both opt-out methods with the exact commands users need

No code changes — documentation only. The opt-out mechanisms were already implemented; this just makes them discoverable.

Note: there is already a branch `alonp98/fix-146-telemetry-opt-in` in this repo that may address related concerns. This PR is narrowly scoped to README disclosure only, so it shouldn't conflict.