### PR TITLE
fix(windows): flush telemetry before process exit to prevent libuv crash

### DIFF
--- a/src/bin.ts
+++ b/src/bin.ts
@@ -7,17 +7,18 @@ import { restoreTerminal } from './lib/terminal.js';
 
 let signalCleanupDone = false;
 
-function signalCleanup(code: number) {
+async function signalCleanup(code: number) {
   if (signalCleanupDone) return;
   signalCleanupDone = true;
   restoreTerminal();
   releaseLock();
+  await flushTelemetry();
   process.exit(code);
 }
 
 process.on('exit', restoreTerminal);
-process.on('SIGINT', () => signalCleanup(130));
-process.on('SIGTERM', () => signalCleanup(143));
+process.on('SIGINT', () => void signalCleanup(130));
+process.on('SIGTERM', () => void signalCleanup(143));
 
 acquireLock();
 
@@ -45,5 +46,10 @@ program
   .finally(async () => {
     releaseLock();
     await flushTelemetry();
-    process.exit(Number(process.exitCode ?? 0));
+    // Let Node drain remaining handles before exiting. A short timeout
+    // guards against the process hanging if something keeps a handle alive
+    // (e.g. Commander internals). Using setTimeout + unref ensures the
+    // timer itself won't keep the process alive.
+    const safetyExit = setTimeout(() => process.exit(Number(process.exitCode ?? 0)), 200);
+    safetyExit.unref();
   });

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -31,8 +31,8 @@ export function initTelemetry(): void {
   if (!wasNoticeShown()) {
     console.log(
       chalk.dim('  Caliber collects anonymous usage data to improve the product.') +
-      '\n' +
-      chalk.dim('  Disable with --no-traces or CALIBER_TELEMETRY_DISABLED=1\n')
+        '\n' +
+        chalk.dim('  Disable with --no-traces or CALIBER_TELEMETRY_DISABLED=1\n'),
     );
     markNoticeShown();
   }
@@ -63,12 +63,13 @@ export function trackEvent(name: string, properties?: Record<string, unknown>): 
   });
 }
 
+let flushPromise: Promise<void> | null = null;
+
 export async function flushTelemetry(): Promise<void> {
   if (!client) return;
-  try {
-    await client.shutdown();
-  } catch {
-    // never throw — fire-and-forget
-  }
+  if (flushPromise) return flushPromise;
+  const c = client;
   client = null;
+  flushPromise = c.shutdown().catch(() => {});
+  return flushPromise;
 }


### PR DESCRIPTION
## Summary

Fixes #194

After PR #193 fixed spawn-related crashes, the same `UV_HANDLE_CLOSING` libuv assertion still fires on Windows + Node 25 via the PostHog telemetry client. `process.exit()` was called immediately after `await flushTelemetry()`, killing the process before Node's event loop finished closing PostHog's TCP sockets.

## Changes

**`src/bin.ts`:**
- Replaced hard `process.exit()` after telemetry flush with an `unref()`'d 200ms safety timeout. Node drains remaining handles naturally; the timer only fires as a safety net if something else keeps the process alive, but won't keep it alive on its own.
- Made `signalCleanup` async and added `await flushTelemetry()` before `process.exit()` for SIGINT/SIGTERM paths.

**`src/telemetry/index.ts`:**
- Made `flushTelemetry()` concurrency-safe: nulls `client` immediately on first call and deduplicates concurrent callers via a shared promise. Prevents double `shutdown()` if `.finally()` and a signal handler race.

## Test plan

- [ ] All 963 existing tests pass
- [ ] Type check clean
- [ ] Reporter can verify: `caliber status` with telemetry enabled no longer crashes on Windows + Node 25
- [ ] `caliber --no-traces status` continues to work (control case)