### PR TITLE
fix(windows): resolve DEP0190 and libuv crashes in spawn calls

### DIFF
--- a/src/commands/learn.ts
+++ b/src/commands/learn.ts
@@ -1,6 +1,7 @@
 import fs from 'fs';
 import path from 'path';
 import chalk from 'chalk';
+import { quoteForWindows } from '../utils/windows.js';
 import { readStdin } from '../learner/stdin.js';
 import {
   appendEvent,
@@ -170,16 +171,17 @@ export async function learnObserveCommand(options: { failure?: boolean; prompt?:
         // and shell:true skips Node's exe quoting — quote here so paths like
         // `C:\Users\First Last\AppData\Roaming\npm\caliber.cmd` survive cmd.exe parsing.
         const isWin = process.platform === 'win32';
-        const spawnExe = isWin ? `"${exe}"` : exe;
-        const child = spawn(
-          spawnExe,
-          [...binArgs, 'learn', 'finalize', '--auto', '--incremental'],
-          {
-            detached: true,
-            stdio: ['ignore', logFd, logFd],
-            ...(isWin && { shell: true }),
-          },
-        );
+        const argsArray = [...binArgs, 'learn', 'finalize', '--auto', '--incremental'];
+        const child = isWin
+          ? spawn([`"${exe}"`, ...argsArray.map(quoteForWindows)].join(' '), {
+              detached: true,
+              stdio: ['ignore', logFd, logFd],
+              shell: true,
+            })
+          : spawn(exe, argsArray, {
+              detached: true,
+              stdio: ['ignore', logFd, logFd],
+            });
         // If spawn fails the child never advances lastAnalysisEventCount, so without
         // this guard every subsequent observe call past the threshold re-fires the
         // broken spawn. Bump the counter on error to back off until the next interval.

--- a/src/llm/__tests__/cursor-acp.test.ts
+++ b/src/llm/__tests__/cursor-acp.test.ts
@@ -22,7 +22,11 @@ function mockPrintAgent(output: string, exitCode = 0) {
   };
   child.stdout = new EventEmitter();
   child.stderr = new EventEmitter();
-  child.stdin = new Writable({ write(_chunk, _enc, cb) { cb(); } });
+  child.stdin = new Writable({
+    write(_chunk, _enc, cb) {
+      cb();
+    },
+  });
   child.kill = vi.fn();
   child.killed = false;
 
@@ -39,6 +43,24 @@ function mockPrintAgent(output: string, exitCode = 0) {
 
 describe('CursorAcpProvider', () => {
   const originalEnv = process.env;
+
+  function assertSpawnArgs(expectedArgs: any[]) {
+    if (process.platform === 'win32') {
+      expect(spawn).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ shell: true }),
+      );
+      const cmdStr = spawn.mock.calls[0][0] as string;
+      expect(cmdStr).toContain('agent');
+      for (const arg of expectedArgs) {
+        if (typeof arg === 'string') {
+          expect(cmdStr).toContain(arg);
+        }
+      }
+    } else {
+      expect(spawn).toHaveBeenCalledWith('agent', expectedArgs, expect.any(Object));
+    }
+  }
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -58,11 +80,14 @@ describe('CursorAcpProvider', () => {
     const result = await provider.call({ system: 'Return JSON.', prompt: 'Detect stack.' });
 
     expect(result).toBe('{"languages":["TypeScript"]}');
-    expect(spawn).toHaveBeenCalledWith(
-      'agent',
-      ['--print', '--trust', '--workspace', expect.any(String), '--model', 'sonnet-4.6'],
-      expect.any(Object),
-    );
+    assertSpawnArgs([
+      '--print',
+      '--trust',
+      '--workspace',
+      expect.any(String),
+      '--model',
+      'sonnet-4.6',
+    ]);
   });
 
   it('includes --api-key when CURSOR_API_KEY is set', async () => {
@@ -72,11 +97,16 @@ describe('CursorAcpProvider', () => {
     const provider = new CursorAcpProvider({ provider: 'cursor', model: 'sonnet-4.6' });
     await provider.call({ system: 'S', prompt: 'P' });
 
-    expect(spawn).toHaveBeenCalledWith(
-      'agent',
-      ['--print', '--trust', '--workspace', expect.any(String), '--model', 'sonnet-4.6', '--api-key', 'test-key'],
-      expect.any(Object),
-    );
+    assertSpawnArgs([
+      '--print',
+      '--trust',
+      '--workspace',
+      expect.any(String),
+      '--model',
+      'sonnet-4.6',
+      '--api-key',
+      'test-key',
+    ]);
   });
 
   it('includes --model auto when model is "auto"', async () => {
@@ -85,11 +115,7 @@ describe('CursorAcpProvider', () => {
     const provider = new CursorAcpProvider({ provider: 'cursor', model: 'auto' });
     await provider.call({ system: 'S', prompt: 'P' });
 
-    expect(spawn).toHaveBeenCalledWith(
-      'agent',
-      ['--print', '--trust', '--workspace', expect.any(String), '--model', 'auto'],
-      expect.any(Object),
-    );
+    assertSpawnArgs(['--print', '--trust', '--workspace', expect.any(String), '--model', 'auto']);
   });
 
   it('does not include --model when model is "default"', async () => {
@@ -98,19 +124,24 @@ describe('CursorAcpProvider', () => {
     const provider = new CursorAcpProvider({ provider: 'cursor', model: 'default' });
     await provider.call({ system: 'S', prompt: 'P' });
 
-    expect(spawn).toHaveBeenCalledWith(
-      'agent',
-      ['--print', '--trust', '--workspace', expect.any(String)],
-      expect.any(Object),
-    );
+    assertSpawnArgs(['--print', '--trust', '--workspace', expect.any(String)]);
   });
 
   it('stream() emits text from stream-json events', async () => {
-    const events = [
-      JSON.stringify({ type: 'assistant', message: { content: [{ text: 'Hello' }] }, timestamp_ms: 1 }),
-      JSON.stringify({ type: 'assistant', message: { content: [{ text: ' World' }] }, timestamp_ms: 2 }),
-      JSON.stringify({ type: 'result', duration_ms: 100 }),
-    ].join('\n') + '\n';
+    const events =
+      [
+        JSON.stringify({
+          type: 'assistant',
+          message: { content: [{ text: 'Hello' }] },
+          timestamp_ms: 1,
+        }),
+        JSON.stringify({
+          type: 'assistant',
+          message: { content: [{ text: ' World' }] },
+          timestamp_ms: 2,
+        }),
+        JSON.stringify({ type: 'result', duration_ms: 100 }),
+      ].join('\n') + '\n';
 
     mockPrintAgent(events);
 
@@ -122,18 +153,26 @@ describe('CursorAcpProvider', () => {
       { system: 'S', prompt: 'P' },
       {
         onText: (text) => chunks.push(text),
-        onEnd: () => { ended = true; },
+        onEnd: () => {
+          ended = true;
+        },
         onError: () => {},
       },
     );
 
     expect(chunks).toEqual(['Hello', ' World']);
     expect(ended).toBe(true);
-    expect(spawn).toHaveBeenCalledWith(
-      'agent',
-      ['--print', '--trust', '--workspace', expect.any(String), '--model', 'sonnet-4.6', '--output-format', 'stream-json', '--stream-partial-output'],
-      expect.any(Object),
-    );
+    assertSpawnArgs([
+      '--print',
+      '--trust',
+      '--workspace',
+      expect.any(String),
+      '--model',
+      'sonnet-4.6',
+      '--output-format',
+      'stream-json',
+      '--stream-partial-output',
+    ]);
   });
 
   it('uses CURSOR_API_KEY from env when set', () => {

--- a/src/llm/cursor-acp.ts
+++ b/src/llm/cursor-acp.ts
@@ -10,6 +10,7 @@ import type {
 import { parseSeatBasedError, isRateLimitError } from './seat-based-errors.js';
 import { trackUsage } from './usage.js';
 import { estimateTokens } from './utils.js';
+import { quoteForWindows } from '../utils/windows.js';
 
 const IS_WINDOWS = process.platform === 'win32';
 
@@ -111,11 +112,17 @@ export class CursorAcpProvider implements LLMProvider {
     if (this.warmProcess && !this.warmProcess.killed && this.warmModel === targetModel) return;
 
     const args = this.buildArgs(targetModel, false);
-    this.warmProcess = spawn(resolveAgentBin(), args, {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      env: { ...process.env, ...(this.cursorApiKey && { CURSOR_API_KEY: this.cursorApiKey }) },
-      ...(IS_WINDOWS && { shell: true }),
-    });
+    const env = { ...process.env, ...(this.cursorApiKey && { CURSOR_API_KEY: this.cursorApiKey }) };
+    this.warmProcess = IS_WINDOWS
+      ? spawn([quoteForWindows(resolveAgentBin()), ...args.map(quoteForWindows)].join(' '), {
+          stdio: ['pipe', 'pipe', 'pipe'],
+          env,
+          shell: true,
+        })
+      : spawn(resolveAgentBin(), args, {
+          stdio: ['pipe', 'pipe', 'pipe'],
+          env,
+        });
     this.warmModel = targetModel;
 
     this.warmProcess.on('error', () => {
@@ -170,11 +177,17 @@ export class CursorAcpProvider implements LLMProvider {
     }
 
     const args = this.buildArgs(model, streaming);
-    const child = spawn(resolveAgentBin(), args, {
-      stdio: ['pipe', 'pipe', 'pipe'],
-      env: { ...process.env, ...(this.cursorApiKey && { CURSOR_API_KEY: this.cursorApiKey }) },
-      ...(IS_WINDOWS && { shell: true }),
-    });
+    const env = { ...process.env, ...(this.cursorApiKey && { CURSOR_API_KEY: this.cursorApiKey }) };
+    const child = IS_WINDOWS
+      ? spawn([quoteForWindows(resolveAgentBin()), ...args.map(quoteForWindows)].join(' '), {
+          stdio: ['pipe', 'pipe', 'pipe'],
+          env,
+          shell: true,
+        })
+      : spawn(resolveAgentBin(), args, {
+          stdio: ['pipe', 'pipe', 'pipe'],
+          env,
+        });
 
     const stderrChunks: Buffer[] = [];
     child.stderr!.on('data', (chunk: Buffer) => {

--- a/src/utils/windows.ts
+++ b/src/utils/windows.ts
@@ -1,0 +1,5 @@
+export function quoteForWindows(arg: string): string {
+  if (!arg) return '""';
+  if (!/[ \t\n\v"]/.test(arg)) return arg;
+  return '"' + arg.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\+)$/, '$1$1') + '"';
+}


### PR DESCRIPTION
Resolves #192

As reported in #192, using `child_process.spawn` with an arguments array and `shell: true` on Windows triggers the Node 22+ `DEP0190` deprecation warning and causes intermittent `libuv` crashes in Node 25.

This PR introduces a `quoteForWindows` helper and updates the remaining spawn sites (`agent prewarm`, `agent spawn`, and `learn finalize`) to use a single joined command string with properly escaped arguments. This brings them inline with the already functioning `spawnClaude` and `spawnOpenCode` implementations.