### PR TITLE
fix(windows): use forward-slash paths for bash hook commands

### DIFF
--- a/src/lib/__tests__/hooks.test.ts
+++ b/src/lib/__tests__/hooks.test.ts
@@ -170,6 +170,67 @@ describe('pre-commit hook generation', () => {
   });
 });
 
+describe('script hook paths use forward slashes', () => {
+  let originalCwd: string;
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    const { resetResolvedCaliber } = await import('../resolve-caliber.js');
+    resetResolvedCaliber();
+    tmpDir = makeTmpDir();
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+
+    mockedExecSync.mockImplementation(() => {
+      throw new Error('not found');
+    });
+    process.argv[1] = '/usr/local/bin/caliber';
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  it('Stop hook script path contains only forward slashes', async () => {
+    const { installStopHook } = await import('../hooks.js');
+    installStopHook();
+
+    const settings = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, '.claude', 'settings.json'), 'utf-8'),
+    );
+    const command = settings.hooks.Stop[0].hooks[0].command;
+    expect(command).not.toContain('\\');
+    expect(command).toBe('.claude/hooks/caliber-check-sync.sh');
+  });
+
+  it('SessionStart hook script path contains only forward slashes', async () => {
+    const { installSessionStartHook } = await import('../hooks.js');
+    installSessionStartHook();
+
+    const settings = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, '.claude', 'settings.json'), 'utf-8'),
+    );
+    const command = settings.hooks.SessionStart[0].hooks[0].command;
+    expect(command).not.toContain('\\');
+    expect(command).toBe('.claude/hooks/caliber-session-freshness.sh');
+  });
+
+  it('Notification hook script path contains only forward slashes', async () => {
+    const { installNotificationHook } = await import('../hooks.js');
+    installNotificationHook();
+
+    const settings = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, '.claude', 'settings.json'), 'utf-8'),
+    );
+    const command = settings.hooks.Notification[0].hooks[0].command;
+    expect(command).not.toContain('\\');
+    expect(command).toBe('.claude/hooks/caliber-freshness-notify.sh');
+  });
+});
+
 describe('SessionEnd hook command', () => {
   let originalArgv: string[];
   let originalEnv: NodeJS.ProcessEnv;

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -197,7 +197,7 @@ printf '{"decision":"block","reason":"Caliber agent config sync is not set up on
 
 const stopHook = createScriptHook({
   eventName: 'Stop',
-  scriptPath: path.join('.claude', 'hooks', 'caliber-check-sync.sh'),
+  scriptPath: path.posix.join('.claude', 'hooks', 'caliber-check-sync.sh'),
   scriptContent: STOP_HOOK_SCRIPT_CONTENT,
   description: 'Caliber: offer setup if not configured',
 });
@@ -227,7 +227,7 @@ fi
 
 const sessionStartHook = createScriptHook({
   eventName: 'SessionStart',
-  scriptPath: path.join('.claude', 'hooks', 'caliber-session-freshness.sh'),
+  scriptPath: path.posix.join('.claude', 'hooks', 'caliber-session-freshness.sh'),
   scriptContent: getFreshnessScript,
   description: 'Caliber: check config freshness on session start',
 });
@@ -240,7 +240,7 @@ export const removeSessionStartHook = sessionStartHook.remove;
 
 const notificationHook = createScriptHook({
   eventName: 'Notification',
-  scriptPath: path.join('.claude', 'hooks', 'caliber-freshness-notify.sh'),
+  scriptPath: path.posix.join('.claude', 'hooks', 'caliber-freshness-notify.sh'),
   scriptContent: getFreshnessScript,
   description: 'Caliber: warn when agent configs are stale',
 });


### PR DESCRIPTION
## Summary

Fixes #191

`path.join` on Windows produces backslash-separated paths (`.claude\hooks\caliber-X.sh`). When written into `.claude/settings.json` as hook command strings, bash interprets `\h`, `\c`, `\s` as escape sequences and strips the backslashes, producing broken paths like `.claudehookscaliber-X.sh`.

## Changes

- Switched all 3 `scriptPath` definitions in `src/lib/hooks.ts` from `path.join` to `path.posix.join`
- Added 3 regression tests asserting each hook command uses forward slashes

`path.posix.join` always produces `/`-separated paths on every platform. Forward slashes work for both filesystem operations (Node normalizes them on Windows) and bash command resolution.

## Test plan

- [ ] All 3 new tests pass locally and in CI (including `windows-latest`)
- [ ] Existing hook tests still pass
- [ ] Type check clean