### PR TITLE
fix: sync divergent skill files across platforms

### DIFF
--- a/.agents/skills/adding-a-command/SKILL.md
+++ b/.agents/skills/adding-a-command/SKILL.md
@@ -1,88 +1,184 @@
 ---
 name: adding-a-command
-description: Creates a new CLI command following the Commander.js pattern in src/commands/. Handles command registration in src/cli.ts, telemetry tracking via tracked() wrapper, and option parsing. Use when user says 'add command', 'new CLI command', 'create subcommand', or asks to add files to src/commands/. Do NOT use for modifying existing commands or refactoring command logic.
+description: Creates a new CLI command following the Commander.js pattern in src/commands/. Handles command registration in src/cli.ts, telemetry tracking via tracked() wrapper, and option parsing. Use when user says add command, new CLI command, create subcommand, or adds files to src/commands/. Do NOT use for modifying existing commands or fixing bugs in existing commands.
+paths:
+  - src/commands/**/*.ts
+  - src/cli.ts
 ---
 # Adding a Command
 
 ## Critical
 
-- **Every command must be wrapped with `tracked()`** — this enables telemetry. Without it, the command will not report usage.
-- **Commands are registered in `src/cli.ts`**, not auto-discovered. You must manually import and attach each command.
-- **Use Commander.js patterns exactly** — `.option()` for flags, `.argument()` for positional args, `.action()` for the handler.
-- **Always provide a `.description()`** — it appears in `caliber --help`.
+- **Export pattern**: Command must export a named async function: `export async function myCommand(options?: OptionType)`. Never use default exports.
+- **Registration in cli.ts**: Every command must be imported and registered with `.command()` chain in `src/cli.ts`, wrapped with `tracked()` for telemetry.
+- **Error signaling**: Use `throw new Error('__exit__')` to exit gracefully without printing the error message. Use chalk for user-facing messages.
+- **Options typing**: Commands receiving options must define a TypeScript interface for those options. Pass options as a destructured object parameter.
 
 ## Instructions
 
-1. **Create the command file** in `src/commands/{{command-name}}.ts`.
-   - Signature: `export async function {{commandName}}(options: OptionType, ...args: any[]) { ... }`
-   - Use async/await for all async operations (DB, LLM, file I/O).
-   - Import `tracked` from `src/lib/hooks.ts`: `import { tracked } from '../lib/hooks.js';`
-   - Verify the command exports the handler function before proceeding.
+1. **Create the command file** at `src/commands/{commandName}.ts` with named async export.
+   - Signature: `export async function {commandName}Command(options?: { optionName?: optionType }) { ... }`
+   - Import only what you need (avoid kitchen-sink imports).
+   - Return void (handle all output via console.log or chalk).
+   - Verify the file follows the naming convention: camelCase function + "Command" suffix.
 
-2. **Define the OptionType interface** (if needed).
-   - Place above the handler function in the same file.
-   - Example from `score.ts`: `interface ScoreOptions { json?: boolean; verbose?: boolean; }`
-   - Verify the interface matches all `.option()` calls in Step 3.
+2. **Handle errors consistently**: Wrap error-prone operations in try/catch. Distinguish between user errors and system errors:
+   - User error (bad input): `console.error(chalk.red('message')); throw new Error('__exit__');`
+   - System error (missing dependency): `throw new Error('Detailed error message');` — this will print and exit with code 1.
+   - Parse-like errors: Use ora spinner with `.fail()` before throwing.
+   - This step prevents double error printing in bin.ts.
 
-3. **Register in `src/cli.ts`**.
-   - Import: `import { {{commandName}} } from './commands/{{command-name}}.js';`
-   - Attach to program: `program.command('{{cmd-name}}').description('...').option('--flag', '...').action(tracked({{commandName}}));`
-   - Use `.option()` for optional flags, `.argument()` for required positional args.
-   - Verify the import path includes `.js` extension (ESM).
+3. **Import and register in src/cli.ts** in the correct location:
+   - Add import at the top: `import { {commandName}Command } from './commands/{commandName}.js';`
+   - Register the command in the appropriate section (main commands, or nested under a group like `sources`).
+   - For main commands: `.command('{kebab-name}').description('...').option(...).action(tracked('{kebab-name}', {commandName}Command))`
+   - For subcommands (like `sources add`): `sources.command('add').description(...).action(tracked('sources:add', sourcesAddCommand))`
+   - Key: Wrap handler with `tracked('{command-name}', handler)` for automatic telemetry.
+   - Verify the command name in tracked() uses kebab-case for main commands and colon-separated for subcommands.
 
-4. **Add tests** in `src/commands/__tests__/{{command-name}}.test.ts`.
-   - Use Vitest + `vi.mock()` for LLM, file I/O, and hooks.
-   - Test both success and error paths.
-   - Verify tests pass: `npm run test -- {{command-name}}.test.ts`.
+4. **Define options (if needed)**:
+   - Add `.option()` chains before `.action()`: `.option('--flag', 'Description')` or `.option('--opt <value>', 'Description')`
+   - For parsed options (like comma-separated agents), add a parse function: `.option('--opt <value>', 'Description', parseFunction)`
+   - Pass options to handler: `.action(tracked('name', (opts) => command(opts)))`
+   - Define TypeScript interface for the options object.
+   - Verify option names use camelCase (Commander converts kebab-case flags to camelCase).
 
-5. **Validate telemetry**.
-   - Confirm `tracked()` wraps the action handler.
-   - Verify the command fires an event in PostHog.
+5. **Verify before proceeding**:
+   - Function exports correctly and is imported in cli.ts.
+   - Command is registered with tracked() wrapper.
+   - Output uses chalk for colors, not plain console.log.
+   - Error paths throw `new Error('__exit__')` for user errors.
 
 ## Examples
 
-**User says:** "Add a 'debug' command that prints the fingerprint JSON."
+### Example 1: Simple command (status)
 
-**Actions taken:**
+User says: "Add a command to show config status"
 
-1. Create `src/commands/debug.ts`:
+**Actions taken**:
+1. Create src/commands/status.ts with statusCommand() export
+2. Import and register in src/cli.ts with tracked() wrapper
+
+**Result**: `caliber status` displays config status; `caliber status --json` outputs JSON.
+
+Code example:
 ```typescript
-import { tracked } from '../lib/hooks.js';
-import { collectFingerprint } from '../fingerprint/index.js';
+import chalk from 'chalk';
+import { loadConfig } from '../llm/config.js';
 
-export async function debug(options: { verbose?: boolean }) {
-  const fp = await collectFingerprint();
-  console.log(JSON.stringify(fp, null, 2));
+export async function statusCommand(options?: { json?: boolean }) {
+  const config = loadConfig();
+  
+  if (options?.json) {
+    console.log(JSON.stringify({ configured: !!config }, null, 2));
+    return;
+  }
+  
+  console.log(chalk.bold('Status'));
+  console.log(`  LLM: ${chalk.green(config?.provider || 'Not configured')}`);
 }
 ```
 
-2. Register in `src/cli.ts`:
+Registration in src/cli.ts:
 ```typescript
-import { debug } from './commands/debug.js';
-
+import { statusCommand } from './commands/status.js';
 program
-  .command('debug')
-  .description('Print fingerprint JSON')
-  .option('--verbose', 'Include timing info')
-  .action(tracked(debug));
+  .command('status')
+  .description('Show config status')
+  .option('--json', 'Output as JSON')
+  .action(tracked('status', statusCommand));
 ```
 
-3. Test in `src/commands/__tests__/debug.test.ts`:
+---
+
+### Example 2: Subcommand with arguments
+
+User says: "Add a sources add subcommand"
+
+**Actions taken**:
+1. Create src/commands/sources.ts with sourcesAddCommand() export
+2. Register under sources group with tracked('sources:add', ...)
+
+**Result**: `caliber sources add ../lib` adds a source.
+
+Code example:
 ```typescript
-vi.mock('../fingerprint/index.js');
-it('should print fingerprint', async () => {
-  const consoleSpy = vi.spyOn(console, 'log');
-  await debug({ verbose: false });
-  expect(consoleSpy).toHaveBeenCalled();
-});
+export async function sourcesAddCommand(sourcePath: string) {
+  if (!fs.existsSync(sourcePath)) {
+    console.log(chalk.red(`Path not found: ${sourcePath}`));
+    throw new Error('__exit__');
+  }
+  const existing = loadSourcesConfig(process.cwd());
+  existing.push({ type: 'repo', path: sourcePath });
+  writeSourcesConfig(process.cwd(), existing);
+  console.log(chalk.green(`Added ${sourcePath}`));
+}
 ```
 
-**Result:** Running `caliber debug` prints the fingerprint and logs a telemetry event.
+Registration:
+```typescript
+const sources = program.command('sources');
+sources
+  .command('add')
+  .argument('<path>', 'Path to add')
+  .action(tracked('sources:add', sourcesAddCommand));
+```
+
+---
+
+### Example 3: Command with option parsing
+
+User says: "Add init with --agent flag supporting comma-separated values"
+
+**Actions taken**:
+1. Create parseAgentOption() parser in src/cli.ts
+2. Create src/commands/init.ts with initCommand(options)
+3. Register with custom parser
+
+**Result**: `caliber init --agent claude,cursor` passes parsed array to handler.
+
+Parser code:
+```typescript
+function parseAgentOption(value: string) {
+  const agents = value.split(',').map(s => s.trim().toLowerCase());
+  if (agents.length === 0) {
+    console.error('Invalid agent');
+    process.exit(1);
+  }
+  return agents;
+}
+
+program.command('init')
+  .option('--agent <type>', 'Agents (comma-separated)', parseAgentOption)
+  .action(tracked('init', initCommand));
+```
 
 ## Common Issues
 
-- **"tracked is not defined"** — Verify import: `import { tracked } from '../lib/hooks.js';` with `.js` extension.
-- **"Command not found"** — Check `src/cli.ts` for the import and `.action(tracked(...))` attachment.
-- **"options is undefined"** — Ensure the handler signature is `async function(options: Type, ...args: any[])` and the Commander action passes options as the first parameter.
-- **"PostHog event not firing"** — Confirm `tracked()` wraps the action handler; without it, events won't emit.
-- **ESM import errors** — Always include `.js` extensions in import paths (e.g., `../lib/hooks.js` not `../lib/hooks`).
+**Issue**: "SyntaxError: The requested module does not provide an export named 'myCommand'"
+- **Cause**: Function not exported or exported as default instead of named.
+- **Fix**: Use `export async function myCommand(...)` (not `export default`).
+
+**Issue**: Command appears in help but crashes when run
+- **Cause**: Handler not wrapped with `tracked()` or function import mismatch.
+- **Fix**: Verify import name matches function export. Wrap with `tracked('command-name', handler)`.
+
+**Issue**: "Error: __exit__" appears in output for user errors
+- **Cause**: Throwing generic error instead of using error exit pattern.
+- **Fix**: Use `console.error(chalk.red('message')); throw new Error('__exit__');` for user-facing errors.
+
+**Issue**: --dry-run flag not recognized
+- **Cause**: Option not declared with `.option()` or wrong camelCase in interface.
+- **Fix**: Add `.option('--dry-run', 'Description')` and ensure options interface has `dryRun?: boolean`.
+
+**Issue**: Subcommand crashes but parent command works
+- **Cause**: Using `program.command()` instead of `groupVar.command()` for subcommands.
+- **Fix**: Register on group: `const sources = program.command('sources'); sources.command('add')...`
+
+**Issue**: Telemetry not appearing
+- **Cause**: Handler not wrapped with `tracked()` or wrong command name.
+- **Fix**: Ensure `.action(tracked('{kebab-case}', handler))` wraps handler. Use colon for subcommands like 'sources:add'.
+
+**Issue**: "Cannot find module" with relative imports
+- **Cause**: Using `.ts` extension in imports.
+- **Fix**: Always use `.js` extension: `import { x } from '../lib/file.js'` (required for ESM).

--- a/.agents/skills/caliber-testing/SKILL.md
+++ b/.agents/skills/caliber-testing/SKILL.md
@@ -1,105 +1,370 @@
 ---
 name: caliber-testing
-description: Write Vitest tests following Caliber patterns: tests in __tests__/ directories, use vi.mock() for modules, leverage global LLM mock from src/test/setup.ts, save/restore env vars. Trigger: user says 'write tests', 'add tests', 'test this', or creates *.test.ts files. Do NOT use for non-test code or when user is debugging existing tests.
+description: Writes Vitest tests following project patterns: __tests__/ directories, vi.mock() for module mocking with vi.hoisted() for test-time factories, global LLM mock from src/test/setup.ts, environment variable save/restore in beforeEach/afterEach, vi.clearAllMocks() lifecycle, and test file organization. Use when user says 'write tests', 'add test coverage', 'test this', creates *.test.ts files, or when test failures appear in CI. Do NOT use for non-test code or for debugging without writing tests.
+paths:
+  - src/**/__tests__/*.test.ts
 ---
 # Caliber Testing
 
 ## Critical
 
-- **Test location**: Always place tests in `__tests__/` subdirectory alongside source code (e.g., `src/commands/__tests__/score.test.ts` for `src/commands/score.ts`)
-- **Global LLM mock**: src/test/setup.ts provides `mockLLM` and `mockLLMStream` globally — use these instead of creating new mocks
-- **Environment variables**: Wrap tests in `beforeEach(() => { process.env.SAVED = ... })` and `afterEach(() => { process.env.SAVED = null })` to avoid test pollution
-- **Import extensions**: Use `.js` extensions for all relative imports (ESM convention)
-- **Test file naming**: `[module].test.ts` (not `.spec.ts`)
+- All test files MUST be placed in `__tests__/` directories parallel to source files: `src/[module]/__tests__/[module].test.ts`
+- Register any new `__tests__/` directories in `vitest.config.ts`'s `include` glob (already configured: `src/**/*.test.ts`)
+- NEVER mock `src/test/setup.ts` — it is the global LLM provider mock already applied to all tests
+- Environment variable tests MUST save `process.env` in `beforeEach`, restore in `afterEach`, and explicitly delete env vars to test absence
+- Temporary file/directory cleanup MUST happen in `afterEach`, not in individual test cleanup. Use `fs.rmSync(dir, { recursive: true, force: true })`
+- When a test requires unmocking modules mocked in global setup, call `vi.unmock('../module.js')` BEFORE the import statement
+- Run `pnpm test` locally and `pnpm test:coverage` before committing to verify coverage thresholds (lines: 50, functions: 50, branches: 50, statements: 50)
 
 ## Instructions
 
-1. **Set up test file structure**
-   - Create file at `src/[feature]/__tests__/[name].test.ts`
-   - Import testing utilities: `import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'`
-   - Import source file under test
-   - Verify file location matches existing test patterns in project
+### Step 1: Create the test file in the correct directory
+Create `src/[module]/__tests__/[module].test.ts`. The parent source file is `src/[module]/[module].ts`.
 
-2. **Handle environment variables**
-   - Save original values in `beforeEach`: `const savedEnv = { ...process.env }`
-   - Restore in `afterEach`: `Object.assign(process.env, savedEnv); delete process.env.NEW_VAR`
-   - This prevents tests from affecting each other
-   - Verify cleanup runs with `afterEach` or test will fail on subsequent runs
+**Verify**: The `__tests__` directory exists at the same level as the source file being tested.
 
-3. **Mock external modules with vi.mock()**
-   - Place `vi.mock()` calls at top of test file before imports
-   - Use hoisted pattern: `vi.mock('../path/to/module.js', () => ({ default: { /* mock */ } }))`
-   - For functions: `vi.mock('../utils/fetch.js', () => ({ fetchData: vi.fn() }))`
-   - Verify mock is applied before any test runs by checking first test imports the mocked module
+### Step 2: Import test framework
+At the top of every test file, import from `vitest`:
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+```
 
-4. **Use global LLM mock from setup.ts**
-   - Global `mockLLM` and `mockLLMStream` are auto-registered in vitest.config.ts setupFiles
-   - Import from `src/test/setup.js`: `import { mockLLM } from '../test/setup.js'`
-   - Configure per test: `mockLLM.mockResolvedValue({ /* response */ })`
-   - Reset between tests: `mockLLM.mockReset()` in `afterEach`
-   - Verify mock was called: `expect(mockLLM).toHaveBeenCalledWith(...)`
+Add additional imports based on what you're testing:
+- File system: `import fs from 'fs'; import path from 'path'; import os from 'os';`
+- Temporary files: Use `fs.mkdtempSync(path.join(os.tmpdir(), 'caliber-prefix-'))`
+- Exec: `import { execSync } from 'child_process';`
 
-5. **Structure test groups with describe blocks**
-   - Group related tests: `describe('scoreCommand', () => { it('should...', ...) })`
-   - Use nested describes for sub-features: `describe('error handling', () => { ... })`
-   - Verify each describe has at least one test
+**Verify**: All required test utilities are imported before test definitions.
 
-6. **Write assertions matching project style**
-   - Use `expect()` with `.toEqual()`, `.toBeDefined()`, `.rejects.toThrow()`
-   - For async: `await expect(asyncFn()).resolves.toEqual(...)`
-   - For errors: `await expect(asyncFn()).rejects.toThrow('message')`
-   - Verify assertion matches the actual return type
+### Step 3: Set up module mocking (if needed)
+If testing a module that imports other modules you want to mock:
+
+```typescript
+vi.mock('../config.js', () => ({
+  loadConfig: vi.fn(),
+  writeConfigFile: vi.fn(),
+}));
+```
+
+For complex mocks with test-time factory functions (hoisted):
+```typescript
+const { mockLoadConfig } = vi.hoisted(() => ({
+  mockLoadConfig: vi.fn(),
+}));
+
+vi.mock('../config.js', () => ({
+  loadConfig: () => mockLoadConfig(),
+}));
+```
+
+For unmocking global setup mocks (e.g., to test llm/index.js itself):
+```typescript
+vi.unmock('../index.js');
+```
+
+Place all `vi.mock()` and `vi.unmock()` calls BEFORE importing the module under test.
+
+**Verify**: Mock declarations appear before the import of the module being tested.
+
+### Step 4: Organize tests in describe blocks
+Group related tests with `describe()`:
+```typescript
+describe('functionName', () => {
+  it('returns X when Y', () => {
+    // test body
+  });
+});
+```
+
+**Verify**: Each `it()` test has a clear, complete assertion.
+
+### Step 5: Manage environment and process state
+For tests that modify `process.env` or `process.argv`:
+
+```typescript
+describe('config tests', () => {
+  const originalEnv = process.env;
+  const originalArgv = process.argv;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv }; // Copy, not reference
+    process.argv = [...originalArgv];
+    delete process.env.SPECIFIC_VAR; // Explicitly remove vars to test absence
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    process.argv = originalArgv;
+  });
+
+  it('tests env var behavior', () => {
+    process.env.MY_VAR = 'test';
+    // test code
+  });
+});
+```
+
+**Verify**: `beforeEach` creates a copy of env/argv; `afterEach` restores originals; unused env vars are explicitly deleted with `delete process.env.VAR`.
+
+### Step 6: Manage temporary files and directories
+For file system tests, create temporary directories and clean them up:
+
+```typescript
+describe('file tree', () => {
+  const dirs: string[] = [];
+  
+  afterEach(() => {
+    for (const d of dirs) {
+      try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
+    }
+    dirs.length = 0;
+  });
+
+  it('processes files', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'caliber-test-'));
+    dirs.push(tmp);
+    // use tmp directory
+  });
+});
+```
+
+**Verify**: All temporary directories are pushed to a cleanup array and removed in `afterEach`.
+
+### Step 7: Handle mock state cleanup
+Before each test, clear mock call history to avoid pollution between tests:
+
+```typescript
+beforeEach(() => {
+  vi.clearAllMocks(); // Reset all mock call counts and return values
+});
+
+afterEach(() => {
+  vi.restoreAllMocks(); // Restore original implementations
+  vi.resetModules(); // Reset cached module imports (if you reload modules)
+});
+```
+
+**Verify**: `beforeEach` calls `vi.clearAllMocks()` for providers and `afterEach` calls `vi.restoreAllMocks()`.
+
+### Step 8: Test assertions
+Write assertions using `expect()`. Match the patterns from existing tests:
+
+```typescript
+// Simple checks
+expect(value).toBe(expected);
+expect(array).toContain(item);
+expect(fn).toThrow('error message');
+
+// Instance checks
+expect(obj).toBeInstanceOf(ClassName);
+
+// Mock checks
+expect(mockFn).toHaveBeenCalledTimes(1);
+expect(mockFn).toHaveBeenCalledWith(arg);
+
+// File system checks
+expect(fs.existsSync(path)).toBe(true);
+```
+
+**Verify**: Each test has at least one assertion and uses appropriate `expect()` matchers.
+
+### Step 9: Run tests
+Run tests locally before committing:
+```bash
+pnpm test                # Run all tests in watch mode
+pnpm test:coverage       # Check coverage thresholds
+pnpm test -- src/my/path/__tests__/my.test.ts  # Run single test file
+```
+
+**Verify**: All tests pass and coverage thresholds are met (lines: 50%, functions: 50%, branches: 50%).
 
 ## Examples
 
-**User says: "Write tests for src/scoring/index.ts"**
+### Example 1: Testing a module with environment variables (config.test.ts pattern)
 
-Actions:
-1. Create `src/scoring/__tests__/index.test.ts`
-2. Import: `import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'`
-3. Import under test: `import { scoreConfig } from '../index.js'`
-4. Set up env var handling:
-   ```typescript
-   let savedEnv: Record<string, string | undefined>
-   beforeEach(() => {
-     savedEnv = { ...process.env }
-   })
-   afterEach(() => {
-     Object.assign(process.env, savedEnv)
-     delete process.env.CUSTOM_VAR
-   })
-   ```
-5. Write test using global `mockLLM`:
-   ```typescript
-   describe('scoreConfig', () => {
-     it('should score with default weights', async () => {
-       const result = await scoreConfig({ /* ... */ })
-       expect(result.score).toBeDefined()
-       expect(mockLLM).toHaveBeenCalled()
-     })
-   })
-   ```
+**User asks**: "Write tests for my config loader that reads from env vars and a config file."
 
-Result: Test file at correct path, uses global mock, cleans up env vars, follows project conventions.
+**Actions taken**:
+1. Create `src/lib/__tests__/config.test.ts`
+2. Import test framework and fs module
+3. Mock `fs` and `os`
+4. Save/restore `process.env` in beforeEach/afterEach
+5. Delete specific env vars to test absence
+6. Test each branch: env vars set, file exists, both, neither
+
+**Result**:
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+
+vi.mock('fs');
+vi.mock('os', () => ({ default: { homedir: () => '/home/user' } }));
+
+import { loadConfig } from '../config.js';
+
+describe('config', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns env config when ANTHROPIC_API_KEY is set', () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test';
+    const config = loadConfig();
+    expect(config?.provider).toBe('anthropic');
+  });
+
+  it('returns null when no env vars set', () => {
+    expect(loadConfig()).toBeNull();
+  });
+});
+```
+
+### Example 2: Testing file system operations with temp cleanup (file-tree.test.ts pattern)
+
+**User asks**: "Write tests for file tree analysis."
+
+**Actions taken**:
+1. Create `src/fingerprint/__tests__/file-tree.test.ts`
+2. Set up a cleanup array for temp directories
+3. Create temp dirs in each test and push to cleanup array
+4. Clean up all temp dirs in afterEach
+5. Test with various file mtimes and directory structures
+
+**Result**:
+```typescript
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { getFileTree } from '../file-tree.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
+  }
+  dirs.length = 0;
+});
+
+describe('getFileTree', () => {
+  it('returns files sorted by mtime descending', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'caliber-ft-'));
+    dirs.push(tmp);
+
+    fs.writeFileSync(path.join(tmp, 'a.ts'), 'a');
+    fs.writeFileSync(path.join(tmp, 'b.ts'), 'b');
+    const tree = getFileTree(tmp);
+    expect(tree).toHaveLength(2);
+  });
+});
+```
+
+### Example 3: Testing with module mocking and factory functions (index.test.ts pattern)
+
+**User asks**: "Write tests for the provider factory that instantiates different providers based on config."
+
+**Actions taken**:
+1. Create `src/llm/__tests__/index.test.ts`
+2. Use `vi.unmock('../index.js')` to test the real module
+3. Create mock classes in `vi.hoisted()`
+4. Mock dependencies (config, provider classes)
+5. Test provider selection logic
+6. Use `resetProvider()` between tests to clear cached instances
+
+**Result**:
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.unmock('../index.js');
+
+const { mockLoadConfig, MockAnthropicProvider } = vi.hoisted(() => {
+  class MockAnthropicProvider {
+    config: unknown;
+    call = vi.fn();
+    constructor(c: unknown) { this.config = c; }
+  }
+  return {
+    mockLoadConfig: vi.fn(),
+    MockAnthropicProvider,
+  };
+});
+
+vi.mock('../config.js', () => ({
+  loadConfig: () => mockLoadConfig(),
+}));
+
+vi.mock('../anthropic.js', () => ({
+  AnthropicProvider: MockAnthropicProvider,
+}));
+
+import { getProvider, resetProvider } from '../index.js';
+
+describe('getProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetProvider();
+  });
+
+  it('creates AnthropicProvider for anthropic config', () => {
+    mockLoadConfig.mockReturnValue({
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      apiKey: 'sk-test',
+    });
+    const provider = getProvider();
+    expect(provider).toBeInstanceOf(MockAnthropicProvider);
+  });
+});
+```
 
 ## Common Issues
 
-**Error: "Cannot find module '../test/setup.js'"**
-- Verify import path uses `.js` extension (ESM)
-- If accessing `mockLLM`, ensure it's imported: `import { mockLLM } from '../test/setup.js'`
-- Check that setup.ts exports the mock in src/test/setup.ts
+**"Cannot find module" when running tests**
+- **Cause**: `vi.mock()` called after the import statement
+- **Fix**: Move all `vi.mock()` and `vi.unmock()` calls to the TOP of the file, before any `import` statements
 
-**Error: "Test timeout" or "mock not called"**
-- Verify `vi.mock()` is at top of file, before all imports
-- Check that mocked module path matches actual import in source file
-- Ensure async test uses `await` or returns Promise: `it('name', async () => { ... })`
+**Environment variable persists across tests**
+- **Cause**: `beforeEach` assigns by reference instead of copying: `process.env = originalEnv`
+- **Fix**: Create a copy in `beforeEach`: `process.env = { ...originalEnv }; delete process.env.VAR`
 
-**Error: "process.env.VAR is not defined in next test"**
-- Verify `afterEach` restores env vars: `Object.assign(process.env, savedEnv)`
-- Check that `beforeEach` saves original: `const savedEnv = { ...process.env }`
-- If adding new env vars, delete them: `delete process.env.NEW_VAR` in afterEach
+**Temporary files not cleaned up, filling disk**
+- **Cause**: `afterEach` not called or temp paths not tracked
+- **Fix**: Use centralized cleanup array: `dirs: string[] = []` pushed to in tests, cleaned in `afterEach` with `fs.rmSync(..., { recursive: true, force: true })`
+
+**Mock return value from previous test bleeds into next test**
+- **Cause**: `vi.clearAllMocks()` not called in `beforeEach`
+- **Fix**: Add `vi.clearAllMocks()` as first statement in `beforeEach`
+
+**"vi.mocked() is not a function" when accessing mock calls**
+- **Cause**: Trying to use `vi.mocked()` on a non-mocked module
+- **Fix**: Ensure the module is mocked with `vi.mock()` before importing, then cast: `const mockFn = vi.mocked(importedFn)`
 
 **Test passes locally but fails in CI**
-- Verify no hardcoded absolute paths (use relative imports)
-- Check that mocks reset between tests: add `mockLLM.mockReset()` in afterEach
-- Ensure test doesn't depend on file system state (use memfs for file operations)
+- **Cause**: Tests rely on real file system or network (not mocked)
+- **Fix**: Check if temp files are being created in real directories instead of mocked ones. Verify all external calls use `vi.mock()` for fs/http/exec
+
+**Coverage threshold failures: "lines not covered", "statements not covered"**
+- **Cause**: Branches or error paths not tested
+- **Fix**: Run `pnpm test:coverage` locally to see untested lines. Add `it()` tests for error cases, edge conditions, and branches that return different values
+- **Example**: If `if (x) return 'a'; else return 'b';` has 0% branch coverage, add tests: one with x=true, one with x=false
+
+**"expected 1 error but got 0" when testing error throws**
+- **Cause**: Error not actually thrown, or thrown asynchronously
+- **Fix**: For sync functions: `expect(() => fn()).toThrow('message')`. For async: `expect(async () => { await fn() }).rejects.toThrow('message')` or use `await expect(promise).rejects.toThrow()`
+
+**Mock factory returns undefined**
+- **Cause**: `vi.hoisted()` variables used before definition in the same block
+- **Fix**: Ensure `vi.hoisted()` block returns all factories, and `vi.mock()` blocks use them after the hoisted definition
+
+**Test flakes (sometimes passes, sometimes fails)**
+- **Cause**: Timing issues or file system race conditions in cleanup
+- **Fix**: For file cleanup, use `{ force: true }` in `rmSync`. For timing, avoid `setTimeout`; use `vi.useFakeTimers()` and `vi.runAllTimers()` if needed. Check for leftover files from previous test runs in `beforeEach`

--- a/.agents/skills/llm-provider/SKILL.md
+++ b/.agents/skills/llm-provider/SKILL.md
@@ -1,144 +1,247 @@
 ---
 name: llm-provider
-description: Adds a new LLM provider implementing LLMProvider interface from src/llm/types.ts with call() and stream() methods. Integrates config in src/llm/config.ts, factory in src/llm/index.ts, and error handling. Use when adding new provider, 'add LLM backend', integrating external API. Do NOT use for modifying existing providers or debugging provider issues.
+description: Adds a new LLM provider implementing LLMProvider interface with call() and stream() methods. Integrates with provider factory in src/llm/index.ts, config detection in src/llm/config.ts, and error handling via tracking and recovery. Use when adding a new model backend, integrating a third-party LLM API, or extending LLM platform support. Do NOT use for fixing bugs in existing providers, modifying existing provider behavior, or changing the LLMProvider interface.
+paths:
+  - src/llm/**/*.ts
+  - src/llm/__tests__/**/*.ts
 ---
 # LLM Provider
 
 ## Critical
 
-- **Interface contract**: Provider MUST implement `LLMProvider` from `src/llm/types.ts` — both `call()` (non-streaming) and `stream()` methods are required
-- **No authentication in code**: API keys/tokens come from env vars only (e.g., `process.env.PROVIDER_API_KEY`). Never hardcode secrets
-- **Validation before integration**: Provider must pass a unit test in `src/llm/__tests__/` before wiring into config/factory
-- **Error handling**: All errors must extend or match the patterns in `src/llm/types.ts` (e.g., `LLMError` or provider-specific exceptions)
+1. **All providers MUST implement the LLMProvider interface** from src/llm/types.ts with three methods:
+   - call(options: LLMCallOptions): Promise<string> — single non-streaming call returning text
+   - stream(options: LLMStreamOptions, callbacks: LLMStreamCallbacks): Promise<void> — streaming call invoking callbacks
+   - listModels?(): Promise<string[]> — optional; list available models from the API
+
+2. **Initialize client in constructor and store defaultModel from config**. Example: `this.client = new YourSDK({ apiKey: config.apiKey })`. Never lazy-initialize on first call — providers are instantiated once and cached in src/llm/index.ts.
+
+3. **For EVERY response in call() and stream(), invoke trackUsage(model, usage)** from src/llm/usage.js before returning/ending. This is mandatory — it captures token metrics for CLI telemetry and cost analysis. If the API doesn't return usage data, estimate via estimateTokens(text), which assumes ~4 chars per token.
+
+4. **Both call() and stream() must respect the model parameter** using pattern: `options.model || this.defaultModel`. Never hardcode model names. Callers supply model overrides via LLMCallOptions.model.
+
+5. **Error handling: catch all errors, preserve error messages unchanged**. The retry logic in src/llm/index.ts handles transient errors (ECONNRESET, socket hang up, 529 overload). For seat-based providers (Cursor, Claude CLI), wrap stderr via parseSeatBasedError() for user-friendly messages.
+
+6. **Always update ProviderType union** (Step 2), DEFAULT_MODELS (Step 4), and createProvider() switch case (Step 5) in lock-step. Missing any one breaks the build or causes runtime Unknown provider error.
 
 ## Instructions
 
-**Step 1: Implement the provider in src/llm/**
+### Step 1: Create provider class file
+Verify directory exists: `ls -la src/llm/`. Create `src/llm/your-provider.ts`. Match existing provider patterns (src/llm/anthropic.ts, src/llm/openai-compat.ts).
 
-Create `src/llm/{provider-name}.ts` implementing `LLMProvider<TConfig>` from `src/llm/types.ts`.
-
-Reference existing providers:
-- `anthropic.ts` — streaming via `message_start`, `content_block_delta` events
-- `openai-compat.ts` — standard OpenAI-compatible API
-- `cursor-acp.ts` — headless agent mode with `--stream-partial-output`
-
-Implement:
+Minimal structure:
 ```typescript
-export class MyProvider implements LLMProvider<MyConfig> {
-  constructor(config: MyConfig) { this.config = config; }
-  
-  async call(request: LLMRequest): Promise<string> {
-    // Non-streaming call
-    // Return full text response
+import type { LLMProvider, LLMCallOptions, LLMStreamOptions, LLMStreamCallbacks, LLMConfig, TokenUsage } from './types.js';
+import { trackUsage } from './usage.js';
+import { estimateTokens } from './utils.js';
+
+export class YourProviderProvider implements LLMProvider {
+  private client: YourSDKType;
+  private defaultModel: string;
+
+  constructor(config: LLMConfig) {
+    if (!config.apiKey) throw new Error('API key required');
+    this.client = new YourSDK({ apiKey: config.apiKey, ...(config.baseUrl && { baseURL: config.baseUrl }) });
+    this.defaultModel = config.model;
   }
-  
-  async *stream(request: LLMRequest): AsyncGenerator<string> {
-    // Streaming call — yield text chunks
-    // Handle protocol-specific events (if any)
+
+  async call(options: LLMCallOptions): Promise<string> {
+    const model = options.model || this.defaultModel;
+    const response = await this.client.messages.create({ model, max_tokens: options.maxTokens || 4096, system: options.system, messages: [{ role: 'user', content: options.prompt }] });
+    trackUsage(model, { inputTokens: response.usage?.input_tokens || 0, outputTokens: response.usage?.output_tokens || 0 });
+    return response.content?.[0]?.text || '';
+  }
+
+  async stream(options: LLMStreamOptions, callbacks: LLMStreamCallbacks): Promise<void> {
+    const model = options.model || this.defaultModel;
+    const messages = [...(options.messages || []), { role: 'user' as const, content: options.prompt }];
+    try {
+      const stream = await this.client.stream({ model, max_tokens: options.maxTokens || 10240, system: options.system, messages });
+      let stopReason: string | undefined, usage: TokenUsage | undefined;
+      for await (const chunk of stream) {
+        if (chunk.delta?.text) callbacks.onText(chunk.delta.text);
+        if (chunk.delta?.stop_reason) stopReason = chunk.delta.stop_reason;
+        if (chunk.usage) usage = { inputTokens: chunk.usage.input_tokens, outputTokens: chunk.usage.output_tokens };
+      }
+      if (usage) trackUsage(model, usage);
+      callbacks.onEnd({ stopReason, usage });
+    } catch (error) { callbacks.onError(error instanceof Error ? error : new Error(String(error))); }
   }
 }
 ```
 
-**Verify**: Type-check passes (`npx tsc --noEmit`) and provider exports correctly.
+Verify: File exports the class; imports match existing providers.
 
-**Step 2: Add configuration in src/llm/config.ts**
-
-Register provider type and config interface in `src/llm/config.ts` alongside existing providers (`anthropic`, `openai`, `cursor`, `claude-cli`).
-
-Add to union type:
+### Step 2: Add to ProviderType union
+Edit `src/llm/types.ts` line 1. Add your provider in kebab-case:
 ```typescript
-export type LLMConfig = AnthropicConfig | OpenAIConfig | MyProviderConfig | ...;
+export type ProviderType = 'anthropic' | 'vertex' | 'openai' | 'cursor' | 'claude-cli' | 'your-provider';
 ```
+Verify: `npx tsc --noEmit` shows no ProviderType errors.
 
-Add config interface:
+### Step 3: Add config fields
+If your provider needs fields beyond apiKey, model, baseUrl, extend LLMConfig in src/llm/types.ts:
 ```typescript
-export interface MyProviderConfig {
-  provider: 'my-provider';
-  apiKey?: string; // optional if using env var
+export interface LLMConfig {
+  provider: ProviderType;
   model: string;
-  // other settings
+  fastModel?: string;
+  apiKey?: string;
+  baseUrl?: string;
+  yourProviderSecret?: string;
 }
 ```
 
-**Verify**: Config merges into `LLMConfig` union without conflicts.
+### Step 4: Update config.ts
+Edit `src/llm/config.ts`:
 
-**Step 3: Wire into factory in src/llm/index.ts**
-
-Update `src/llm/index.ts` `createLLMClient()` function to instantiate provider:
-
+**Line 9:** Add to DEFAULT_MODELS:
 ```typescript
-case 'my-provider':
-  return new MyProvider(config as MyProviderConfig);
+export const DEFAULT_MODELS: Record<ProviderType, string> = {
+  anthropic: 'claude-sonnet-4-6',
+  vertex: 'claude-sonnet-4-6',
+  openai: 'gpt-5.4-mini',
+  cursor: 'sonnet-4.6',
+  'claude-cli': 'default',
+  'your-provider': 'your-provider/default-model',
+};
 ```
 
-Add import at top:
+**Line 17:** Add to MODEL_CONTEXT_WINDOWS if known:
 ```typescript
-import { MyProvider } from './my-provider.js';
+export const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
+  'your-provider/model-name': 128_000,
+};
 ```
 
-**Verify**: Factory passes config correctly and type-checks.
+**Line 59:** In resolveFromEnv(), add env detection before final return null:
+```typescript
+if (process.env.YOUR_PROVIDER_API_KEY) {
+  return {
+    provider: 'your-provider',
+    apiKey: process.env.YOUR_PROVIDER_API_KEY,
+    model: process.env.CALIBER_MODEL || DEFAULT_MODELS['your-provider'],
+    baseUrl: process.env.YOUR_PROVIDER_BASE_URL,
+  };
+}
+```
 
-**Step 4: Write unit test in src/llm/__tests__/**
+**Line 115:** In readConfigFile() validation, add 'your-provider' to includes list.
 
-Create `src/llm/__tests__/my-provider.test.ts` with:
-- Mock API responses matching provider's protocol
-- `call()` test: verify request format, response parsing
-- `stream()` test: verify chunk parsing, event handling
-- Error handling test (invalid API key, timeout, malformed response)
+Verify: `npm run test -- src/llm/__tests__/ -t config` confirms env var detection works.
 
-Use existing test patterns from `anthropic.test.ts` or `openai-compat.test.ts`.
+### Step 5: Register in factory
+Edit `src/llm/index.ts`. Add import (line ~4):
+```typescript
+import { YourProviderProvider } from './your-provider.js';
+```
 
-**Verify**: `npm run test -- src/llm/__tests__/my-provider.test.ts` passes.
+In createProvider() switch (line ~24), add before default case:
+```typescript
+case 'your-provider':
+  return new YourProviderProvider(config);
+```
 
-**Step 5: Test integration**
+Verify: `npx tsc --noEmit` passes; no type errors on switch cases.
 
-Run full LLM test suite:
+### Step 6: Write tests
+Create `src/llm/__tests__/your-provider.test.ts`:
+```typescript
+import { describe, it, expect, beforeEach } from 'vitest';
+import { YourProviderProvider } from '../your-provider.js';
+
+describe('YourProviderProvider', () => {
+  let provider: YourProviderProvider;
+  beforeEach(() => {
+    provider = new YourProviderProvider({ provider: 'your-provider', model: 'test', apiKey: 'test' });
+  });
+
+  it('implements LLMProvider interface', () => {
+    expect(typeof provider.call).toBe('function');
+    expect(typeof provider.stream).toBe('function');
+  });
+
+  it('call() returns string', async () => {
+    const result = await provider.call({ system: 'helpful', prompt: 'hi' });
+    expect(typeof result).toBe('string');
+  });
+
+  it('stream() invokes callbacks', async () => {
+    const texts: string[] = [];
+    let ended = false;
+    await provider.stream({ system: 'helpful', prompt: 'hi' }, {
+      onText: (t) => texts.push(t),
+      onEnd: () => { ended = true; },
+      onError: () => {},
+    });
+    expect(ended).toBe(true);
+  });
+});
+```
+
+Verify: `npm run test -- src/llm/__tests__/your-provider.test.ts` passes.
+
+### Step 7: Integration test
+Run factory tests with your provider env var:
 ```bash
-npm run test -- src/llm/
+YOUR_PROVIDER_API_KEY=test npm run test -- src/llm/__tests__/index.test.ts
 ```
-
-Test config loading:
-```bash
-npm run build && npx caliber config --check
-```
-
-If provider requires user setup (interactive prompts), add to `src/commands/interactive-provider-setup.ts` following patterns for Anthropic/OpenAI.
+Verify: getProvider() instantiates your provider; llmCall() dispatches correctly.
 
 ## Examples
 
-**User says**: "Add support for Groq API"
+### Example 1: Local LM Studio server
+User says: "I need caliber to use my local LM Studio instance."
 
-**Actions**:
-1. Create `src/llm/groq.ts` → implement `LLMProvider` with OpenAI-compatible fetch calls
-2. Update `src/llm/config.ts` → add `GroqConfig` type with `model`, `apiKey` fields
-3. Update `src/llm/index.ts` → factory case for `'groq'`
-4. Write `src/llm/__tests__/groq.test.ts` → mock Groq API responses, test `call()` and `stream()`
-5. Run: `npm run test -- src/llm/groq.test.ts` → passes
+Actions: Create src/llm/lm-studio.ts extending OpenAICompatProvider. Add 'lm-studio' to ProviderType. In config.ts:
+```typescript
+if (process.env.LM_STUDIO_BASE_URL) {
+  return { provider: 'lm-studio', apiKey: '', model: 'local', baseUrl: process.env.LM_STUDIO_BASE_URL };
+}
+```
+Register in createProvider() case. User: `export LM_STUDIO_BASE_URL=http://localhost:8000/v1`. Result: caliber uses local LM Studio; tokens estimated via estimateTokens().
 
-**Result**: User can set `LLM_PROVIDER=groq` and `GROQ_API_KEY=...`, caliber uses Groq for all LLM calls.
+### Example 2: Ollama (seat-based)
+User says: "Ollama is auto-detected; no API key needed."
+
+Actions: Create src/llm/ollama.ts extending OpenAICompatProvider. Add 'ollama' to ProviderType and SEAT_BASED_PROVIDERS. In config.ts:
+```typescript
+if (process.env.OLLAMA_HOST) {
+  return { provider: 'ollama', model: 'mistral', baseUrl: process.env.OLLAMA_HOST || 'http://localhost:11434/v1' };
+}
+```
+Result: Offline per-machine LLM without API keys.
 
 ## Common Issues
 
-**"Cannot find module './my-provider'"**
-- Verify file is named `src/llm/{provider-name}.ts` (kebab-case)
-- Import uses `.js` extension: `import { MyProvider } from './my-provider.js'`
-- Run `npm run build` to check TypeScript
+**Unknown provider: your-provider**
+- Cause: ProviderType updated but createProvider() case missing.
+- Fix: Add case in src/llm/index.ts and import the class.
 
-**"MyProvider does not implement LLMProvider"**
-- Ensure both `call()` and `stream()` methods exist and match signature in `src/llm/types.ts`
-- `call()` returns `Promise<string>`, `stream()` returns `AsyncGenerator<string>`
-- Run `npx tsc --noEmit` for full type errors
+**Cannot find module './your-provider.js'**
+- Cause: File named your_provider.ts (underscore) not your-provider.ts (kebab).
+- Fix: Rename file to use kebab-case.
 
-**"Provider not found in factory"**
-- Check `src/llm/index.ts` `createLLMClient()` has `case 'my-provider'` matching config type
-- Verify config union in `src/llm/config.ts` includes `MyProviderConfig`
+**API key is required for YourProvider**
+- Cause: Env var YOUR_PROVIDER_API_KEY not set; resolveFromEnv() didn't detect it.
+- Fix: Verify env var name in config.ts matches. Test: `YOUR_PROVIDER_API_KEY=test npm run test -- src/llm/__tests__/index.test.ts`.
 
-**"API key undefined at runtime"**
-- Provider reads from `process.env.PROVIDER_API_KEY` or `config.apiKey`
-- User must set env var or pass in config
-- Check `.env` file or shell: `echo $PROVIDER_API_KEY`
+**LLM response did not include usage tokens**
+- Cause: Provider API doesn't return usage (local models).
+- Fix: Estimate tokens: `trackUsage(model, { inputTokens: estimateTokens(options.system + options.prompt), outputTokens: estimateTokens(response.text) });`
 
-**"Stream yields nothing / incomplete chunks"**
-- Verify `stream()` parses protocol correctly (event vs. line delimiters)
-- Test against mock: `npm run test -- src/llm/__tests__/my-provider.test.ts`
-- Compare event structure to `anthropic.ts` (SSE) or `openai-compat.ts` (JSON Lines)
+**Stream callbacks never fire; onEnd not called**
+- Cause: Async iterator not fully consumed before method returns.
+- Fix: Ensure iteration completes before onEnd(): `for await (const chunk of stream) { } callbacks.onEnd({ stopReason, usage });`
+
+**My model parameter is ignored**
+- Cause: call()/stream() doesn't use `options.model || this.defaultModel`.
+- Fix: Replace hardcoded model: `const model = options.model || this.defaultModel; const response = await this.client.create({ model, ... });`
+
+**trackUsage() is never called**
+- Cause: Forgot to call trackUsage() in call() or stream().
+- Fix: Add after every response: `trackUsage(model, { inputTokens: ..., outputTokens: ... });`
+
+**Type error: Provider doesn't implement LLMProvider**
+- Cause: Missing method or wrong signature.
+- Fix: Verify all required methods exist with exact signatures from src/llm/types.ts. Copy-paste from anthropic.ts as reference.

--- a/.agents/skills/scoring-checks/SKILL.md
+++ b/.agents/skills/scoring-checks/SKILL.md
@@ -1,114 +1,284 @@
 ---
 name: scoring-checks
-description: Add a new deterministic scoring check in src/scoring/checks/. Returns Check[] array, uses constants from src/scoring/constants.ts, integrates in src/scoring/index.ts. Use when adding scoring logic, creating checks, modifying check weights. Do NOT use for display/UI changes or check result formatting.
+description: Add a new deterministic scoring check in src/scoring/checks/ that evaluates config quality. Follows the Check[] return pattern, uses point constants from src/scoring/constants.ts, and integrates via filterChecksForTarget() in src/scoring/index.ts. Use when user says 'add scoring check', 'new check', 'modify scoring criteria', or works in src/scoring/checks/. Do NOT use for display changes or refactoring scoring logic.
+paths:
+  - src/scoring/checks/**/*.ts
+  - src/scoring/constants.ts
+  - src/scoring/index.ts
 ---
-# Scoring Checks
+# Adding a Scoring Check
+
+Add a new deterministic check that evaluates a single aspect of AI agent config quality. All checks must be filesystem-based with no network calls or LLM inference.
 
 ## Critical
 
-1. **Check must return `Check[]`** — Never return a single check or a Promise. Return an empty array `[]` if the condition fails.
-2. **Use constants from `src/scoring/constants.ts`** — All weights, thresholds, and names must reference constants, never hardcoded values.
-3. **Deterministic only** — No LLM calls. Scoring checks inspect existing files, fingerprint data, and git history. Use `src/fingerprint/` data exclusively.
-4. **File structure**: Create one file per check in `src/scoring/checks/`. Export a default function with signature `(ctx: ScoringContext) => Check[]`.
-5. **Integration point**: Add the check function to the `checks` array in `src/scoring/index.ts` — this is the ONLY place checks are orchestrated.
+- **Check must be deterministic**: Same filesystem state → same result every time. No randomness, no external APIs.
+- **Point values come from constants.ts**: Every `earnedPoints` and `maxPoints` must reference `POINTS_*` from `src/scoring/constants.ts`. Do NOT hardcode numbers.
+- **Always return `Check[]` array**: Export a function `check<Category>(dir: string): Check[]` where category is one of: `existence`, `quality`, `grounding`, `accuracy`, `freshness`, `bonus`.
+- **Every check must have**: `id` (kebab-case, unique), `name`, `category`, `maxPoints`, `earnedPoints`, `passed`, `detail`, and optional `suggestion`/`fix`.
+- **Fix object fields**: `action` (string describing what to do), `data` (context for the fix), `instruction` (user-facing guidance).
+- **Register in src/scoring/index.ts**: Add the import and spread the result into the `allChecks` array in `computeLocalScore()`.
+- **Target filtering**: If the check is platform-specific (Claude-only, Cursor-only, etc.), add its ID to the appropriate `*_ONLY_CHECKS` set in `constants.ts`.
 
 ## Instructions
 
-1. **Create the check file** at `src/scoring/checks/{check-name}.ts`.
-   - Import `Check` type from `../types.js`.
-   - Import constants from `../constants.js`.
-   - Export default function: `export default function {checkName}(ctx: ScoringContext): Check[] { }`
-   - Verify file compiles: `npx tsc --noEmit`.
+### Step 1: Define point constants in src/scoring/constants.ts
 
-2. **Inspect the ScoringContext** to access fingerprint data.
-   - Available: `ctx.fingerprint`, `ctx.manifest` (existing config), `ctx.git` (history).
-   - Example: `ctx.fingerprint.sources` (detected sources), `ctx.fingerprint.files` (file tree).
-   - Verify using `src/scoring/__tests__/` test setup to mock context.
+Verify before proceeding: Is your check measurable with a numeric point value?
 
-3. **Build the Check object**.
-   - `id`: Unique string, lowercase-kebab (e.g., `'existence'`, `'freshness-days-old'`).
-   - `name`: Human-readable display name (e.g., `'CLAUDE.md exists'`).
-   - `points`: Number (0–100). Must reference constant from `src/scoring/constants.ts`.
-   - `reasons`: String array explaining why the check passed/failed (max 1–2 sentences each).
-   - `passed`: Boolean.
-   - Return `[check]` if passed, `[]` if failed.
+Add constants below the appropriate category section (existence, quality, grounding, accuracy, freshness, bonus):
 
-4. **Reference constants for all numeric values**.
-   - Open `src/scoring/constants.ts` and use existing constants or add new ones.
-   - Example: `const POINTS_EXISTENCE = 10` in constants, then use `points: POINTS_EXISTENCE` in check.
-   - Verify constant is exported: `export const POINTS_EXISTENCE = 10`.
-
-5. **Add the check to the orchestrator** in `src/scoring/index.ts`.
-   - Import: `import {checkName} from './checks/{check-name}.js'`.
-   - Add to `checks` array: `{checkName}(ctx),`.
-   - Verify tests pass: `npm test -- src/scoring/__tests__/index.test.ts`.
-
-6. **Write a test** in `src/scoring/checks/__tests__/{check-name}.test.ts`.
-   - Mock `ScoringContext` with fingerprint data using `memfs` or fixtures from existing tests.
-   - Test both pass and fail cases.
-   - Verify test runs: `npx vitest run src/scoring/checks/__tests__/{check-name}.test.ts`.
-
-## Examples
-
-**User says**: "Add a scoring check that verifies CLAUDE.md exists and is not empty."
-
-**Actions**:
-1. Create `src/scoring/checks/existence.ts`:
 ```typescript
-import type { Check, ScoringContext } from '../types.js';
-import { POINTS_EXISTENCE } from '../constants.js';
+// In the appropriate CATEGORY section, e.g., Quality checks (25 pts):
+export const POINTS_YOUR_CHECK_NAME = 4; // 1-12 pts typical
 
-export default function existence(ctx: ScoringContext): Check[] {
-  const claudeMd = ctx.manifest.claude;
-  const passed = claudeMd && claudeMd.trim().length > 0;
+// If threshold-based, add a companion array:
+export const YOUR_THRESHOLD_ARRAY = [
+  { minValue: 10, points: 4 },
+  { minValue: 5, points: 2 },
+] as const;
+```
 
-  if (!passed) {
-    return [];
-  }
+Check existing patterns: Token budgets use `TOKEN_BUDGET_THRESHOLDS`, code blocks use `CODE_BLOCK_THRESHOLDS`, concreteness uses `CONCRETENESS_THRESHOLDS`.
 
-  return [{
-    id: 'existence',
-    name: 'CLAUDE.md exists and is not empty',
-    points: POINTS_EXISTENCE,
-    reasons: ['CLAUDE.md is present and contains configuration.'],
-    passed: true,
-  }];
+Verify: Review `CATEGORY_MAX` object to ensure your check fits within its category's point budget.
+
+### Step 2: Create or edit check function in src/scoring/checks/
+
+Choose the file based on category. Each file exports a `check<Name>(dir: string): Check[]` function:
+
+- `existence.ts` — files/directories exist (CLAUDE.md, .cursorrules, skills, MCP servers)
+- `quality.ts` — config structure, size, clarity (code blocks, token budget, concreteness, duplicates)
+- `grounding.ts` — references to actual project files/directory structure
+- `accuracy.ts` — validity of references, git-based config drift
+- `freshness.ts` — git commit-based staleness, secrets, permissions
+- `bonus.ts` — hooks, learned content, OpenSkills format
+- `sources.ts` — source configuration and usage
+
+Create the function following this structure:
+
+```typescript
+import type { Check } from '../index.js';
+import {
+  POINTS_YOUR_CHECK,
+  YOUR_THRESHOLD_ARRAY,
+} from '../constants.js';
+import { readFileOrNull } from '../utils.js'; // or other helpers
+
+export function checkYourCategory(dir: string): Check[] {
+  const checks: Check[] = [];
+
+  // 1. Measure something concrete
+  const yourMetric = /* e.g., countFiles(), validatePaths(), etc. */;
+  const threshold = YOUR_THRESHOLD_ARRAY.find(t => yourMetric >= t.minValue);
+  const earnedPts = threshold?.points ?? 0;
+
+  checks.push({
+    id: 'your_unique_check_id',
+    name: 'Human-readable check name',
+    category: 'quality', // matches function context
+    maxPoints: POINTS_YOUR_CHECK,
+    earnedPoints: earnedPts,
+    passed: earnedPts >= Math.ceil(POINTS_YOUR_CHECK * 0.6), // or custom logic
+    detail: `${earnedPts}/${POINTS_YOUR_CHECK} points — ${yourMetric} items found`,
+    suggestion: earnedPts >= POINTS_YOUR_CHECK ? undefined : 'Action to improve',
+    fix: earnedPts >= POINTS_YOUR_CHECK ? undefined : {
+      action: 'verb_noun', // e.g., 'add_code_blocks', 'fix_references'
+      data: { currentValue: yourMetric, targetValue: 10 },
+      instruction: 'Specific, actionable guidance for the user.',
+    },
+  });
+
+  return checks;
 }
 ```
 
-2. Add to `src/scoring/constants.ts`: `export const POINTS_EXISTENCE = 10`.
+Verify ID uniqueness: Run `grep -r "'your_unique_check_id'" src/scoring/checks/` — should return only your new check.
 
-3. Update `src/scoring/index.ts`:
+### Step 3: Handle platform-specific filtering (if applicable)
+
+If your check only applies to certain agents (Claude, Cursor, Codex, GitHub Copilot), register it in `src/scoring/constants.ts`:
+
 ```typescript
-import existence from './checks/existence.js';
-// ...
-const checks = [
-  existence(ctx),
-  // other checks
-];
+// Add to the appropriate set:
+export const CLAUDE_ONLY_CHECKS = new Set([
+  'claude_md_exists',
+  'your_new_check_id', // ← add here
+  'claude_rules_exist',
+]);
 ```
 
-4. Test with `npm test`.
+Available sets (update exactly one if applicable):
+- `CLAUDE_ONLY_CHECKS` — Claude Code targets
+- `CURSOR_ONLY_CHECKS` — Cursor targets
+- `CODEX_ONLY_CHECKS` — Codex/OpenCode targets
+- `COPILOT_ONLY_CHECKS` — GitHub Copilot targets
+- `BOTH_ONLY_CHECKS` — Both Claude AND Cursor (cross-platform parity)
+- `NON_CODEX_CHECKS` — Everything except Codex/OpenCode
+- `CLAUDE_OR_CODEX_CHECKS` — Claude OR Codex
 
-**Result**: Check is integrated and appears in score output.
+Verify filtering: Examine `filterChecksForTarget()` in `src/scoring/index.ts` to ensure your category will work correctly for your target agents.
+
+### Step 4: Register in src/scoring/index.ts
+
+Import your function at the top:
+
+```typescript
+import { checkYourCategory } from './checks/your-file.js';
+```
+
+Add to `computeLocalScore()` inside the `allChecks` array initialization:
+
+```typescript
+export function computeLocalScore(dir: string, targetAgent?: TargetAgent): ScoreResult {
+  const target = targetAgent ?? detectTargetAgent(dir);
+
+  const allChecks: Check[] = [
+    ...checkExistence(dir),
+    ...checkQuality(dir),
+    ...checkGrounding(dir),
+    ...checkAccuracy(dir),
+    ...checkYourCategory(dir), // ← ADD HERE IN ORDER
+    ...checkFreshness(dir),
+    ...checkBonus(dir),
+    ...checkSources(dir),
+  ];
+  // ... rest of function
+}
+```
+
+Verify registration: Run `npm test src/scoring/__tests__/accuracy.test.ts` (or similar) — all existing tests should still pass.
+
+### Step 5: Write deterministic unit tests
+
+Create or edit `src/scoring/checks/__tests__/your-file.test.ts`:
+
+```typescript
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { checkYourCategory } from '../your-file.js';
+import { POINTS_YOUR_CHECK } from '../../constants.js';
+
+describe('checkYourCategory', () => {
+  it('awards full points when condition passes', () => {
+    const dir = mkdtempSync('test-scoring-');
+    try {
+      // Set up the passing condition
+      writeFileSync(join(dir, 'SOME_FILE.md'), 'content that satisfies check');
+      
+      const checks = checkYourCategory(dir);
+      const check = checks.find(c => c.id === 'your_unique_check_id');
+      
+      expect(check).toBeDefined();
+      expect(check?.passed).toBe(true);
+      expect(check?.earnedPoints).toBe(POINTS_YOUR_CHECK);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  it('awards zero points when condition fails', () => {
+    const dir = mkdtempSync('test-scoring-');
+    try {
+      // Don't create the required condition
+      const checks = checkYourCategory(dir);
+      const check = checks.find(c => c.id === 'your_unique_check_id');
+      
+      expect(check?.passed).toBe(false);
+      expect(check?.earnedPoints).toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  it('returns correct detail message', () => {
+    const dir = mkdtempSync('test-scoring-');
+    try {
+      const checks = checkYourCategory(dir);
+      const check = checks.find(c => c.id === 'your_unique_check_id');
+      expect(check?.detail).toBeTruthy();
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+});
+```
+
+Run tests: `npm test src/scoring/checks/__tests__/your-file.test.ts`. All must pass before shipping.
+
+## Examples
+
+### Example 1: Existence Check
+
+**Trigger**: User says "Add a check to verify .claude/rules/ directory exists."
+
+**Actions**:
+1. Add `export const POINTS_CLAUDE_RULES = 3;` to constants.ts
+2. In existence.ts: `existsSync(join(dir, '.claude', 'rules'))` → true/false
+3. Import in index.ts and add `...checkExistence(dir)` (already done)
+4. Test with mkdtempSync; verify earnedPoints matches POINTS_CLAUDE_RULES
+
+**Result**: Check `id: 'claude_rules_exist'` returns `earnedPoints: 3, passed: true` when dir exists.
+
+### Example 2: Quality Check with Thresholds
+
+**Trigger**: User says "Verify config has at least 3 code blocks with executable commands."
+
+**Actions**:
+1. Add to constants.ts:
+   ```typescript
+   export const CODE_BLOCK_THRESHOLDS = [
+     { minBlocks: 3, points: 8 },
+     { minBlocks: 2, points: 6 },
+     { minBlocks: 1, points: 3 },
+   ] as const;
+   ```
+2. In quality.ts:
+   - Parse CLAUDE.md with regex to count \`\`\` blocks
+   - Match against CODE_BLOCK_THRESHOLDS
+   - Return points based on threshold match
+3. In fix: Suggest which commands to add
+
+**Result**: 3+ blocks = 8 pts, 2 blocks = 6 pts, 1 block = 3 pts, 0 blocks = 0 pts.
+
+### Example 3: Accuracy Check (Reference Validation)
+
+**Trigger**: User says "Check that all file paths mentioned in config actually exist."
+
+**Actions**:
+1. Add `export const POINTS_REFERENCES_VALID = 8;` to constants.ts
+2. In accuracy.ts:
+   - Extract backtick-quoted paths and dir patterns from config
+   - Check existence with `existsSync(join(dir, path))`
+   - Calculate ratio: `valid / total`
+   - Award partial points: `Math.round(ratio * POINTS_REFERENCES_VALID)`
+3. In fix: List invalid paths the user should fix
+
+**Result**: 80% valid refs = ~6 pts; 100% valid = 8 pts; 0% valid = 0 pts.
 
 ## Common Issues
 
-**"Check is not appearing in score output"**
-- Verify check is added to `checks` array in `src/scoring/index.ts`.
-- Verify it returns `Check[]` (not a single object or Promise).
-- Run `npm run build && npm test` to ensure no import errors.
+**Issue**: "My check doesn't appear in the score report."
+**Fix**: 1) Verify ID in `*_ONLY_CHECKS` if platform-specific. 2) Verify import and spread in `index.ts` `allChecks` array. 3) Run `npm test` to ensure no tsc errors. 4) Check `detectTargetAgent()` returns your target platform.
 
-**"Type error: ScoringContext has no property X"**
-- Check `src/scoring/types.ts` for available context properties.
-- Use `ctx.fingerprint`, `ctx.manifest`, `ctx.git` — not custom properties.
-- Verify fingerprint data exists in test fixture: `console.log(ctx)` in test.
+**Issue**: "Points are hardcoded but should use constants."
+**Fix**: Replace all literal numbers like `earnedPoints: 5` with `earnedPoints: POINTS_YOUR_CHECK`. Constants are in `src/scoring/constants.ts` — use them consistently.
 
-**"Constant is undefined"**
-- Open `src/scoring/constants.ts` and confirm constant is exported.
-- Use `npm run build` to catch missing exports.
-- Add new constants if needed and commit to constants.ts first.
+**Issue**: "Check makes an API call or network request."
+**Fix**: Scoring MUST be deterministic and offline. Use only: `fs` module (readFileSync, existsSync, readdirSync), `path`, `execSync` for git commands. No HTTP, no LLM calls, no external services.
 
-**"Test fails with 'memfs is not found'"**
-- Import from test setup: `import { vol } from 'memfs'`.
-- See existing tests in `src/scoring/checks/__tests__/` for memfs usage patterns.
+**Issue**: "Platform-specific check appears for the wrong agent."
+**Fix**: 1) Verify check ID is in correct `*_ONLY_CHECKS` set. 2) Double-check `filterChecksForTarget()` handles your platform set. 3) Test with `detectTargetAgent()` on a real project.
+
+**Issue**: "Test fails with 'Module not found' error."
+**Fix**: Ensure file is in `src/scoring/checks/` (not nested). Use `.js` extension in imports (TypeScript transpiles to ES modules). Run `npm run build` to check for tsc errors.
+
+**Issue**: "Detail message is confusing or too technical."
+**Fix**: Use friendly language: `3 code blocks found (need 3 for full points)` instead of `codeBlockCount=3`. Make it clear WHY they got/lost points.
+
+**Issue**: "Threshold-based check gives wrong points for edge cases."
+**Fix**: Test all boundaries: value=0, value=threshold, value>>threshold. Use `.find()` to match highest-to-lowest: `find(t => value >= t.minValue)`.
+
+**Issue**: "Two checks have the same ID."
+**Fix**: Run `grep -r "'my_id'" src/scoring/checks/` to find duplicates. IDs must be globally unique across all check files. Use descriptive names like `claude_md_exists`, not `check_1`.

--- a/.agents/skills/writers-pattern/SKILL.md
+++ b/.agents/skills/writers-pattern/SKILL.md
@@ -1,76 +1,272 @@
 ---
 name: writers-pattern
-description: Adds a new platform writer in src/writers/ following existing patterns (claude, cursor, codex). Returns string[] of generated file paths. Integrates with writeSetup() orchestration. Use when implementing 'add platform', 'new writer', 'support new agent'. Do NOT use for refactoring existing writers or modifying writers/index.ts exports.
+description: Add a new platform writer module in src/writers/ that generates and writes agent config files for a supported platform. Each writer exports a function that accepts a config interface, creates directories (rules/, skills/, mcp configs), writes files with proper formatting and frontmatter, and returns string[] of written file paths. Use when adding platform support for a new agent, integrating a new code AI tool, or extending caliber to support new targets. Do NOT use for modifying existing writers, refactoring scoring logic, or changing how writers are invoked.
+paths:
+  - src/writers/*/index.ts
+  - src/writers/__tests__/*.test.ts
+  - src/writers/index.ts
 ---
-# Writers Pattern
+# Platform Writer Pattern
 
 ## Critical
 
-- Each writer MUST export a default function matching the signature: `(config: WriterConfig, skillLines: SkillLine[]) => Promise<string[]>`
-- Writer MUST return full file paths written, not relative paths
-- All writers MUST be exported in `src/writers/index.ts` as named exports
-- Writer files live in `src/writers/{platform}/index.ts` with sibling `__tests__/index.test.ts`
-- Configuration object (`WriterConfig`) is shared across all writers — inspect `src/writers/claude/index.ts` for the exact shape
-- Never hardcode file paths or extension detection — use the `config` object and `skillLines` array passed in
+- **Every writer MUST**:
+  1. Export a single named function: `write<Platform>Config(config: <PlatformConfig>): string[]`
+  2. Accept a platform-specific config interface defining what content to write
+  3. Return `string[]` of all written file paths (used by manifest and progress display)
+  4. Create parent directories with `fs.mkdirSync(dir, { recursive: true })` before writing files
+  5. Wrap skill frontmatter exactly as shown in Step 4 (YAML between `---` markers)
+  6. NOT modify files outside the intended platform directories (e.g., Claude writer only touches `.claude/`, `CLAUDE.md`, `.mcp.json`)
+
+- **Integration point**: Every writer MUST be imported and called in `src/writers/index.ts` within the `writeSetup()` function. Missing this step means the writer will never execute.
+
+- **Validation before Step 1**: Verify the platform name is unique (`ls src/writers/` shows no `<platform>/index.ts`). If it exists, you are modifying, not adding.
 
 ## Instructions
 
-1. **Create directory structure**
-   - Create `src/writers/{platform}/index.ts` (main writer)
-   - Create `src/writers/{platform}/__tests__/index.test.ts` (test file)
-   - Verify directory does not already exist: `ls -la src/writers/{platform}/` should return error
+### Step 1: Define the Platform Config Interface
+Verify the platform name is unique (see Critical). Create `src/writers/<platform>/index.ts`.
 
-2. **Implement writer function signature**
-   - Import `WriterConfig` and `SkillLine` from `src/writers/index.ts`
-   - Export default async function: `export default async function write{Platform}(config: WriterConfig, skillLines: SkillLine[]): Promise<string[]>`
-   - Function receives `config` with properties: `cwd`, `platform`, `agent`, `token` (optional), `quiet` (boolean)
-   - Function receives `skillLines` array of objects with `name`, `description`, `path`, `markdown` properties
-   - Return array of absolute file paths written (e.g., `['/path/to/file1', '/path/to/file2']`)
+At the top of the file, define a config interface that describes all content the writer accepts. The interface MUST include:
+- A main markdown/text file (e.g., `claudeMd`, `cursorrules`, `agentsMd`, `instructions`)
+- Optional nested arrays: `rules`, `skills`, `mcpServers`, `instructionFiles`, etc.
+- Each rule/skill/file has at minimum: `name` or `filename`, `content`, and for skills, `description`
 
-3. **Implement core write logic**
-   - Determine target directory from `config.cwd` (entry point for all writes)
-   - For each skill in `skillLines`, generate platform-specific file(s)
-   - Match file structure of existing writer: inspect `src/writers/claude/index.ts` lines 1–50 for pattern (typically generates SKILL.md or equivalent)
-   - Use `await fs.promises.writeFile()` or Caliber's `writeFile()` helper if available
-   - Catch and handle write errors — log to stderr if `config.quiet` is false
-   - Use `path.resolve()` and `path.join()` for all path operations
+Example (matching GitHub Copilot pattern already in codebase):
+```typescript
+interface CopilotConfig {
+  instructions: string;  // Main content
+  instructionFiles?: Array<{ filename: string; content: string }>;
+}
+```
 
-4. **Add test file**
-   - Create `src/writers/{platform}/__tests__/index.test.ts` with vitest imports
-   - Test the writer function with mock `WriterConfig` and `SkillLine[]` inputs
-   - Assert that returned `string[]` contains expected file paths
-   - Mock file I/O if needed using memfs or spy on `fs.promises.writeFile`
-   - Verify at least one skill is written per test case
+**Validation**: Confirm the interface property names match platform conventions (e.g., Claude uses `claudeMd`, Cursor uses `cursorrules`). Check existing writers: `src/writers/claude/index.ts` line 9, `src/writers/cursor/index.ts` line 9, `src/writers/codex/index.ts` line 5.
 
-5. **Export writer in src/writers/index.ts**
-   - Open `src/writers/index.ts`
-   - Add import: `import write{Platform} from './{platform}/index.js'`
-   - Export as named export in the module exports object (inspect existing claude, cursor, codex exports)
-   - Verify import uses `.js` extension (ESM convention in this project)
+### Step 2: Implement the Writer Export Function
+Export a function named `write<Platform>Config(config: <PlatformConfig>): string[]` that:
 
-6. **Verify integration**
-   - Run `npm run build` — must compile without errors
-   - Run `npm run test -- src/writers/{platform}/__tests__/` — all tests pass
-   - Run `npm run lint` — no linting errors in new writer code
-   - Inspect `src/writers/index.ts` to confirm new writer is exported and callable
+1. Initialize an empty `written: string[] = []` array to track all written paths.
+2. For the **main config file** (e.g., `CLAUDE.md` for Claude, `.cursorrules` for Cursor):
+   - Wrap the content with **platform-specific blocks**: Use helpers from `src/writers/pre-commit-block.ts`
+   - Common blocks: `appendPreCommitBlock(content, platform)`, `appendLearningsBlock(content)`, `appendSyncBlock(content)`
+   - Examples from actual codebase:
+     - **Claude** (`src/writers/claude/index.ts` line 19-22): `appendSyncBlock(appendLearningsBlock(appendPreCommitBlock(config.claudeMd)))`
+     - **Cursor** (`src/writers/cursor/index.ts` line 19-22): No sync block; injects rules instead (pre-commit, learnings, sync as separate files)
+     - **Codex** (`src/writers/codex/index.ts` line 13-16): `appendLearningsBlock(appendPreCommitBlock(config.agentsMd, 'codex'))`
+     - **Copilot** (`src/writers/github-copilot/index.ts` line 19-22): `appendSyncBlock(appendLearningsBlock(appendPreCommitBlock(config.instructions, 'copilot')))`
+   - Write to the exact path (e.g., `fs.writeFileSync('CLAUDE.md', wrappedContent)`) and push to `written`.
+
+3. For **rules** (if applicable): Platform convention determines directory.
+   - Cursor uses `.cursor/rules/`, Claude uses `.claude/rules/` (see `src/writers/index.ts` lines 123-126 and 135-137)
+   - For each rule: create the directory, write to `<dir>/<rule.filename>`, push path to `written`
+   - **Cursor special case** (`src/writers/cursor/index.ts` line 24-27): Cursor injects three system rules:
+     ```typescript
+     const preCommitRule = getCursorPreCommitRule();
+     const learningsRule = getCursorLearningsRule();
+     const syncRule = getCursorSyncRule();
+     const allRules = [...(config.rules || []), preCommitRule, learningsRule, syncRule];
+     ```
+
+4. For **skills**: Write with YAML frontmatter.
+   - Directory pattern: `.claude/skills/<skillName>/SKILL.md`, `.cursor/skills/<skillName>/SKILL.md`, `.agents/skills/<skillName>/SKILL.md`, `.opencode/skills/<skillName>/SKILL.md`
+   - Frontmatter format (exact indentation from `src/writers/claude/index.ts` line 40-47):
+     ```
+     ---
+     name: <skill.name>
+     description: <skill.description>
+     paths:
+       - <optional path pattern 1>
+       - <optional path pattern 2>
+     ---
+     <skill.content>
+     ```
+   - For **Opencode** (`src/writers/opencode/index.ts` line 30): Use `buildSkillContent(skill)` from `src/lib/builtin-skills.js` instead of manual frontmatter.
+   - Create directory with `fs.mkdirSync(skillDir, { recursive: true })`, write skill, push to `written`
+
+5. For **MCP Servers** (if applicable): Write/merge JSON at platform-specific path.
+   - **Claude** (`src/writers/claude/index.ts` line 54-65): `.mcp.json` at root
+   - **Cursor** (`src/writers/cursor/index.ts` line 54-69): `.cursor/mcp.json`
+   - Pattern: Read existing servers (if file exists, try to parse JSON with try/catch), merge with new servers using spread operator `{ ...existingServers, ...config.mcpServers }`, write merged object
+   - Wrap in `{ mcpServers: mergedServers }` and output as pretty-printed JSON: `JSON.stringify(wrapped, null, 2)`
+
+6. For **instruction files** (GitHub Copilot, `src/writers/github-copilot/index.ts` line 26-33): Write to `.github/instructions/` directory.
+   - Create directory, iterate files, write each to `<dir>/<file.filename>`, push paths
+
+Return the `written` array.
+
+**Validation**: Confirm all file write operations are synchronous (`fs.writeFileSync`, `fs.mkdirSync`). Ensure every written path is added to the array. No async operations allowed.
+
+### Step 3: Add Type Exports (if complex interface)
+If the config interface may be reused elsewhere (e.g., in `src/writers/index.ts` for the `AgentSetup` type), export the interface from the module.
+
+**Validation**: Check `src/writers/index.ts` lines 15-19 to see if new agent setup params are needed.
+
+### Step 4: Import and Register in `src/writers/index.ts`
+Open `src/writers/index.ts`. At the top (around line 2-6), add:
+```typescript
+import { write<Platform>Config } from './<platform>/index.js';
+```
+
+Update the `AgentSetup` interface (around line 12-20):
+- Add `'<platform>'` to the `targetAgent` tuple (line 13: `('claude' | 'cursor' | 'codex' | 'opencode' | 'github-copilot' | '<platform>')[]`)
+- Add a new property: `<platform>?: Parameters<typeof write<Platform>Config>[0];`
+
+Update `getFilesToWrite()` function (starting line 117): Add a new conditional block:
+```typescript
+if (setup.targetAgent.includes('<platform>') && setup.<platform>) {
+  files.push('<main-config-file>');
+  if (setup.<platform>.rules) {
+    for (const r of setup.<platform>.rules) files.push(`<rules-dir>/${r.filename}`);
+  }
+  if (setup.<platform>.skills) {
+    for (const s of setup.<platform>.skills) files.push(`<skills-dir>/${s.name}/SKILL.md`);
+  }
+  // ... repeat for other config types (mcpServers, instructionFiles, etc.)
+}
+```
+
+Update `writeSetup()` function (starting line 22): Add a new conditional block before the return (after line 56):
+```typescript
+if (setup.targetAgent.includes('<platform>') && setup.<platform>) {
+  written.push(...write<Platform>Config(setup.<platform>));
+}
+```
+
+**Validation**: Confirm the function call order in `writeSetup()` is consistent (line 37-56): claude → cursor → codex → opencode → github-copilot → (new platform). This ensures AGENTS.md is written once if shared (as with Codex/Opencode, see line 50-52).
+
+### Step 5: Add Tests
+Create `src/writers/__tests__/<platform>.test.ts` following the vitest pattern in `src/writers/__tests__/codex.test.ts`:
+
+1. Mock `fs` module: `vi.mock('fs')`
+2. Mock return values in `beforeEach`: `vi.mocked(fs.existsSync).mockReturnValue(false)`
+3. Test that:
+   - Main config file is written to correct path
+   - Returned array includes all written paths
+   - Directories are created before file writes (use `.toHaveBeenCalledWith(path, { recursive: true })`)
+   - Skills have correct frontmatter format (check `vi.mocked(fs.writeFileSync).mock.calls`)
+   - MCP/instruction files are merged/created correctly
+   - Pre-commit/learnings/sync blocks are included in main file (expect content `.toContain('caliber:managed:pre-commit')`)
+
+Run: `npm test -- src/writers/__tests__/<platform>.test.ts`
+
+**Validation**: All tests pass. Confirm mocked file operations match actual file system structure.
+
+### Step 6: Update `detectSyncedAgents()` in `src/commands/refresh.ts` (Optional)
+If the platform writes config files with distinct naming (e.g., `.newplatform/`), update the detection logic around line 68-77 so end-user refresh output correctly identifies the synced platform:
+
+```typescript
+if (joined.includes('.newplatform/') || joined.includes('newplatform-config')) {
+  agents.push('<Platform Name>');
+}
+```
+
+**Validation**: Run `npm run refresh` and confirm the summary message lists the new platform.
 
 ## Examples
 
-**User says**: "Add support for a new agent platform called Jetbrains"
+### Example 1: Add a hypothetical "DevCode" platform writer
 
-**Actions**:
-1. Create `src/writers/jetbrains/index.ts`
-2. Implement `export default async function writeJetbrains(config: WriterConfig, skillLines: SkillLine[]): Promise<string[]>` — reads `config.cwd`, iterates `skillLines`, writes files to `.jetbrains/rules/` (or platform-specific dir)
-3. Create `src/writers/jetbrains/__tests__/index.test.ts` with tests
-4. Add to `src/writers/index.ts`: `import writeJetbrains from './jetbrains/index.js'` and export
-5. Run build + tests + lint — all pass
+**User says**: "Add support for DevCode, a new agent that reads config from `.devcode/settings.md` and `.devcode/rules/` directory."
 
-**Result**: New writer available via `writeSetup()` orchestration; each skill generates a file in the platform-specific directory and returns full paths written.
+**Actions taken**:
+
+1. Create `src/writers/devcode/index.ts` (matching pattern from `src/writers/claude/index.ts`):
+   ```typescript
+   import fs from 'fs';
+   import path from 'path';
+   import { appendPreCommitBlock, appendLearningsBlock } from '../pre-commit-block.js';
+
+   interface DevcodeConfig {
+     settingsMd: string;
+     rules?: Array<{ filename: string; content: string }>;
+   }
+
+   export function writeDevcodeConfig(config: DevcodeConfig): string[] {
+     const written: string[] = [];
+
+     fs.writeFileSync(
+       '.devcode/settings.md',
+       appendLearningsBlock(appendPreCommitBlock(config.settingsMd, 'devcode'))
+     );
+     written.push('.devcode/settings.md');
+
+     if (config.rules?.length) {
+       const rulesDir = path.join('.devcode', 'rules');
+       if (!fs.existsSync(rulesDir)) fs.mkdirSync(rulesDir, { recursive: true });
+       for (const rule of config.rules) {
+         const rulePath = path.join(rulesDir, rule.filename);
+         fs.writeFileSync(rulePath, rule.content);
+         written.push(rulePath);
+       }
+     }
+
+     return written;
+   }
+   ```
+
+2. Update `src/writers/index.ts`:
+   - Line 2: Add `import { writeDevcodeConfig } from './devcode/index.js';`
+   - Line 13: Change `targetAgent` tuple to include `'devcode'`
+   - Line 19: Add `devcode?: Parameters<typeof writeDevcodeConfig>[0];`
+   - Line 117+: Add devcode block to `getFilesToWrite()` (match Codex pattern lines 144-149)
+   - Line 37+: Add devcode block to `writeSetup()` (match Codex pattern lines 45-47)
+   - Line 68+: Update `detectSyncedAgents()` to check for `.devcode/`
+
+3. Create `src/writers/__tests__/devcode.test.ts` (matching `src/writers/__tests__/codex.test.ts`):
+   ```typescript
+   import { describe, it, expect, vi, beforeEach } from 'vitest';
+   import fs from 'fs';
+   import path from 'path';
+
+   vi.mock('fs');
+
+   import { writeDevcodeConfig } from '../devcode/index.js';
+
+   describe('writeDevcodeConfig', () => {
+     beforeEach(() => {
+       vi.clearAllMocks();
+       vi.mocked(fs.existsSync).mockReturnValue(false);
+     });
+
+     it('writes settings.md and rules', () => {
+       const config = {
+         settingsMd: '# DevCode Config',
+         rules: [{ filename: 'style.md', content: 'Style rules' }],
+       };
+       const written = writeDevcodeConfig(config);
+       expect(written).toContain('.devcode/settings.md');
+       expect(written).toContain(path.join('.devcode', 'rules', 'style.md'));
+     });
+   });
+   ```
+
+4. Run: `npm test && npm run build`
+
+**Result**: Caliber now generates `.devcode/settings.md` and rules on `caliber refresh` and `caliber init`.
 
 ## Common Issues
 
-- **Type error: 'WriterConfig' not found** — Ensure import is `import type { WriterConfig, SkillLine } from '../index.js'` (use `type` keyword for type imports)
-- **Function returns relative paths instead of absolute** — Use `path.resolve(config.cwd, relativePath)` to construct full paths; all returned paths must be absolute
-- **Writer not callable in index.ts exports** — Verify default export function in `{platform}/index.ts` is async and returns `Promise<string[]>`, then check `index.ts` import uses `.js` extension
-- **Tests fail with 'Cannot find module'** — Confirm `__tests__/index.test.ts` imports writer as `import write{Platform} from '../index.js'` (relative path, ESM)
-- **Build fails: 'platform' already exists** — Check if `src/writers/{platform}/` dir exists from prior attempt; remove or use different platform name
+**Issue**: "TypeError: write<Platform>Config is not a function"
+- **Fix**: Verify the function is **exported** (not just defined). Check `export function write<Platform>Config(...)` in the writer file. Missing `export` is a common mistake.
+
+**Issue**: "ENOENT: no such file or directory, open '.platform/config.md'"
+- **Fix**: The parent directory was not created. Ensure `fs.mkdirSync(parentDir, { recursive: true })` is called **before** `fs.writeFileSync(filePath, content)`. See correct order in `src/writers/claude/index.ts` lines 26-27.
+
+**Issue**: "Skill file has no frontmatter / malformed YAML"
+- **Fix**: Verify frontmatter format is exactly (no extra blank lines):
+  ```
+  ---\nname: <name>\ndescription: <desc>\n---\n<content>
+  ```
+  Use `[...].join('\n')` and test with a single skill first. Compare with working code in `src/writers/claude/index.ts` lines 40-48.
+
+**Issue**: "MCP servers not merging, file is truncated"
+- **Fix**: Confirm the merge pattern from `src/writers/claude/index.ts` line 54-65: read existing JSON (with try/catch), parse safely, merge with spread operator `{ ...existingServers, ...config.mcpServers }`, then write the merged object. Do NOT overwrite — always merge.
+
+**Issue**: "new writer is called but written files are empty array"
+- **Fix**: Verify the writer function returns the `written` array. Check that every file operation pushes to `written`. Missing a `written.push(filePath)` after `fs.writeFileSync()` is the most common error. See `src/writers/codex/index.ts` lines 17 and 32 for correct pattern.
+
+**Issue**: "Tests mock fs but actual files are created in .tmp/ or cause permission errors"
+- **Fix**: Ensure `vi.mock('fs')` is at the top of the test file before any imports. All `fs` operations will be mocked and return mock values from `beforeEach` setup. See `src/writers/__tests__/codex.test.ts` line 5.
+
+**Issue**: "Cursor pre-commit rule not applied, or learnings block missing"
+- **Fix**: Cursor injects system rules during the write, unlike Claude which uses block appenders. Check that `getCursorPreCommitRule()`, `getCursorLearningsRule()`, and `getCursorSyncRule()` are called and concatenated with user rules **before** iterating (see `src/writers/cursor/index.ts` lines 24-27). Claude and Codex use block-append helpers instead.

--- a/.cursor/skills/adding-a-command/SKILL.md
+++ b/.cursor/skills/adding-a-command/SKILL.md
@@ -1,106 +1,184 @@
 ---
 name: adding-a-command
-description: Create a new CLI command following Commander.js pattern. Handles command file in src/commands/, registration in src/cli.ts, telemetry tracking via tracked() wrapper, and option parsing. Use when user says 'add command', 'new CLI command', 'create subcommand', or adds files to src/commands/. Do NOT use for modifying existing commands or refactoring command structure.
+description: Creates a new CLI command following the Commander.js pattern in src/commands/. Handles command registration in src/cli.ts, telemetry tracking via tracked() wrapper, and option parsing. Use when user says add command, new CLI command, create subcommand, or adds files to src/commands/. Do NOT use for modifying existing commands or fixing bugs in existing commands.
+paths:
+  - src/commands/**/*.ts
+  - src/cli.ts
 ---
 # Adding a Command
 
 ## Critical
 
-- Commands MUST be registered in `src/cli.ts` using `.command()` and `.action()` with the `tracked()` wrapper for telemetry.
-- Command file MUST be in `src/commands/{commandName}.ts` and export a default async function with signature: `async (options: CommandOptions, ctx: CLIContext) => Promise<void>`.
-- Always use `tracked(commandName, async () => { ... })` wrapper in `src/cli.ts` to enable telemetry tracking.
-- Test file MUST be in `src/commands/__tests__/{commandName}.test.ts` with at least one happy-path test.
+- **Export pattern**: Command must export a named async function: `export async function myCommand(options?: OptionType)`. Never use default exports.
+- **Registration in cli.ts**: Every command must be imported and registered with `.command()` chain in `src/cli.ts`, wrapped with `tracked()` for telemetry.
+- **Error signaling**: Use `throw new Error('__exit__')` to exit gracefully without printing the error message. Use chalk for user-facing messages.
+- **Options typing**: Commands receiving options must define a TypeScript interface for those options. Pass options as a destructured object parameter.
 
 ## Instructions
 
-1. **Create command file** in `src/commands/{commandName}.ts`
-   - Export default async function: `export default async (options: any, ctx: CLIContext) => { ... }`
-   - Import `CLIContext` from `src/cli.ts`
-   - Use `ctx.log()` for output (respects quiet mode via `--quiet`)
-   - Use `ctx.spinner()` for async operations
-   - Verify function signature matches existing commands like `src/commands/score.ts`
+1. **Create the command file** at `src/commands/{commandName}.ts` with named async export.
+   - Signature: `export async function {commandName}Command(options?: { optionName?: optionType }) { ... }`
+   - Import only what you need (avoid kitchen-sink imports).
+   - Return void (handle all output via console.log or chalk).
+   - Verify the file follows the naming convention: camelCase function + "Command" suffix.
 
-2. **Register in src/cli.ts**
-   - Import the command: `import addCommand from './commands/mycommand.js'`
-   - Add command definition:
-     ```ts
-     program
-       .command('mycommand')
-       .description('One-line description')
-       .option('--option', 'Option description')
-       .action(tracked('mycommand', addCommand))
-     ```
-   - Verify imports are `.js` (ESM)
-   - Verify `tracked()` wrapper is applied to `.action()`
+2. **Handle errors consistently**: Wrap error-prone operations in try/catch. Distinguish between user errors and system errors:
+   - User error (bad input): `console.error(chalk.red('message')); throw new Error('__exit__');`
+   - System error (missing dependency): `throw new Error('Detailed error message');` — this will print and exit with code 1.
+   - Parse-like errors: Use ora spinner with `.fail()` before throwing.
+   - This step prevents double error printing in bin.ts.
 
-3. **Add telemetry event** in `src/telemetry/events.ts`
-   - Add event type: `export type MyCommandEvent = { type: 'mycommand:start' | 'mycommand:success' | 'mycommand:error'; ... }`
-   - Include `duration?: number` field for timed events
-   - Update `export type AllEvents = ... | MyCommandEvent`
-   - Verify event matches pattern in existing events
+3. **Import and register in src/cli.ts** in the correct location:
+   - Add import at the top: `import { {commandName}Command } from './commands/{commandName}.js';`
+   - Register the command in the appropriate section (main commands, or nested under a group like `sources`).
+   - For main commands: `.command('{kebab-name}').description('...').option(...).action(tracked('{kebab-name}', {commandName}Command))`
+   - For subcommands (like `sources add`): `sources.command('add').description(...).action(tracked('sources:add', sourcesAddCommand))`
+   - Key: Wrap handler with `tracked('{command-name}', handler)` for automatic telemetry.
+   - Verify the command name in tracked() uses kebab-case for main commands and colon-separated for subcommands.
 
-4. **Create test file** in `src/commands/__tests__/{commandName}.test.ts`
-   - Import `describe`, `it`, `expect`, `vi` from `vitest`
-   - Import command from parent: `import addCommand from '../mycommand.js'`
-   - Create mock `CLIContext`: `{ log: vi.fn(), spinner: vi.fn().mockReturnValue({ start: vi.fn(), stop: vi.fn() }) }`
-   - Test happy path: `await addCommand({}, ctx); expect(ctx.log).toHaveBeenCalled()`
-   - Verify test runs: `npx vitest run src/commands/__tests__/{commandName}.test.ts`
+4. **Define options (if needed)**:
+   - Add `.option()` chains before `.action()`: `.option('--flag', 'Description')` or `.option('--opt <value>', 'Description')`
+   - For parsed options (like comma-separated agents), add a parse function: `.option('--opt <value>', 'Description', parseFunction)`
+   - Pass options to handler: `.action(tracked('name', (opts) => command(opts)))`
+   - Define TypeScript interface for the options object.
+   - Verify option names use camelCase (Commander converts kebab-case flags to camelCase).
 
-5. **Build and validate**
-   - Run `npm run build` → verify no TypeScript errors
-   - Run `npm run lint` → verify ESLint passes
-   - Test command: `node dist/bin.js mycommand --help` → verify options listed
-   - Run `npm run test` → verify new test passes
+5. **Verify before proceeding**:
+   - Function exports correctly and is imported in cli.ts.
+   - Command is registered with tracked() wrapper.
+   - Output uses chalk for colors, not plain console.log.
+   - Error paths throw `new Error('__exit__')` for user errors.
 
 ## Examples
 
-User says: "Add a new `verify` command that checks if config files exist"
+### Example 1: Simple command (status)
 
-**Actions:**
-1. Create `src/commands/verify.ts`:
-   ```ts
-   import { CLIContext } from '../cli.js';
-   export default async (options: any, ctx: CLIContext) => {
-     const spinner = ctx.spinner('Verifying config files...');
-     spinner.start();
-     const exists = await checkFilesExist();
-     spinner.stop();
-     ctx.log(`✓ Config files ${exists ? 'found' : 'missing'}`);
-   };
-   ```
-2. Register in `src/cli.ts`:
-   ```ts
-   import verifyCommand from './commands/verify.js';
-   program
-     .command('verify')
-     .description('Verify configuration files exist')
-     .action(tracked('verify', verifyCommand))
-   ```
-3. Add to `src/telemetry/events.ts`:
-   ```ts
-   export type VerifyEvent = {
-     type: 'verify:start' | 'verify:success' | 'verify:error';
-     duration?: number;
-   };
-   ```
-4. Create `src/commands/__tests__/verify.test.ts` with happy-path test
-5. Run `npm run build && npm run test && npm run lint`
+User says: "Add a command to show config status"
+
+**Actions taken**:
+1. Create src/commands/status.ts with statusCommand() export
+2. Import and register in src/cli.ts with tracked() wrapper
+
+**Result**: `caliber status` displays config status; `caliber status --json` outputs JSON.
+
+Code example:
+```typescript
+import chalk from 'chalk';
+import { loadConfig } from '../llm/config.js';
+
+export async function statusCommand(options?: { json?: boolean }) {
+  const config = loadConfig();
+  
+  if (options?.json) {
+    console.log(JSON.stringify({ configured: !!config }, null, 2));
+    return;
+  }
+  
+  console.log(chalk.bold('Status'));
+  console.log(`  LLM: ${chalk.green(config?.provider || 'Not configured')}`);
+}
+```
+
+Registration in src/cli.ts:
+```typescript
+import { statusCommand } from './commands/status.js';
+program
+  .command('status')
+  .description('Show config status')
+  .option('--json', 'Output as JSON')
+  .action(tracked('status', statusCommand));
+```
+
+---
+
+### Example 2: Subcommand with arguments
+
+User says: "Add a sources add subcommand"
+
+**Actions taken**:
+1. Create src/commands/sources.ts with sourcesAddCommand() export
+2. Register under sources group with tracked('sources:add', ...)
+
+**Result**: `caliber sources add ../lib` adds a source.
+
+Code example:
+```typescript
+export async function sourcesAddCommand(sourcePath: string) {
+  if (!fs.existsSync(sourcePath)) {
+    console.log(chalk.red(`Path not found: ${sourcePath}`));
+    throw new Error('__exit__');
+  }
+  const existing = loadSourcesConfig(process.cwd());
+  existing.push({ type: 'repo', path: sourcePath });
+  writeSourcesConfig(process.cwd(), existing);
+  console.log(chalk.green(`Added ${sourcePath}`));
+}
+```
+
+Registration:
+```typescript
+const sources = program.command('sources');
+sources
+  .command('add')
+  .argument('<path>', 'Path to add')
+  .action(tracked('sources:add', sourcesAddCommand));
+```
+
+---
+
+### Example 3: Command with option parsing
+
+User says: "Add init with --agent flag supporting comma-separated values"
+
+**Actions taken**:
+1. Create parseAgentOption() parser in src/cli.ts
+2. Create src/commands/init.ts with initCommand(options)
+3. Register with custom parser
+
+**Result**: `caliber init --agent claude,cursor` passes parsed array to handler.
+
+Parser code:
+```typescript
+function parseAgentOption(value: string) {
+  const agents = value.split(',').map(s => s.trim().toLowerCase());
+  if (agents.length === 0) {
+    console.error('Invalid agent');
+    process.exit(1);
+  }
+  return agents;
+}
+
+program.command('init')
+  .option('--agent <type>', 'Agents (comma-separated)', parseAgentOption)
+  .action(tracked('init', initCommand));
+```
 
 ## Common Issues
 
-**"Cannot find module './commands/mycommand.js'"**
-- Verify file is at `src/commands/mycommand.ts` (TypeScript)
-- Verify import in `src/cli.ts` uses `.js` extension: `from './commands/mycommand.js'`
-- Rebuild: `npm run build`
+**Issue**: "SyntaxError: The requested module does not provide an export named 'myCommand'"
+- **Cause**: Function not exported or exported as default instead of named.
+- **Fix**: Use `export async function myCommand(...)` (not `export default`).
 
-**"tracked is not exported from src/cli.ts"**
-- Verify `tracked()` function exists in `src/cli.ts` (it should; check existing commands)
-- Verify you're using it as `.action(tracked('commandName', commandFunction))`
+**Issue**: Command appears in help but crashes when run
+- **Cause**: Handler not wrapped with `tracked()` or function import mismatch.
+- **Fix**: Verify import name matches function export. Wrap with `tracked('command-name', handler)`.
 
-**Test fails with "CLIContext is not a constructor"**
-- Create mock object manually: `const ctx = { log: vi.fn(), spinner: vi.fn().mockReturnValue({ start: vi.fn(), stop: vi.fn() }) }`
-- Do NOT try to instantiate CLIContext; it's an interface
+**Issue**: "Error: __exit__" appears in output for user errors
+- **Cause**: Throwing generic error instead of using error exit pattern.
+- **Fix**: Use `console.error(chalk.red('message')); throw new Error('__exit__');` for user-facing errors.
 
-**"--option not recognized" when testing**
-- Verify `.option()` is chained in `src/cli.ts` BEFORE `.action()`
-- Rebuild and test with `npm run build && node dist/bin.js mycommand --help`
+**Issue**: --dry-run flag not recognized
+- **Cause**: Option not declared with `.option()` or wrong camelCase in interface.
+- **Fix**: Add `.option('--dry-run', 'Description')` and ensure options interface has `dryRun?: boolean`.
+
+**Issue**: Subcommand crashes but parent command works
+- **Cause**: Using `program.command()` instead of `groupVar.command()` for subcommands.
+- **Fix**: Register on group: `const sources = program.command('sources'); sources.command('add')...`
+
+**Issue**: Telemetry not appearing
+- **Cause**: Handler not wrapped with `tracked()` or wrong command name.
+- **Fix**: Ensure `.action(tracked('{kebab-case}', handler))` wraps handler. Use colon for subcommands like 'sources:add'.
+
+**Issue**: "Cannot find module" with relative imports
+- **Cause**: Using `.ts` extension in imports.
+- **Fix**: Always use `.js` extension: `import { x } from '../lib/file.js'` (required for ESM).

--- a/.cursor/skills/caliber-testing/SKILL.md
+++ b/.cursor/skills/caliber-testing/SKILL.md
@@ -1,124 +1,370 @@
 ---
 name: caliber-testing
-description: Writes Vitest tests following project patterns: __tests__/ dirs, vi.mock() for modules, global LLM mock from src/test/setup.ts, env var save/restore, and describe/it blocks. Use when user says 'write tests', 'add tests', 'test this', or creates *.test.ts files. Do NOT use for non-test code or documentation.
+description: Writes Vitest tests following project patterns: __tests__/ directories, vi.mock() for module mocking with vi.hoisted() for test-time factories, global LLM mock from src/test/setup.ts, environment variable save/restore in beforeEach/afterEach, vi.clearAllMocks() lifecycle, and test file organization. Use when user says 'write tests', 'add test coverage', 'test this', creates *.test.ts files, or when test failures appear in CI. Do NOT use for non-test code or for debugging without writing tests.
+paths:
+  - src/**/__tests__/*.test.ts
 ---
 # Caliber Testing
 
 ## Critical
 
-- **Test location**: All tests live in `__tests__/` directories at the same level as the code being tested. File names: `<module>.test.ts`.
-- **Global LLM mock**: `src/test/setup.ts` automatically mocks `@anthropic-ai/sdk`, `@anthropic-ai/vertex-sdk`, and `openai`. Do NOT re-mock these in individual tests—use the global mock.
-- **Env var isolation**: Save and restore `process.env` in `beforeEach` / `afterEach`. See example below.
-- **Module mocks**: Use `vi.mock()` at the top of test files with `{ spy: true }` or define default behavior. Always import the real module and use `vi.getMocked()` to assert on calls.
+- All test files MUST be placed in `__tests__/` directories parallel to source files: `src/[module]/__tests__/[module].test.ts`
+- Register any new `__tests__/` directories in `vitest.config.ts`'s `include` glob (already configured: `src/**/*.test.ts`)
+- NEVER mock `src/test/setup.ts` — it is the global LLM provider mock already applied to all tests
+- Environment variable tests MUST save `process.env` in `beforeEach`, restore in `afterEach`, and explicitly delete env vars to test absence
+- Temporary file/directory cleanup MUST happen in `afterEach`, not in individual test cleanup. Use `fs.rmSync(dir, { recursive: true, force: true })`
+- When a test requires unmocking modules mocked in global setup, call `vi.unmock('../module.js')` BEFORE the import statement
+- Run `pnpm test` locally and `pnpm test:coverage` before committing to verify coverage thresholds (lines: 50, functions: 50, branches: 50, statements: 50)
 
 ## Instructions
 
-1. **Create test file in `__tests__/`**
-   - Path: `src/<feature>/__tests__/<module>.test.ts`
-   - Verify the directory exists; create if needed.
+### Step 1: Create the test file in the correct directory
+Create `src/[module]/__tests__/[module].test.ts`. The parent source file is `src/[module]/[module].ts`.
 
-2. **Import testing utilities and the module under test**
-   ```typescript
-   import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
-   import { functionToTest } from '../index.js';
-   ```
-   - Note: Use `.js` import extensions (ESM convention in this project).
+**Verify**: The `__tests__` directory exists at the same level as the source file being tested.
 
-3. **Save/restore env vars if your code reads `process.env`**
-   ```typescript
-   let originalEnv: NodeJS.ProcessEnv;
-   beforeEach(() => {
-     originalEnv = { ...process.env };
-   });
-   afterEach(() => {
-     process.env = originalEnv;
-   });
-   ```
-   - Verify this pattern is in place before running tests.
+### Step 2: Import test framework
+At the top of every test file, import from `vitest`:
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+```
 
-4. **Mock external modules using `vi.mock()` at file top (if needed)**
-   ```typescript
-   vi.mock('../dependency.js', () => ({
-     dependencyFunc: vi.fn().mockResolvedValue({ data: 'test' }),
-   }));
-   ```
-   - Do NOT mock LLM libraries (`@anthropic-ai/sdk`, `openai`, `@anthropic-ai/vertex-sdk`)—the global setup handles them.
-   - Use `{ spy: true }` to spy on the original implementation if needed.
+Add additional imports based on what you're testing:
+- File system: `import fs from 'fs'; import path from 'path'; import os from 'os';`
+- Temporary files: Use `fs.mkdtempSync(path.join(os.tmpdir(), 'caliber-prefix-'))`
+- Exec: `import { execSync } from 'child_process';`
 
-5. **Write test cases using `describe` and `it`**
-   ```typescript
-   describe('functionToTest', () => {
-     it('should return expected value when input is valid', () => {
-       const result = functionToTest('input');
-       expect(result).toBe('expected');
-     });
+**Verify**: All required test utilities are imported before test definitions.
 
-     it('should throw error when input is invalid', () => {
-       expect(() => functionToTest(null)).toThrow('Invalid input');
-     });
-   });
-   ```
-   - Verify test names are descriptive and follow "should..." convention.
+### Step 3: Set up module mocking (if needed)
+If testing a module that imports other modules you want to mock:
 
-6. **For async code, use `async/await` in test functions**
-   ```typescript
-   it('should fetch data', async () => {
-     const result = await fetchData();
-     expect(result).toBeDefined();
-   });
-   ```
-   - Verify the test waits for all promises to resolve before assertions.
+```typescript
+vi.mock('../config.js', () => ({
+  loadConfig: vi.fn(),
+  writeConfigFile: vi.fn(),
+}));
+```
 
-7. **Run tests and verify all pass**
-   ```bash
-   npm run test -- src/<feature>/__tests__/<module>.test.ts
-   ```
-   - Or for the whole feature: `npm run test -- src/<feature>/`
-   - Verify exit code is 0 and all assertions pass.
+For complex mocks with test-time factory functions (hoisted):
+```typescript
+const { mockLoadConfig } = vi.hoisted(() => ({
+  mockLoadConfig: vi.fn(),
+}));
+
+vi.mock('../config.js', () => ({
+  loadConfig: () => mockLoadConfig(),
+}));
+```
+
+For unmocking global setup mocks (e.g., to test llm/index.js itself):
+```typescript
+vi.unmock('../index.js');
+```
+
+Place all `vi.mock()` and `vi.unmock()` calls BEFORE importing the module under test.
+
+**Verify**: Mock declarations appear before the import of the module being tested.
+
+### Step 4: Organize tests in describe blocks
+Group related tests with `describe()`:
+```typescript
+describe('functionName', () => {
+  it('returns X when Y', () => {
+    // test body
+  });
+});
+```
+
+**Verify**: Each `it()` test has a clear, complete assertion.
+
+### Step 5: Manage environment and process state
+For tests that modify `process.env` or `process.argv`:
+
+```typescript
+describe('config tests', () => {
+  const originalEnv = process.env;
+  const originalArgv = process.argv;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv }; // Copy, not reference
+    process.argv = [...originalArgv];
+    delete process.env.SPECIFIC_VAR; // Explicitly remove vars to test absence
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    process.argv = originalArgv;
+  });
+
+  it('tests env var behavior', () => {
+    process.env.MY_VAR = 'test';
+    // test code
+  });
+});
+```
+
+**Verify**: `beforeEach` creates a copy of env/argv; `afterEach` restores originals; unused env vars are explicitly deleted with `delete process.env.VAR`.
+
+### Step 6: Manage temporary files and directories
+For file system tests, create temporary directories and clean them up:
+
+```typescript
+describe('file tree', () => {
+  const dirs: string[] = [];
+  
+  afterEach(() => {
+    for (const d of dirs) {
+      try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
+    }
+    dirs.length = 0;
+  });
+
+  it('processes files', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'caliber-test-'));
+    dirs.push(tmp);
+    // use tmp directory
+  });
+});
+```
+
+**Verify**: All temporary directories are pushed to a cleanup array and removed in `afterEach`.
+
+### Step 7: Handle mock state cleanup
+Before each test, clear mock call history to avoid pollution between tests:
+
+```typescript
+beforeEach(() => {
+  vi.clearAllMocks(); // Reset all mock call counts and return values
+});
+
+afterEach(() => {
+  vi.restoreAllMocks(); // Restore original implementations
+  vi.resetModules(); // Reset cached module imports (if you reload modules)
+});
+```
+
+**Verify**: `beforeEach` calls `vi.clearAllMocks()` for providers and `afterEach` calls `vi.restoreAllMocks()`.
+
+### Step 8: Test assertions
+Write assertions using `expect()`. Match the patterns from existing tests:
+
+```typescript
+// Simple checks
+expect(value).toBe(expected);
+expect(array).toContain(item);
+expect(fn).toThrow('error message');
+
+// Instance checks
+expect(obj).toBeInstanceOf(ClassName);
+
+// Mock checks
+expect(mockFn).toHaveBeenCalledTimes(1);
+expect(mockFn).toHaveBeenCalledWith(arg);
+
+// File system checks
+expect(fs.existsSync(path)).toBe(true);
+```
+
+**Verify**: Each test has at least one assertion and uses appropriate `expect()` matchers.
+
+### Step 9: Run tests
+Run tests locally before committing:
+```bash
+pnpm test                # Run all tests in watch mode
+pnpm test:coverage       # Check coverage thresholds
+pnpm test -- src/my/path/__tests__/my.test.ts  # Run single test file
+```
+
+**Verify**: All tests pass and coverage thresholds are met (lines: 50%, functions: 50%, branches: 50%).
 
 ## Examples
 
-**User says**: "Write tests for the `detectLanguage` function in `src/fingerprint/code-analysis.ts`."
+### Example 1: Testing a module with environment variables (config.test.ts pattern)
 
-**Actions**:
-1. Create `src/fingerprint/__tests__/code-analysis.test.ts`.
-2. Import `detectLanguage` and Vitest utilities.
-3. Mock file I/O if needed: `vi.mock('fs/promises')` (not LLM).
-4. Write test cases:
-   ```typescript
-   import { describe, it, expect, vi } from 'vitest';
-   import { detectLanguage } from '../code-analysis.js';
+**User asks**: "Write tests for my config loader that reads from env vars and a config file."
 
-   vi.mock('fs/promises', () => ({
-     readFile: vi.fn(),
-   }));
+**Actions taken**:
+1. Create `src/lib/__tests__/config.test.ts`
+2. Import test framework and fs module
+3. Mock `fs` and `os`
+4. Save/restore `process.env` in beforeEach/afterEach
+5. Delete specific env vars to test absence
+6. Test each branch: env vars set, file exists, both, neither
 
-   describe('detectLanguage', () => {
-     it('should detect TypeScript from file extension', () => {
-       const lang = detectLanguage('foo.ts');
-       expect(lang).toBe('typescript');
-     });
+**Result**:
+```typescript
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
 
-     it('should detect Python from file extension', () => {
-       const lang = detectLanguage('bar.py');
-       expect(lang).toBe('python');
-     });
+vi.mock('fs');
+vi.mock('os', () => ({ default: { homedir: () => '/home/user' } }));
 
-     it('should return unknown for unrecognized extension', () => {
-       const lang = detectLanguage('data.xyz');
-       expect(lang).toBe('unknown');
-     });
-   });
-   ```
-5. Run: `npm run test -- src/fingerprint/__tests__/code-analysis.test.ts`
+import { loadConfig } from '../config.js';
 
-**Result**: Tests pass, file is committed, patterns replicated in future tests.
+describe('config', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('returns env config when ANTHROPIC_API_KEY is set', () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-ant-test';
+    const config = loadConfig();
+    expect(config?.provider).toBe('anthropic');
+  });
+
+  it('returns null when no env vars set', () => {
+    expect(loadConfig()).toBeNull();
+  });
+});
+```
+
+### Example 2: Testing file system operations with temp cleanup (file-tree.test.ts pattern)
+
+**User asks**: "Write tests for file tree analysis."
+
+**Actions taken**:
+1. Create `src/fingerprint/__tests__/file-tree.test.ts`
+2. Set up a cleanup array for temp directories
+3. Create temp dirs in each test and push to cleanup array
+4. Clean up all temp dirs in afterEach
+5. Test with various file mtimes and directory structures
+
+**Result**:
+```typescript
+import { describe, it, expect, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+import { getFileTree } from '../file-tree.js';
+
+const dirs: string[] = [];
+afterEach(() => {
+  for (const d of dirs) {
+    try { fs.rmSync(d, { recursive: true, force: true }); } catch {}
+  }
+  dirs.length = 0;
+});
+
+describe('getFileTree', () => {
+  it('returns files sorted by mtime descending', () => {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'caliber-ft-'));
+    dirs.push(tmp);
+
+    fs.writeFileSync(path.join(tmp, 'a.ts'), 'a');
+    fs.writeFileSync(path.join(tmp, 'b.ts'), 'b');
+    const tree = getFileTree(tmp);
+    expect(tree).toHaveLength(2);
+  });
+});
+```
+
+### Example 3: Testing with module mocking and factory functions (index.test.ts pattern)
+
+**User asks**: "Write tests for the provider factory that instantiates different providers based on config."
+
+**Actions taken**:
+1. Create `src/llm/__tests__/index.test.ts`
+2. Use `vi.unmock('../index.js')` to test the real module
+3. Create mock classes in `vi.hoisted()`
+4. Mock dependencies (config, provider classes)
+5. Test provider selection logic
+6. Use `resetProvider()` between tests to clear cached instances
+
+**Result**:
+```typescript
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.unmock('../index.js');
+
+const { mockLoadConfig, MockAnthropicProvider } = vi.hoisted(() => {
+  class MockAnthropicProvider {
+    config: unknown;
+    call = vi.fn();
+    constructor(c: unknown) { this.config = c; }
+  }
+  return {
+    mockLoadConfig: vi.fn(),
+    MockAnthropicProvider,
+  };
+});
+
+vi.mock('../config.js', () => ({
+  loadConfig: () => mockLoadConfig(),
+}));
+
+vi.mock('../anthropic.js', () => ({
+  AnthropicProvider: MockAnthropicProvider,
+}));
+
+import { getProvider, resetProvider } from '../index.js';
+
+describe('getProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetProvider();
+  });
+
+  it('creates AnthropicProvider for anthropic config', () => {
+    mockLoadConfig.mockReturnValue({
+      provider: 'anthropic',
+      model: 'claude-sonnet-4-6',
+      apiKey: 'sk-test',
+    });
+    const provider = getProvider();
+    expect(provider).toBeInstanceOf(MockAnthropicProvider);
+  });
+});
+```
 
 ## Common Issues
 
-- **"Cannot find module @anthropic-ai/sdk"**: This means `src/test/setup.ts` was not loaded. Verify `vitest.config.ts` has `setupFiles: ['./src/test/setup.ts']` in the config. Check the vitest.config.ts file for correct setup.
-- **"ReferenceError: vi is not defined"**: Add `import { vi } from 'vitest'` at the top of the test file.
-- **"Module not found: src/llm/anthropic.js"**: Check the import path uses `.js` extension (ESM convention). Verify file exists at `src/llm/anthropic.ts` → import as `./anthropic.js`.
-- **"Timeout: async test did not finish"**: Add `async/await` to test function and ensure all promises are awaited. Example: `it('test', async () => { await fn(); expect(...); });`
-- **"process.env is dirty after test"**: Verify `beforeEach/afterEach` are saving and restoring `process.env`. Add: `beforeEach(() => { originalEnv = { ...process.env }; }); afterEach(() => { process.env = originalEnv; });`
-- **"Mock is not being called"**: Use `vi.getMocked(module).functionName` to assert on mocked function calls. Example: `expect(vi.getMocked(fs).readFile).toHaveBeenCalledWith('path')`.
+**"Cannot find module" when running tests**
+- **Cause**: `vi.mock()` called after the import statement
+- **Fix**: Move all `vi.mock()` and `vi.unmock()` calls to the TOP of the file, before any `import` statements
+
+**Environment variable persists across tests**
+- **Cause**: `beforeEach` assigns by reference instead of copying: `process.env = originalEnv`
+- **Fix**: Create a copy in `beforeEach`: `process.env = { ...originalEnv }; delete process.env.VAR`
+
+**Temporary files not cleaned up, filling disk**
+- **Cause**: `afterEach` not called or temp paths not tracked
+- **Fix**: Use centralized cleanup array: `dirs: string[] = []` pushed to in tests, cleaned in `afterEach` with `fs.rmSync(..., { recursive: true, force: true })`
+
+**Mock return value from previous test bleeds into next test**
+- **Cause**: `vi.clearAllMocks()` not called in `beforeEach`
+- **Fix**: Add `vi.clearAllMocks()` as first statement in `beforeEach`
+
+**"vi.mocked() is not a function" when accessing mock calls**
+- **Cause**: Trying to use `vi.mocked()` on a non-mocked module
+- **Fix**: Ensure the module is mocked with `vi.mock()` before importing, then cast: `const mockFn = vi.mocked(importedFn)`
+
+**Test passes locally but fails in CI**
+- **Cause**: Tests rely on real file system or network (not mocked)
+- **Fix**: Check if temp files are being created in real directories instead of mocked ones. Verify all external calls use `vi.mock()` for fs/http/exec
+
+**Coverage threshold failures: "lines not covered", "statements not covered"**
+- **Cause**: Branches or error paths not tested
+- **Fix**: Run `pnpm test:coverage` locally to see untested lines. Add `it()` tests for error cases, edge conditions, and branches that return different values
+- **Example**: If `if (x) return 'a'; else return 'b';` has 0% branch coverage, add tests: one with x=true, one with x=false
+
+**"expected 1 error but got 0" when testing error throws**
+- **Cause**: Error not actually thrown, or thrown asynchronously
+- **Fix**: For sync functions: `expect(() => fn()).toThrow('message')`. For async: `expect(async () => { await fn() }).rejects.toThrow('message')` or use `await expect(promise).rejects.toThrow()`
+
+**Mock factory returns undefined**
+- **Cause**: `vi.hoisted()` variables used before definition in the same block
+- **Fix**: Ensure `vi.hoisted()` block returns all factories, and `vi.mock()` blocks use them after the hoisted definition
+
+**Test flakes (sometimes passes, sometimes fails)**
+- **Cause**: Timing issues or file system race conditions in cleanup
+- **Fix**: For file cleanup, use `{ force: true }` in `rmSync`. For timing, avoid `setTimeout`; use `vi.useFakeTimers()` and `vi.runAllTimers()` if needed. Check for leftover files from previous test runs in `beforeEach`

--- a/.cursor/skills/llm-provider/SKILL.md
+++ b/.cursor/skills/llm-provider/SKILL.md
@@ -1,81 +1,247 @@
 ---
 name: llm-provider
-description: Adds a new LLM provider implementing LLMProvider interface from src/llm/types.ts with call() and stream() methods. Integrates config in src/llm/config.ts and factory in src/llm/index.ts. Use when adding a new AI backend, integrating a new model API, or extending provider support. Do NOT use for modifying existing providers or debugging provider issues.
+description: Adds a new LLM provider implementing LLMProvider interface with call() and stream() methods. Integrates with provider factory in src/llm/index.ts, config detection in src/llm/config.ts, and error handling via tracking and recovery. Use when adding a new model backend, integrating a third-party LLM API, or extending LLM platform support. Do NOT use for fixing bugs in existing providers, modifying existing provider behavior, or changing the LLMProvider interface.
+paths:
+  - src/llm/**/*.ts
+  - src/llm/__tests__/**/*.ts
 ---
 # LLM Provider
 
 ## Critical
 
-- **All providers must implement `LLMProvider` interface** from `src/llm/types.ts`: `call(messages, params)` and `stream(messages, params)` returning `AsyncIterable<StreamChunk>`
-- **No partial implementations**: Both `call()` and `stream()` must work. Streaming is not optional.
-- **StreamChunk format**: `{ type: 'text' | 'error' | 'usage'; value: string; usage?: { input: number; output: number } }`
-- **Error handling**: Catch provider-specific errors, map to `ChatError` from `src/llm/types.ts` with `code` (e.g., `'auth'`, `'rate_limit'`, `'network'`) and `message`
-- **Model validation**: Call `validateModel(modelId)` in config before accepting the model. Refer to `src/llm/config.ts` for pattern.
+1. **All providers MUST implement the LLMProvider interface** from src/llm/types.ts with three methods:
+   - call(options: LLMCallOptions): Promise<string> — single non-streaming call returning text
+   - stream(options: LLMStreamOptions, callbacks: LLMStreamCallbacks): Promise<void> — streaming call invoking callbacks
+   - listModels?(): Promise<string[]> — optional; list available models from the API
+
+2. **Initialize client in constructor and store defaultModel from config**. Example: `this.client = new YourSDK({ apiKey: config.apiKey })`. Never lazy-initialize on first call — providers are instantiated once and cached in src/llm/index.ts.
+
+3. **For EVERY response in call() and stream(), invoke trackUsage(model, usage)** from src/llm/usage.js before returning/ending. This is mandatory — it captures token metrics for CLI telemetry and cost analysis. If the API doesn't return usage data, estimate via estimateTokens(text), which assumes ~4 chars per token.
+
+4. **Both call() and stream() must respect the model parameter** using pattern: `options.model || this.defaultModel`. Never hardcode model names. Callers supply model overrides via LLMCallOptions.model.
+
+5. **Error handling: catch all errors, preserve error messages unchanged**. The retry logic in src/llm/index.ts handles transient errors (ECONNRESET, socket hang up, 529 overload). For seat-based providers (Cursor, Claude CLI), wrap stderr via parseSeatBasedError() for user-friendly messages.
+
+6. **Always update ProviderType union** (Step 2), DEFAULT_MODELS (Step 4), and createProvider() switch case (Step 5) in lock-step. Missing any one breaks the build or causes runtime Unknown provider error.
 
 ## Instructions
 
-1. **Define provider file** at `src/llm/{provider-name}.ts`
-   - Import `{ LLMProvider, ChatMessage, ChatParams, StreamChunk, ChatError }` from `src/llm/types.ts`
-   - Export class `{ProviderName}Provider implements LLMProvider`
-   - Constructor takes `{ apiKey?: string; model: string; baseUrl?: string }` matching config structure
-   - Store config in instance: `this.apiKey = apiKey || process.env.{PROVIDER_API_KEY}`
-   - Verify API key exists on first call, throw `ChatError` with `code: 'auth'` if missing
+### Step 1: Create provider class file
+Verify directory exists: `ls -la src/llm/`. Create `src/llm/your-provider.ts`. Match existing provider patterns (src/llm/anthropic.ts, src/llm/openai-compat.ts).
 
-2. **Implement `call()` method**
-   - Signature: `async call(messages: ChatMessage[], params: ChatParams): Promise<string>`
-   - Make HTTP request to provider API with messages and params (temperature, max_tokens, etc.)
-   - Extract text from response, return as single string
-   - On error (network, auth, rate limit), throw `ChatError` with appropriate `code` and `message`
-   - Verify this works before proceeding
+Minimal structure:
+```typescript
+import type { LLMProvider, LLMCallOptions, LLMStreamOptions, LLMStreamCallbacks, LLMConfig, TokenUsage } from './types.js';
+import { trackUsage } from './usage.js';
+import { estimateTokens } from './utils.js';
 
-3. **Implement `stream()` method**
-   - Signature: `async *stream(messages: ChatMessage[], params: ChatParams): AsyncIterable<StreamChunk>`
-   - Use provider's streaming endpoint (e.g., SSE, WebSocket, chunked response)
-   - Yield `{ type: 'text', value: '<chunk>' }` for each text delta
-   - Yield `{ type: 'usage', value: '', usage: { input, output } }` at end if available
-   - On error, yield `{ type: 'error', value: '<error message>' }` and return
-   - Test streaming with `for await (const chunk of stream(...)) { console.log(chunk) }`
+export class YourProviderProvider implements LLMProvider {
+  private client: YourSDKType;
+  private defaultModel: string;
 
-4. **Add config in `src/llm/config.ts`**
-   - Import `{ProviderName}Provider` in `getProvider(config, model)` function
-   - Add condition: `if (config.provider === '{provider-slug}') return new {ProviderName}Provider({ apiKey: config.apiKey, model, baseUrl: config.baseUrl })`
-   - Add case in `validateModel()`: check against provider's official model list or hardcode supported models
-   - Export provider slug in `SUPPORTED_PROVIDERS` array if it exists
-   - Verify config function accepts and routes your provider
+  constructor(config: LLMConfig) {
+    if (!config.apiKey) throw new Error('API key required');
+    this.client = new YourSDK({ apiKey: config.apiKey, ...(config.baseUrl && { baseURL: config.baseUrl }) });
+    this.defaultModel = config.model;
+  }
 
-5. **Register in factory at `src/llm/index.ts`**
-   - Import provider in `getProvider()` function
-   - Add to the conditional chain matching provider name from config
-   - Run `npm run build && npm run test` to verify factory picks up provider
+  async call(options: LLMCallOptions): Promise<string> {
+    const model = options.model || this.defaultModel;
+    const response = await this.client.messages.create({ model, max_tokens: options.maxTokens || 4096, system: options.system, messages: [{ role: 'user', content: options.prompt }] });
+    trackUsage(model, { inputTokens: response.usage?.input_tokens || 0, outputTokens: response.usage?.output_tokens || 0 });
+    return response.content?.[0]?.text || '';
+  }
 
-6. **Add tests in `src/llm/__tests__/{provider-name}.test.ts`**
-   - Mock API responses using `vitest.mock()` or `fetch` stub
-   - Test `call()`: verify message formatting, response parsing, error handling
-   - Test `stream()`: verify chunk parsing, usage reporting, error yields
-   - Test config validation: invalid model, missing API key
-   - Run `npx vitest run src/llm/__tests__/{provider-name}.test.ts`
+  async stream(options: LLMStreamOptions, callbacks: LLMStreamCallbacks): Promise<void> {
+    const model = options.model || this.defaultModel;
+    const messages = [...(options.messages || []), { role: 'user' as const, content: options.prompt }];
+    try {
+      const stream = await this.client.stream({ model, max_tokens: options.maxTokens || 10240, system: options.system, messages });
+      let stopReason: string | undefined, usage: TokenUsage | undefined;
+      for await (const chunk of stream) {
+        if (chunk.delta?.text) callbacks.onText(chunk.delta.text);
+        if (chunk.delta?.stop_reason) stopReason = chunk.delta.stop_reason;
+        if (chunk.usage) usage = { inputTokens: chunk.usage.input_tokens, outputTokens: chunk.usage.output_tokens };
+      }
+      if (usage) trackUsage(model, usage);
+      callbacks.onEnd({ stopReason, usage });
+    } catch (error) { callbacks.onError(error instanceof Error ? error : new Error(String(error))); }
+  }
+}
+```
+
+Verify: File exports the class; imports match existing providers.
+
+### Step 2: Add to ProviderType union
+Edit `src/llm/types.ts` line 1. Add your provider in kebab-case:
+```typescript
+export type ProviderType = 'anthropic' | 'vertex' | 'openai' | 'cursor' | 'claude-cli' | 'your-provider';
+```
+Verify: `npx tsc --noEmit` shows no ProviderType errors.
+
+### Step 3: Add config fields
+If your provider needs fields beyond apiKey, model, baseUrl, extend LLMConfig in src/llm/types.ts:
+```typescript
+export interface LLMConfig {
+  provider: ProviderType;
+  model: string;
+  fastModel?: string;
+  apiKey?: string;
+  baseUrl?: string;
+  yourProviderSecret?: string;
+}
+```
+
+### Step 4: Update config.ts
+Edit `src/llm/config.ts`:
+
+**Line 9:** Add to DEFAULT_MODELS:
+```typescript
+export const DEFAULT_MODELS: Record<ProviderType, string> = {
+  anthropic: 'claude-sonnet-4-6',
+  vertex: 'claude-sonnet-4-6',
+  openai: 'gpt-5.4-mini',
+  cursor: 'sonnet-4.6',
+  'claude-cli': 'default',
+  'your-provider': 'your-provider/default-model',
+};
+```
+
+**Line 17:** Add to MODEL_CONTEXT_WINDOWS if known:
+```typescript
+export const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
+  'your-provider/model-name': 128_000,
+};
+```
+
+**Line 59:** In resolveFromEnv(), add env detection before final return null:
+```typescript
+if (process.env.YOUR_PROVIDER_API_KEY) {
+  return {
+    provider: 'your-provider',
+    apiKey: process.env.YOUR_PROVIDER_API_KEY,
+    model: process.env.CALIBER_MODEL || DEFAULT_MODELS['your-provider'],
+    baseUrl: process.env.YOUR_PROVIDER_BASE_URL,
+  };
+}
+```
+
+**Line 115:** In readConfigFile() validation, add 'your-provider' to includes list.
+
+Verify: `npm run test -- src/llm/__tests__/ -t config` confirms env var detection works.
+
+### Step 5: Register in factory
+Edit `src/llm/index.ts`. Add import (line ~4):
+```typescript
+import { YourProviderProvider } from './your-provider.js';
+```
+
+In createProvider() switch (line ~24), add before default case:
+```typescript
+case 'your-provider':
+  return new YourProviderProvider(config);
+```
+
+Verify: `npx tsc --noEmit` passes; no type errors on switch cases.
+
+### Step 6: Write tests
+Create `src/llm/__tests__/your-provider.test.ts`:
+```typescript
+import { describe, it, expect, beforeEach } from 'vitest';
+import { YourProviderProvider } from '../your-provider.js';
+
+describe('YourProviderProvider', () => {
+  let provider: YourProviderProvider;
+  beforeEach(() => {
+    provider = new YourProviderProvider({ provider: 'your-provider', model: 'test', apiKey: 'test' });
+  });
+
+  it('implements LLMProvider interface', () => {
+    expect(typeof provider.call).toBe('function');
+    expect(typeof provider.stream).toBe('function');
+  });
+
+  it('call() returns string', async () => {
+    const result = await provider.call({ system: 'helpful', prompt: 'hi' });
+    expect(typeof result).toBe('string');
+  });
+
+  it('stream() invokes callbacks', async () => {
+    const texts: string[] = [];
+    let ended = false;
+    await provider.stream({ system: 'helpful', prompt: 'hi' }, {
+      onText: (t) => texts.push(t),
+      onEnd: () => { ended = true; },
+      onError: () => {},
+    });
+    expect(ended).toBe(true);
+  });
+});
+```
+
+Verify: `npm run test -- src/llm/__tests__/your-provider.test.ts` passes.
+
+### Step 7: Integration test
+Run factory tests with your provider env var:
+```bash
+YOUR_PROVIDER_API_KEY=test npm run test -- src/llm/__tests__/index.test.ts
+```
+Verify: getProvider() instantiates your provider; llmCall() dispatches correctly.
 
 ## Examples
 
-**User says**: "Add support for Groq as a new LLM provider."
+### Example 1: Local LM Studio server
+User says: "I need caliber to use my local LM Studio instance."
 
-**Actions**:
-1. Create `src/llm/groq.ts` with `GroqProvider` class
-2. Implement `call()` calling `https://api.groq.com/openai/v1/chat/completions` with OpenAI-compatible format
-3. Implement `stream()` using same endpoint with `stream: true`
-4. In `src/llm/config.ts`, add `if (config.provider === 'groq') return new GroqProvider(...)`
-5. In `src/llm/index.ts`, import and route `groq` provider in `getProvider()`
-6. Create tests mocking Groq API responses
-7. Verify: `npm run test -- src/llm/__tests__/groq.test.ts` passes
+Actions: Create src/llm/lm-studio.ts extending OpenAICompatProvider. Add 'lm-studio' to ProviderType. In config.ts:
+```typescript
+if (process.env.LM_STUDIO_BASE_URL) {
+  return { provider: 'lm-studio', apiKey: '', model: 'local', baseUrl: process.env.LM_STUDIO_BASE_URL };
+}
+```
+Register in createProvider() case. User: `export LM_STUDIO_BASE_URL=http://localhost:8000/v1`. Result: caliber uses local LM Studio; tokens estimated via estimateTokens().
 
-**Result**: Caliber can now use Groq models via `{ provider: 'groq', apiKey: '...', model: 'mixtral-8x7b-32768' }`
+### Example 2: Ollama (seat-based)
+User says: "Ollama is auto-detected; no API key needed."
+
+Actions: Create src/llm/ollama.ts extending OpenAICompatProvider. Add 'ollama' to ProviderType and SEAT_BASED_PROVIDERS. In config.ts:
+```typescript
+if (process.env.OLLAMA_HOST) {
+  return { provider: 'ollama', model: 'mistral', baseUrl: process.env.OLLAMA_HOST || 'http://localhost:11434/v1' };
+}
+```
+Result: Offline per-machine LLM without API keys.
 
 ## Common Issues
 
-- **"Provider not recognized" in factory**: Verify provider slug matches exactly in `getProvider()` condition AND in config file. Check spelling and case sensitivity.
-- **"TypeError: stream is not async iterable"**: Ensure `stream()` is a generator function (uses `async *` and `yield`). Test with `for await` loop before deploying.
-- **"API key is undefined"**: Verify environment variable name in provider constructor matches what user sets. Log `apiKey` value in error message: `throw new ChatError('auth', 'API key missing: check {ENV_VAR_NAME}')`
-- **"Stream stops early or yields garbage"**: Check provider's response format (JSON lines, SSE, etc.). Log raw response chunk: `console.error('Raw chunk:', chunk)` to debug parsing.
-- **"Model validation fails but model is valid"**: Ensure `validateModel()` in config covers all supported models for this provider. If list is dynamic, call provider's models endpoint and cache.
-- **Type errors on ChatError**: Verify import is `from 'src/llm/types.js'` (with `.js` extension for ESM).
-- **Tests fail with "fetch is not defined"**: Add `import { fetch } from 'node-fetch'` or mock globally in `src/test/setup.ts`.
+**Unknown provider: your-provider**
+- Cause: ProviderType updated but createProvider() case missing.
+- Fix: Add case in src/llm/index.ts and import the class.
+
+**Cannot find module './your-provider.js'**
+- Cause: File named your_provider.ts (underscore) not your-provider.ts (kebab).
+- Fix: Rename file to use kebab-case.
+
+**API key is required for YourProvider**
+- Cause: Env var YOUR_PROVIDER_API_KEY not set; resolveFromEnv() didn't detect it.
+- Fix: Verify env var name in config.ts matches. Test: `YOUR_PROVIDER_API_KEY=test npm run test -- src/llm/__tests__/index.test.ts`.
+
+**LLM response did not include usage tokens**
+- Cause: Provider API doesn't return usage (local models).
+- Fix: Estimate tokens: `trackUsage(model, { inputTokens: estimateTokens(options.system + options.prompt), outputTokens: estimateTokens(response.text) });`
+
+**Stream callbacks never fire; onEnd not called**
+- Cause: Async iterator not fully consumed before method returns.
+- Fix: Ensure iteration completes before onEnd(): `for await (const chunk of stream) { } callbacks.onEnd({ stopReason, usage });`
+
+**My model parameter is ignored**
+- Cause: call()/stream() doesn't use `options.model || this.defaultModel`.
+- Fix: Replace hardcoded model: `const model = options.model || this.defaultModel; const response = await this.client.create({ model, ... });`
+
+**trackUsage() is never called**
+- Cause: Forgot to call trackUsage() in call() or stream().
+- Fix: Add after every response: `trackUsage(model, { inputTokens: ..., outputTokens: ... });`
+
+**Type error: Provider doesn't implement LLMProvider**
+- Cause: Missing method or wrong signature.
+- Fix: Verify all required methods exist with exact signatures from src/llm/types.ts. Copy-paste from anthropic.ts as reference.

--- a/.cursor/skills/scoring-checks/SKILL.md
+++ b/.cursor/skills/scoring-checks/SKILL.md
@@ -1,140 +1,284 @@
 ---
 name: scoring-checks
-description: Adds a new deterministic scoring check in src/scoring/checks/. Follows the Check[] return pattern, uses constants from src/scoring/constants.ts, and integrates in src/scoring/index.ts. Use when user says 'add scoring check', 'new check', 'modify scoring logic'. Do NOT use for display/UI changes, test modifications, or scoring display formatting.
+description: Add a new deterministic scoring check in src/scoring/checks/ that evaluates config quality. Follows the Check[] return pattern, uses point constants from src/scoring/constants.ts, and integrates via filterChecksForTarget() in src/scoring/index.ts. Use when user says 'add scoring check', 'new check', 'modify scoring criteria', or works in src/scoring/checks/. Do NOT use for display changes or refactoring scoring logic.
+paths:
+  - src/scoring/checks/**/*.ts
+  - src/scoring/constants.ts
+  - src/scoring/index.ts
 ---
-# Scoring Checks
+# Adding a Scoring Check
+
+Add a new deterministic check that evaluates a single aspect of AI agent config quality. All checks must be filesystem-based with no network calls or LLM inference.
 
 ## Critical
 
-- **All checks must be deterministic**: No randomness, no timestamps. Same input → same output.
-- **Return type is always `Check[]`**: Each check has `id`, `name`, `weight`, `maxScore`, `score`, `reasons`.
-- **Weights must sum to 100** across all checks in `src/scoring/index.ts`. Verify: `existenceWeight + qualityWeight + groundingWeight + accuracyWeight + freshnessWeight + bonusWeight + sourcesWeight === 100`.
-- **Only import from `src/scoring/constants.ts`** for weight/threshold values. Never hardcode thresholds.
-- **Check logic is synchronous**. No async/await in check functions.
+- **Check must be deterministic**: Same filesystem state → same result every time. No randomness, no external APIs.
+- **Point values come from constants.ts**: Every `earnedPoints` and `maxPoints` must reference `POINTS_*` from `src/scoring/constants.ts`. Do NOT hardcode numbers.
+- **Always return `Check[]` array**: Export a function `check<Category>(dir: string): Check[]` where category is one of: `existence`, `quality`, `grounding`, `accuracy`, `freshness`, `bonus`.
+- **Every check must have**: `id` (kebab-case, unique), `name`, `category`, `maxPoints`, `earnedPoints`, `passed`, `detail`, and optional `suggestion`/`fix`.
+- **Fix object fields**: `action` (string describing what to do), `data` (context for the fix), `instruction` (user-facing guidance).
+- **Register in src/scoring/index.ts**: Add the import and spread the result into the `allChecks` array in `computeLocalScore()`.
+- **Target filtering**: If the check is platform-specific (Claude-only, Cursor-only, etc.), add its ID to the appropriate `*_ONLY_CHECKS` set in `constants.ts`.
 
 ## Instructions
 
-### Step 1: Define the check function in a new file
+### Step 1: Define point constants in src/scoring/constants.ts
 
-Create `src/scoring/checks/<checkName>.ts`.
+Verify before proceeding: Is your check measurable with a numeric point value?
 
-Use this template:
+Add constants below the appropriate category section (existence, quality, grounding, accuracy, freshness, bonus):
 
 ```typescript
-import { Check } from '../types.js';
-import { <CONSTANT_NAME> } from '../constants.js';
+// In the appropriate CATEGORY section, e.g., Quality checks (25 pts):
+export const POINTS_YOUR_CHECK_NAME = 4; // 1-12 pts typical
 
-export function <checkName>(
-  fingerprint: Fingerprint,
-  config: ParsedConfig,
-): Check[] {
-  const checkId = '<checkName>';
-  let score = 0;
-  const reasons: string[] = [];
+// If threshold-based, add a companion array:
+export const YOUR_THRESHOLD_ARRAY = [
+  { minValue: 10, points: 4 },
+  { minValue: 5, points: 2 },
+] as const;
+```
 
-  // Logic here: inspect fingerprint/config, calculate score 0–maxScore
-  // Add reason strings for each deduction
+Check existing patterns: Token budgets use `TOKEN_BUDGET_THRESHOLDS`, code blocks use `CODE_BLOCK_THRESHOLDS`, concreteness uses `CONCRETENESS_THRESHOLDS`.
 
-  return [
-    {
-      id: checkId,
-      name: 'Check Display Name',
-      weight: <WEIGHT_CONSTANT>,
-      maxScore: 100,
-      score,
-      reasons,
+Verify: Review `CATEGORY_MAX` object to ensure your check fits within its category's point budget.
+
+### Step 2: Create or edit check function in src/scoring/checks/
+
+Choose the file based on category. Each file exports a `check<Name>(dir: string): Check[]` function:
+
+- `existence.ts` — files/directories exist (CLAUDE.md, .cursorrules, skills, MCP servers)
+- `quality.ts` — config structure, size, clarity (code blocks, token budget, concreteness, duplicates)
+- `grounding.ts` — references to actual project files/directory structure
+- `accuracy.ts` — validity of references, git-based config drift
+- `freshness.ts` — git commit-based staleness, secrets, permissions
+- `bonus.ts` — hooks, learned content, OpenSkills format
+- `sources.ts` — source configuration and usage
+
+Create the function following this structure:
+
+```typescript
+import type { Check } from '../index.js';
+import {
+  POINTS_YOUR_CHECK,
+  YOUR_THRESHOLD_ARRAY,
+} from '../constants.js';
+import { readFileOrNull } from '../utils.js'; // or other helpers
+
+export function checkYourCategory(dir: string): Check[] {
+  const checks: Check[] = [];
+
+  // 1. Measure something concrete
+  const yourMetric = /* e.g., countFiles(), validatePaths(), etc. */;
+  const threshold = YOUR_THRESHOLD_ARRAY.find(t => yourMetric >= t.minValue);
+  const earnedPts = threshold?.points ?? 0;
+
+  checks.push({
+    id: 'your_unique_check_id',
+    name: 'Human-readable check name',
+    category: 'quality', // matches function context
+    maxPoints: POINTS_YOUR_CHECK,
+    earnedPoints: earnedPts,
+    passed: earnedPts >= Math.ceil(POINTS_YOUR_CHECK * 0.6), // or custom logic
+    detail: `${earnedPts}/${POINTS_YOUR_CHECK} points — ${yourMetric} items found`,
+    suggestion: earnedPts >= POINTS_YOUR_CHECK ? undefined : 'Action to improve',
+    fix: earnedPts >= POINTS_YOUR_CHECK ? undefined : {
+      action: 'verb_noun', // e.g., 'add_code_blocks', 'fix_references'
+      data: { currentValue: yourMetric, targetValue: 10 },
+      instruction: 'Specific, actionable guidance for the user.',
     },
-  ];
+  });
+
+  return checks;
 }
 ```
 
-Verify the function returns exactly one `Check` object (or multiple if logically grouped). Verify `score` is between 0 and `maxScore`.
+Verify ID uniqueness: Run `grep -r "'your_unique_check_id'" src/scoring/checks/` — should return only your new check.
 
-### Step 2: Export from `src/scoring/checks/index.ts`
+### Step 3: Handle platform-specific filtering (if applicable)
 
-Add the import and export:
+If your check only applies to certain agents (Claude, Cursor, Codex, GitHub Copilot), register it in `src/scoring/constants.ts`:
 
 ```typescript
-export { <checkName> } from './<checkName>.js';
+// Add to the appropriate set:
+export const CLAUDE_ONLY_CHECKS = new Set([
+  'claude_md_exists',
+  'your_new_check_id', // ← add here
+  'claude_rules_exist',
+]);
 ```
 
-Verify file is listed in the barrel export.
+Available sets (update exactly one if applicable):
+- `CLAUDE_ONLY_CHECKS` — Claude Code targets
+- `CURSOR_ONLY_CHECKS` — Cursor targets
+- `CODEX_ONLY_CHECKS` — Codex/OpenCode targets
+- `COPILOT_ONLY_CHECKS` — GitHub Copilot targets
+- `BOTH_ONLY_CHECKS` — Both Claude AND Cursor (cross-platform parity)
+- `NON_CODEX_CHECKS` — Everything except Codex/OpenCode
+- `CLAUDE_OR_CODEX_CHECKS` — Claude OR Codex
 
-### Step 3: Call the check in `src/scoring/index.ts`
+Verify filtering: Examine `filterChecksForTarget()` in `src/scoring/index.ts` to ensure your category will work correctly for your target agents.
 
-In the `score()` function, add a line:
+### Step 4: Register in src/scoring/index.ts
+
+Import your function at the top:
 
 ```typescript
-const <checkName>Results = <checkName>(fingerprint, config);
-allChecks.push(...<checkName>Results);
+import { checkYourCategory } from './checks/your-file.js';
 ```
 
-Verify placement is before the weight-sum validation at the end of `score()`.
-
-### Step 4: Update weight constants in `src/scoring/constants.ts`
-
-If adding a new check type (not modifying an existing one), add the weight constant:
+Add to `computeLocalScore()` inside the `allChecks` array initialization:
 
 ```typescript
-export const <CHECK_NAME>_WEIGHT = <number>;
+export function computeLocalScore(dir: string, targetAgent?: TargetAgent): ScoreResult {
+  const target = targetAgent ?? detectTargetAgent(dir);
+
+  const allChecks: Check[] = [
+    ...checkExistence(dir),
+    ...checkQuality(dir),
+    ...checkGrounding(dir),
+    ...checkAccuracy(dir),
+    ...checkYourCategory(dir), // ← ADD HERE IN ORDER
+    ...checkFreshness(dir),
+    ...checkBonus(dir),
+    ...checkSources(dir),
+  ];
+  // ... rest of function
+}
 ```
 
-Then update all other weight constants so the sum remains 100. Verify the weights comment block lists all active checks.
+Verify registration: Run `npm test src/scoring/__tests__/accuracy.test.ts` (or similar) — all existing tests should still pass.
 
-Verify: Run `npm run test -- src/scoring/__tests__/index.test.ts` to ensure weight validation passes.
+### Step 5: Write deterministic unit tests
 
-### Step 5: Write or update the test
-
-In `src/scoring/__tests__/`, create or update `<checkName>.test.ts`. Test both pass and fail cases:
+Create or edit `src/scoring/checks/__tests__/your-file.test.ts`:
 
 ```typescript
-it('returns maxScore when condition is met', () => {
-  const result = <checkName>({ /* fingerprint */ }, { /* config */ });
-  expect(result[0].score).toBe(100);
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { checkYourCategory } from '../your-file.js';
+import { POINTS_YOUR_CHECK } from '../../constants.js';
+
+describe('checkYourCategory', () => {
+  it('awards full points when condition passes', () => {
+    const dir = mkdtempSync('test-scoring-');
+    try {
+      // Set up the passing condition
+      writeFileSync(join(dir, 'SOME_FILE.md'), 'content that satisfies check');
+      
+      const checks = checkYourCategory(dir);
+      const check = checks.find(c => c.id === 'your_unique_check_id');
+      
+      expect(check).toBeDefined();
+      expect(check?.passed).toBe(true);
+      expect(check?.earnedPoints).toBe(POINTS_YOUR_CHECK);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  it('awards zero points when condition fails', () => {
+    const dir = mkdtempSync('test-scoring-');
+    try {
+      // Don't create the required condition
+      const checks = checkYourCategory(dir);
+      const check = checks.find(c => c.id === 'your_unique_check_id');
+      
+      expect(check?.passed).toBe(false);
+      expect(check?.earnedPoints).toBe(0);
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
+
+  it('returns correct detail message', () => {
+    const dir = mkdtempSync('test-scoring-');
+    try {
+      const checks = checkYourCategory(dir);
+      const check = checks.find(c => c.id === 'your_unique_check_id');
+      expect(check?.detail).toBeTruthy();
+    } finally {
+      rmSync(dir, { recursive: true });
+    }
+  });
 });
-
-it('returns 0 when condition is not met', () => {
-  const result = <checkName>({ /* fingerprint */ }, { /* config */ });
-  expect(result[0].score).toBe(0);
-  expect(result[0].reasons.length).toBeGreaterThan(0);
-});
 ```
 
-Verify: Run `npm run test -- src/scoring/__tests__/<checkName>.test.ts`.
+Run tests: `npm test src/scoring/checks/__tests__/your-file.test.ts`. All must pass before shipping.
 
 ## Examples
 
-**User says**: "Add a scoring check that penalizes repos without a CLAUDE.md file."
+### Example 1: Existence Check
+
+**Trigger**: User says "Add a check to verify .claude/rules/ directory exists."
 
 **Actions**:
-1. Create `src/scoring/checks/existence.ts` (or modify if exists).
-2. Check if `config.claudeMdPath` exists and is non-empty: if yes, `score = 100`; if no, `score = 0` with reason "CLAUDE.md not found".
-3. Add export to `src/scoring/checks/index.ts`.
-4. Call `existenceResults = existence(fingerprint, config)` in `src/scoring/index.ts` and push to `allChecks`.
-5. Ensure weight is defined in `constants.ts` (e.g., `EXISTENCE_WEIGHT = 20`).
-6. Test: `npm run test -- src/scoring/__tests__/existence.test.ts`.
+1. Add `export const POINTS_CLAUDE_RULES = 3;` to constants.ts
+2. In existence.ts: `existsSync(join(dir, '.claude', 'rules'))` → true/false
+3. Import in index.ts and add `...checkExistence(dir)` (already done)
+4. Test with mkdtempSync; verify earnedPoints matches POINTS_CLAUDE_RULES
+
+**Result**: Check `id: 'claude_rules_exist'` returns `earnedPoints: 3, passed: true` when dir exists.
+
+### Example 2: Quality Check with Thresholds
+
+**Trigger**: User says "Verify config has at least 3 code blocks with executable commands."
+
+**Actions**:
+1. Add to constants.ts:
+   ```typescript
+   export const CODE_BLOCK_THRESHOLDS = [
+     { minBlocks: 3, points: 8 },
+     { minBlocks: 2, points: 6 },
+     { minBlocks: 1, points: 3 },
+   ] as const;
+   ```
+2. In quality.ts:
+   - Parse CLAUDE.md with regex to count \`\`\` blocks
+   - Match against CODE_BLOCK_THRESHOLDS
+   - Return points based on threshold match
+3. In fix: Suggest which commands to add
+
+**Result**: 3+ blocks = 8 pts, 2 blocks = 6 pts, 1 block = 3 pts, 0 blocks = 0 pts.
+
+### Example 3: Accuracy Check (Reference Validation)
+
+**Trigger**: User says "Check that all file paths mentioned in config actually exist."
+
+**Actions**:
+1. Add `export const POINTS_REFERENCES_VALID = 8;` to constants.ts
+2. In accuracy.ts:
+   - Extract backtick-quoted paths and dir patterns from config
+   - Check existence with `existsSync(join(dir, path))`
+   - Calculate ratio: `valid / total`
+   - Award partial points: `Math.round(ratio * POINTS_REFERENCES_VALID)`
+3. In fix: List invalid paths the user should fix
+
+**Result**: 80% valid refs = ~6 pts; 100% valid = 8 pts; 0% valid = 0 pts.
 
 ## Common Issues
 
-**Error: "Weights do not sum to 100"**
-- Check `src/scoring/index.ts` at the end of `score()`: find the validation that sums all weights.
-- List all active checks and their weights from `constants.ts`.
-- Adjust the weight constant so the sum equals 100. Example: if adding a new check with weight 15, reduce an existing check's weight by 15.
+**Issue**: "My check doesn't appear in the score report."
+**Fix**: 1) Verify ID in `*_ONLY_CHECKS` if platform-specific. 2) Verify import and spread in `index.ts` `allChecks` array. 3) Run `npm test` to ensure no tsc errors. 4) Check `detectTargetAgent()` returns your target platform.
 
-**Error: "Check returned undefined score"**
-- Ensure the check function always initializes `score` to a number before any logic.
-- Verify no conditional path leaves `score` unset.
-- Check must always return a `Check` object with `score` field.
+**Issue**: "Points are hardcoded but should use constants."
+**Fix**: Replace all literal numbers like `earnedPoints: 5` with `earnedPoints: POINTS_YOUR_CHECK`. Constants are in `src/scoring/constants.ts` — use them consistently.
 
-**Error: "Test fails with 'score out of bounds'"**
-- Verify `score` is >= 0 and <= `maxScore` (usually 100).
-- Check logic should cap: `Math.max(0, Math.min(maxScore, score))`.
-- Verify no negative deductions drop score below 0.
+**Issue**: "Check makes an API call or network request."
+**Fix**: Scoring MUST be deterministic and offline. Use only: `fs` module (readFileSync, existsSync, readdirSync), `path`, `execSync` for git commands. No HTTP, no LLM calls, no external services.
 
-**Error: "Check is called twice or results are duplicated in allChecks"**
-- Ensure `<checkName>()` is called exactly once in `src/scoring/index.ts`.
-- Verify you push the result array with spread: `allChecks.push(...result)` not `allChecks.push(result)`.
+**Issue**: "Platform-specific check appears for the wrong agent."
+**Fix**: 1) Verify check ID is in correct `*_ONLY_CHECKS` set. 2) Double-check `filterChecksForTarget()` handles your platform set. 3) Test with `detectTargetAgent()` on a real project.
 
-**Error: "Fingerprint/config types are unknown"**
-- Import `Fingerprint` from `src/fingerprint/types.js` and `ParsedConfig` from `src/commands/types.js` (or check existing check files for the correct imports).
-- Match the type signature of an existing check function.
+**Issue**: "Test fails with 'Module not found' error."
+**Fix**: Ensure file is in `src/scoring/checks/` (not nested). Use `.js` extension in imports (TypeScript transpiles to ES modules). Run `npm run build` to check for tsc errors.
+
+**Issue**: "Detail message is confusing or too technical."
+**Fix**: Use friendly language: `3 code blocks found (need 3 for full points)` instead of `codeBlockCount=3`. Make it clear WHY they got/lost points.
+
+**Issue**: "Threshold-based check gives wrong points for edge cases."
+**Fix**: Test all boundaries: value=0, value=threshold, value>>threshold. Use `.find()` to match highest-to-lowest: `find(t => value >= t.minValue)`.
+
+**Issue**: "Two checks have the same ID."
+**Fix**: Run `grep -r "'my_id'" src/scoring/checks/` to find duplicates. IDs must be globally unique across all check files. Use descriptive names like `claude_md_exists`, not `check_1`.

--- a/.cursor/skills/writers-pattern/SKILL.md
+++ b/.cursor/skills/writers-pattern/SKILL.md
@@ -1,146 +1,272 @@
 ---
 name: writers-pattern
-description: Adds a new platform writer in src/writers/ following existing patterns (claude, cursor, codex). Generates platform-specific CLAUDE.md, .cursor/rules/, or AGENTS.md configs and integrates with writeSetup(). Use when adding support for a new agent platform or AI tool. Trigger phrases: 'add platform', 'new writer', 'support new agent', 'integrate with X'. Do NOT use for modifying existing writers or one-off file generation.
+description: Add a new platform writer module in src/writers/ that generates and writes agent config files for a supported platform. Each writer exports a function that accepts a config interface, creates directories (rules/, skills/, mcp configs), writes files with proper formatting and frontmatter, and returns string[] of written file paths. Use when adding platform support for a new agent, integrating a new code AI tool, or extending caliber to support new targets. Do NOT use for modifying existing writers, refactoring scoring logic, or changing how writers are invoked.
+paths:
+  - src/writers/*/index.ts
+  - src/writers/__tests__/*.test.ts
+  - src/writers/index.ts
 ---
-# Writers Pattern
+# Platform Writer Pattern
 
 ## Critical
 
-- Writers MUST return `string[]` (array of file paths written)
-- Each writer lives in `src/writers/{platform}/index.ts` with a named export `writeSetup(setup: WriteSetup): Promise<string[]>`
-- Writers are registered in `src/writers/index.ts` in the `writers` Map and exported from `getWriters()`
-- All writers follow the exact signature: `(setup: WriteSetup) => Promise<string[]>`
-- Test files go in `src/writers/{platform}/__tests__/` matching vitest conventions
-- Writers are async and must handle file I/O via fs promises (not sync)
+- **Every writer MUST**:
+  1. Export a single named function: `write<Platform>Config(config: <PlatformConfig>): string[]`
+  2. Accept a platform-specific config interface defining what content to write
+  3. Return `string[]` of all written file paths (used by manifest and progress display)
+  4. Create parent directories with `fs.mkdirSync(dir, { recursive: true })` before writing files
+  5. Wrap skill frontmatter exactly as shown in Step 4 (YAML between `---` markers)
+  6. NOT modify files outside the intended platform directories (e.g., Claude writer only touches `.claude/`, `CLAUDE.md`, `.mcp.json`)
+
+- **Integration point**: Every writer MUST be imported and called in `src/writers/index.ts` within the `writeSetup()` function. Missing this step means the writer will never execute.
+
+- **Validation before Step 1**: Verify the platform name is unique (`ls src/writers/` shows no `<platform>/index.ts`). If it exists, you are modifying, not adding.
 
 ## Instructions
 
-**Step 1: Study existing writers**
-Read `src/writers/claude/index.ts`, `src/writers/cursor/index.ts`, and `src/writers/codex/index.ts` to understand:
-- Input: `WriteSetup` type from `src/writers/types.ts`
-- Output: `Promise<string[]>` (list of written file paths)
-- File structure: how each platform writes configs to project root
-- Integration: how they call staging functions (`ensureStaged()`, `writeFile()`)
+### Step 1: Define the Platform Config Interface
+Verify the platform name is unique (see Critical). Create `src/writers/<platform>/index.ts`.
 
-Verify the `WriteSetup` type includes: `claudeMd`, `rules`, `agents`, `hooks`, `skills`, `manifest`.
+At the top of the file, define a config interface that describes all content the writer accepts. The interface MUST include:
+- A main markdown/text file (e.g., `claudeMd`, `cursorrules`, `agentsMd`, `instructions`)
+- Optional nested arrays: `rules`, `skills`, `mcpServers`, `instructionFiles`, etc.
+- Each rule/skill/file has at minimum: `name` or `filename`, `content`, and for skills, `description`
 
-**Step 2: Create platform directory**
-Create `src/writers/{platform}/` with `index.ts` and `__tests__/` subdirectory.
-
-Example structure for `openai-gpt` platform:
-```
-src/writers/openai-gpt/
-├── index.ts
-└── __tests__/
-    └── openai-gpt.test.ts
-```
-
-**Step 3: Implement writeSetup() export**
-Write the function signature matching claude/cursor/codex. Follow this template:
+Example (matching GitHub Copilot pattern already in codebase):
 ```typescript
-import { WriteSetup } from '../types.js';
-import { ensureStaged, writeFile } from '../staging.js';
-
-export async function writeSetup(setup: WriteSetup): Promise<string[]> {
-  const written: string[] = [];
-  
-  // 1. Write platform-specific config file(s)
-  // Example: .openai/gpt-rules.json or similar
-  if (setup.rules.length > 0) {
-    const filePath = '.openai/gpt-rules.json';
-    await writeFile(filePath, JSON.stringify(setup.rules, null, 2));
-    written.push(filePath);
-  }
-  
-  // 2. Integrate hooks if platform supports them
-  if (setup.hooks && setup.hooks.length > 0) {
-    // Write hooks in platform-specific location
-  }
-  
-  // 3. Stage files if setup.manifest exists
-  if (setup.manifest) {
-    await ensureStaged(written, setup.manifest);
-  }
-  
-  return written;
+interface CopilotConfig {
+  instructions: string;  // Main content
+  instructionFiles?: Array<{ filename: string; content: string }>;
 }
 ```
 
-Verify each write operation appends to `written[]` BEFORE returning.
+**Validation**: Confirm the interface property names match platform conventions (e.g., Claude uses `claudeMd`, Cursor uses `cursorrules`). Check existing writers: `src/writers/claude/index.ts` line 9, `src/writers/cursor/index.ts` line 9, `src/writers/codex/index.ts` line 5.
 
-**Step 4: Register writer in src/writers/index.ts**
-Add to the `writers` Map:
+### Step 2: Implement the Writer Export Function
+Export a function named `write<Platform>Config(config: <PlatformConfig>): string[]` that:
+
+1. Initialize an empty `written: string[] = []` array to track all written paths.
+2. For the **main config file** (e.g., `CLAUDE.md` for Claude, `.cursorrules` for Cursor):
+   - Wrap the content with **platform-specific blocks**: Use helpers from `src/writers/pre-commit-block.ts`
+   - Common blocks: `appendPreCommitBlock(content, platform)`, `appendLearningsBlock(content)`, `appendSyncBlock(content)`
+   - Examples from actual codebase:
+     - **Claude** (`src/writers/claude/index.ts` line 19-22): `appendSyncBlock(appendLearningsBlock(appendPreCommitBlock(config.claudeMd)))`
+     - **Cursor** (`src/writers/cursor/index.ts` line 19-22): No sync block; injects rules instead (pre-commit, learnings, sync as separate files)
+     - **Codex** (`src/writers/codex/index.ts` line 13-16): `appendLearningsBlock(appendPreCommitBlock(config.agentsMd, 'codex'))`
+     - **Copilot** (`src/writers/github-copilot/index.ts` line 19-22): `appendSyncBlock(appendLearningsBlock(appendPreCommitBlock(config.instructions, 'copilot')))`
+   - Write to the exact path (e.g., `fs.writeFileSync('CLAUDE.md', wrappedContent)`) and push to `written`.
+
+3. For **rules** (if applicable): Platform convention determines directory.
+   - Cursor uses `.cursor/rules/`, Claude uses `.claude/rules/` (see `src/writers/index.ts` lines 123-126 and 135-137)
+   - For each rule: create the directory, write to `<dir>/<rule.filename>`, push path to `written`
+   - **Cursor special case** (`src/writers/cursor/index.ts` line 24-27): Cursor injects three system rules:
+     ```typescript
+     const preCommitRule = getCursorPreCommitRule();
+     const learningsRule = getCursorLearningsRule();
+     const syncRule = getCursorSyncRule();
+     const allRules = [...(config.rules || []), preCommitRule, learningsRule, syncRule];
+     ```
+
+4. For **skills**: Write with YAML frontmatter.
+   - Directory pattern: `.claude/skills/<skillName>/SKILL.md`, `.cursor/skills/<skillName>/SKILL.md`, `.agents/skills/<skillName>/SKILL.md`, `.opencode/skills/<skillName>/SKILL.md`
+   - Frontmatter format (exact indentation from `src/writers/claude/index.ts` line 40-47):
+     ```
+     ---
+     name: <skill.name>
+     description: <skill.description>
+     paths:
+       - <optional path pattern 1>
+       - <optional path pattern 2>
+     ---
+     <skill.content>
+     ```
+   - For **Opencode** (`src/writers/opencode/index.ts` line 30): Use `buildSkillContent(skill)` from `src/lib/builtin-skills.js` instead of manual frontmatter.
+   - Create directory with `fs.mkdirSync(skillDir, { recursive: true })`, write skill, push to `written`
+
+5. For **MCP Servers** (if applicable): Write/merge JSON at platform-specific path.
+   - **Claude** (`src/writers/claude/index.ts` line 54-65): `.mcp.json` at root
+   - **Cursor** (`src/writers/cursor/index.ts` line 54-69): `.cursor/mcp.json`
+   - Pattern: Read existing servers (if file exists, try to parse JSON with try/catch), merge with new servers using spread operator `{ ...existingServers, ...config.mcpServers }`, write merged object
+   - Wrap in `{ mcpServers: mergedServers }` and output as pretty-printed JSON: `JSON.stringify(wrapped, null, 2)`
+
+6. For **instruction files** (GitHub Copilot, `src/writers/github-copilot/index.ts` line 26-33): Write to `.github/instructions/` directory.
+   - Create directory, iterate files, write each to `<dir>/<file.filename>`, push paths
+
+Return the `written` array.
+
+**Validation**: Confirm all file write operations are synchronous (`fs.writeFileSync`, `fs.mkdirSync`). Ensure every written path is added to the array. No async operations allowed.
+
+### Step 3: Add Type Exports (if complex interface)
+If the config interface may be reused elsewhere (e.g., in `src/writers/index.ts` for the `AgentSetup` type), export the interface from the module.
+
+**Validation**: Check `src/writers/index.ts` lines 15-19 to see if new agent setup params are needed.
+
+### Step 4: Import and Register in `src/writers/index.ts`
+Open `src/writers/index.ts`. At the top (around line 2-6), add:
 ```typescript
-writers.set('openai-gpt', () => import('./openai-gpt/index.js').then(m => m.writeSetup));
+import { write<Platform>Config } from './<platform>/index.js';
 ```
 
-Verify export from `getWriters()` function includes the new platform.
+Update the `AgentSetup` interface (around line 12-20):
+- Add `'<platform>'` to the `targetAgent` tuple (line 13: `('claude' | 'cursor' | 'codex' | 'opencode' | 'github-copilot' | '<platform>')[]`)
+- Add a new property: `<platform>?: Parameters<typeof write<Platform>Config>[0];`
 
-**Step 5: Write tests in __tests__/index.test.ts**
-Follow vitest patterns from existing tests:
-- Mock `WriteSetup` with realistic rules/hooks/agents
-- Test file path generation (verify `written[]` matches expected files)
-- Test error handling (e.g., writeFile failures)
-- Test integration with `ensureStaged()` if applicable
-
-Example:
+Update `getFilesToWrite()` function (starting line 117): Add a new conditional block:
 ```typescript
-import { describe, it, expect, vi } from 'vitest';
-import { writeSetup } from '../index.js';
-
-describe('openai-gpt writer', () => {
-  it('writes rules to .openai/gpt-rules.json', async () => {
-    const setup = { rules: ['rule1'], manifest: undefined };
-    const written = await writeSetup(setup as any);
-    expect(written).toContain('.openai/gpt-rules.json');
-  });
-});
+if (setup.targetAgent.includes('<platform>') && setup.<platform>) {
+  files.push('<main-config-file>');
+  if (setup.<platform>.rules) {
+    for (const r of setup.<platform>.rules) files.push(`<rules-dir>/${r.filename}`);
+  }
+  if (setup.<platform>.skills) {
+    for (const s of setup.<platform>.skills) files.push(`<skills-dir>/${s.name}/SKILL.md`);
+  }
+  // ... repeat for other config types (mcpServers, instructionFiles, etc.)
+}
 ```
 
-**Step 6: Run tests and type check**
-Execute:
-```bash
-npm test -- src/writers/{platform}/__tests__/
-npx tsc --noEmit
+Update `writeSetup()` function (starting line 22): Add a new conditional block before the return (after line 56):
+```typescript
+if (setup.targetAgent.includes('<platform>') && setup.<platform>) {
+  written.push(...write<Platform>Config(setup.<platform>));
+}
 ```
 
-Verify no type errors and all tests pass.
+**Validation**: Confirm the function call order in `writeSetup()` is consistent (line 37-56): claude → cursor → codex → opencode → github-copilot → (new platform). This ensures AGENTS.md is written once if shared (as with Codex/Opencode, see line 50-52).
+
+### Step 5: Add Tests
+Create `src/writers/__tests__/<platform>.test.ts` following the vitest pattern in `src/writers/__tests__/codex.test.ts`:
+
+1. Mock `fs` module: `vi.mock('fs')`
+2. Mock return values in `beforeEach`: `vi.mocked(fs.existsSync).mockReturnValue(false)`
+3. Test that:
+   - Main config file is written to correct path
+   - Returned array includes all written paths
+   - Directories are created before file writes (use `.toHaveBeenCalledWith(path, { recursive: true })`)
+   - Skills have correct frontmatter format (check `vi.mocked(fs.writeFileSync).mock.calls`)
+   - MCP/instruction files are merged/created correctly
+   - Pre-commit/learnings/sync blocks are included in main file (expect content `.toContain('caliber:managed:pre-commit')`)
+
+Run: `npm test -- src/writers/__tests__/<platform>.test.ts`
+
+**Validation**: All tests pass. Confirm mocked file operations match actual file system structure.
+
+### Step 6: Update `detectSyncedAgents()` in `src/commands/refresh.ts` (Optional)
+If the platform writes config files with distinct naming (e.g., `.newplatform/`), update the detection logic around line 68-77 so end-user refresh output correctly identifies the synced platform:
+
+```typescript
+if (joined.includes('.newplatform/') || joined.includes('newplatform-config')) {
+  agents.push('<Platform Name>');
+}
+```
+
+**Validation**: Run `npm run refresh` and confirm the summary message lists the new platform.
 
 ## Examples
 
-**User says:** "Add support for GitHub Copilot (new platform)"
+### Example 1: Add a hypothetical "DevCode" platform writer
 
-**Actions:**
-1. Create `src/writers/github-copilot/index.ts` (already exists, so this is example-only)
-2. Implement `writeSetup()` that writes `.copilot/rules.md` from `setup.rules`
-3. Add to `src/writers/index.ts`: `writers.set('github-copilot', ...)`
-4. Write tests verifying rules are written to correct path
-5. Verify `npm test` passes and no TypeScript errors
+**User says**: "Add support for DevCode, a new agent that reads config from `.devcode/settings.md` and `.devcode/rules/` directory."
 
-**Result:** New writer integrated; `getWriters()` now includes `github-copilot`; can be used by `refresh` and `regenerate` commands.
+**Actions taken**:
+
+1. Create `src/writers/devcode/index.ts` (matching pattern from `src/writers/claude/index.ts`):
+   ```typescript
+   import fs from 'fs';
+   import path from 'path';
+   import { appendPreCommitBlock, appendLearningsBlock } from '../pre-commit-block.js';
+
+   interface DevcodeConfig {
+     settingsMd: string;
+     rules?: Array<{ filename: string; content: string }>;
+   }
+
+   export function writeDevcodeConfig(config: DevcodeConfig): string[] {
+     const written: string[] = [];
+
+     fs.writeFileSync(
+       '.devcode/settings.md',
+       appendLearningsBlock(appendPreCommitBlock(config.settingsMd, 'devcode'))
+     );
+     written.push('.devcode/settings.md');
+
+     if (config.rules?.length) {
+       const rulesDir = path.join('.devcode', 'rules');
+       if (!fs.existsSync(rulesDir)) fs.mkdirSync(rulesDir, { recursive: true });
+       for (const rule of config.rules) {
+         const rulePath = path.join(rulesDir, rule.filename);
+         fs.writeFileSync(rulePath, rule.content);
+         written.push(rulePath);
+       }
+     }
+
+     return written;
+   }
+   ```
+
+2. Update `src/writers/index.ts`:
+   - Line 2: Add `import { writeDevcodeConfig } from './devcode/index.js';`
+   - Line 13: Change `targetAgent` tuple to include `'devcode'`
+   - Line 19: Add `devcode?: Parameters<typeof writeDevcodeConfig>[0];`
+   - Line 117+: Add devcode block to `getFilesToWrite()` (match Codex pattern lines 144-149)
+   - Line 37+: Add devcode block to `writeSetup()` (match Codex pattern lines 45-47)
+   - Line 68+: Update `detectSyncedAgents()` to check for `.devcode/`
+
+3. Create `src/writers/__tests__/devcode.test.ts` (matching `src/writers/__tests__/codex.test.ts`):
+   ```typescript
+   import { describe, it, expect, vi, beforeEach } from 'vitest';
+   import fs from 'fs';
+   import path from 'path';
+
+   vi.mock('fs');
+
+   import { writeDevcodeConfig } from '../devcode/index.js';
+
+   describe('writeDevcodeConfig', () => {
+     beforeEach(() => {
+       vi.clearAllMocks();
+       vi.mocked(fs.existsSync).mockReturnValue(false);
+     });
+
+     it('writes settings.md and rules', () => {
+       const config = {
+         settingsMd: '# DevCode Config',
+         rules: [{ filename: 'style.md', content: 'Style rules' }],
+       };
+       const written = writeDevcodeConfig(config);
+       expect(written).toContain('.devcode/settings.md');
+       expect(written).toContain(path.join('.devcode', 'rules', 'style.md'));
+     });
+   });
+   ```
+
+4. Run: `npm test && npm run build`
+
+**Result**: Caliber now generates `.devcode/settings.md` and rules on `caliber refresh` and `caliber init`.
 
 ## Common Issues
 
-**"Cannot find module src/writers/{platform}"**
-- Verify directory exists and `index.ts` is in it
-- Check import path uses `.js` extension per ESM convention
-- Run `npm run build` to compile TypeScript
+**Issue**: "TypeError: write<Platform>Config is not a function"
+- **Fix**: Verify the function is **exported** (not just defined). Check `export function write<Platform>Config(...)` in the writer file. Missing `export` is a common mistake.
 
-**"writeSetup is not a named export"**
-- Ensure function is exported as `export async function writeSetup(...)`
-- Do NOT use default export; writers are imported by name in `src/writers/index.ts`
+**Issue**: "ENOENT: no such file or directory, open '.platform/config.md'"
+- **Fix**: The parent directory was not created. Ensure `fs.mkdirSync(parentDir, { recursive: true })` is called **before** `fs.writeFileSync(filePath, content)`. See correct order in `src/writers/claude/index.ts` lines 26-27.
 
-**"written array is empty but files were created"**
-- Every `writeFile()` call must append to `written[]` before returning
-- Do NOT forget to push file paths to array
-- Example: `written.push(filePath)` after each file operation
+**Issue**: "Skill file has no frontmatter / malformed YAML"
+- **Fix**: Verify frontmatter format is exactly (no extra blank lines):
+  ```
+  ---\nname: <name>\ndescription: <desc>\n---\n<content>
+  ```
+  Use `[...].join('\n')` and test with a single skill first. Compare with working code in `src/writers/claude/index.ts` lines 40-48.
 
-**"Tests fail with 'ensureStaged not defined'"**
-- Verify import: `import { ensureStaged } from '../staging.js'`
-- Check staging.ts exports the function
-- Mock `fs` if testing file I/O (see vitest setup in `src/test/setup.ts`)
+**Issue**: "MCP servers not merging, file is truncated"
+- **Fix**: Confirm the merge pattern from `src/writers/claude/index.ts` line 54-65: read existing JSON (with try/catch), parse safely, merge with spread operator `{ ...existingServers, ...config.mcpServers }`, then write the merged object. Do NOT overwrite — always merge.
 
-**"Type 'WriteSetup' does not match signature"**
-- Verify `WriteSetup` is imported from `../types.js`
-- Ensure function signature is exactly: `(setup: WriteSetup) => Promise<string[]>`
-- Do NOT add optional parameters or change return type
+**Issue**: "new writer is called but written files are empty array"
+- **Fix**: Verify the writer function returns the `written` array. Check that every file operation pushes to `written`. Missing a `written.push(filePath)` after `fs.writeFileSync()` is the most common error. See `src/writers/codex/index.ts` lines 17 and 32 for correct pattern.
+
+**Issue**: "Tests mock fs but actual files are created in .tmp/ or cause permission errors"
+- **Fix**: Ensure `vi.mock('fs')` is at the top of the test file before any imports. All `fs` operations will be mocked and return mock values from `beforeEach` setup. See `src/writers/__tests__/codex.test.ts` line 5.
+
+**Issue**: "Cursor pre-commit rule not applied, or learnings block missing"
+- **Fix**: Cursor injects system rules during the write, unlike Claude which uses block appenders. Check that `getCursorPreCommitRule()`, `getCursorLearningsRule()`, and `getCursorSyncRule()` are called and concatenated with user rules **before** iterating (see `src/writers/cursor/index.ts` lines 24-27). Claude and Codex use block-append helpers instead.


### PR DESCRIPTION
## Summary

Aligns `.agents/` and `.cursor/` skill copies with `.claude/` (source of truth) for 4 skills that had diverged with incorrect TypeScript signatures.

**Divergences fixed:**
- `llm-provider` — wrong `stream()` return type, missing `trackUsage` documentation
- `adding-a-command` — `.agents/` had wrong function signature, `.cursor/` used default exports (should be named)
- `writers-pattern` — wrong function parameters (`WriterConfig, SkillLine[]` vs actual `ClaudeConfig`)
- `scoring-checks` — wrong function signature (`ScoringContext` vs actual `dir: string`)

## Test plan

- [x] `diff .claude/skills/X/SKILL.md .agents/skills/X/SKILL.md` shows no diff for all 4 skills
- [x] `diff .claude/skills/X/SKILL.md .cursor/skills/X/SKILL.md` shows no diff for all 4 skills
- [x] `npm run test` passes (950 tests)
- [x] `npx tsc --noEmit` clean

Closes #183