### PR TITLE
fix(windows): bypass cmd-shim console flash by invoking node directly in pre-commit hook

### DIFF
--- a/src/lib/__tests__/hooks.test.ts
+++ b/src/lib/__tests__/hooks.test.ts
@@ -113,6 +113,243 @@ describe('pre-commit hook generation', () => {
     });
   });
 
+  describe('Windows global install context (cmd shim flash bypass)', () => {
+    // pandorum 2026-04-28: every commit triggered a brief cmd window flash
+    // because the bash hook resolved `caliber` to `caliber.cmd`, which goes
+    // through `cmd.exe /d /s /c` and allocates a console. Worse, npm's shim
+    // emits `title %COMSPEC%` so the flash *looks* identical to an elevated
+    // cmd window. The fix: when on Windows and the resolved binary ends in
+    // .cmd, derive the package's bin.js and call node directly instead.
+
+    const WIN_CALIBER_CMD = 'C:\\Users\\dev\\AppData\\Roaming\\npm\\caliber.cmd';
+    const WIN_NODE = 'C:\\Program Files\\nodejs\\node.exe';
+
+    async function withWin32<T>(fn: () => T | Promise<T>): Promise<T> {
+      const original = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'win32', configurable: true });
+      try {
+        // The await keeps process.platform pinned to 'win32' across the
+        // microtask the inner code awaits (e.g. dynamic imports). A sync
+        // try/finally would restore the value before the awaited body
+        // ever runs — same shape bug as withScope wrappers in test
+        // helpers everywhere.
+        return await fn();
+      } finally {
+        Object.defineProperty(process, 'platform', { value: original, configurable: true });
+      }
+    }
+
+    beforeEach(() => {
+      delete process.env.npm_execpath;
+      process.argv[1] = WIN_CALIBER_CMD;
+    });
+
+    it('emits direct node invocation when bin.js + node are present', async () => {
+      const { resetResolvedCaliber } = await import('../resolve-caliber.js');
+      resetResolvedCaliber();
+
+      const tmpDir = makeTmpDir();
+      const gitDir = path.join(tmpDir, '.git');
+      const hooksDir = path.join(gitDir, 'hooks');
+      fs.mkdirSync(hooksDir, { recursive: true });
+
+      // Lay down a real bin.js so the existsSync probe finds it. The
+      // node path is mocked via where, so it doesn't need to exist.
+      const fakeBinJs = path.join(tmpDir, 'fake-bin.js');
+      fs.writeFileSync(fakeBinJs, '');
+      const fakeCmd = path.join(tmpDir, 'fake-caliber.cmd');
+      fs.writeFileSync(fakeCmd, '');
+      const fakeNpmDir = tmpDir;
+      const expectedBinJs = path.join(
+        fakeNpmDir,
+        'node_modules',
+        '@rely-ai',
+        'caliber',
+        'dist',
+        'bin.js',
+      );
+      fs.mkdirSync(path.dirname(expectedBinJs), { recursive: true });
+      fs.writeFileSync(expectedBinJs, '');
+
+      mockedExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === 'string' && cmd.includes('where caliber')) {
+          return fakeCmd + '\n';
+        }
+        if (typeof cmd === 'string' && cmd.includes('where node')) {
+          return WIN_NODE + '\n';
+        }
+        if (typeof cmd === 'string' && cmd.includes('rev-parse')) {
+          return `${gitDir}\n`;
+        }
+        return '';
+      });
+
+      const origCwd = process.cwd();
+      process.chdir(tmpDir);
+      try {
+        await withWin32(async () => {
+          const { installPreCommitHook } = await import('../hooks.js');
+          installPreCommitHook();
+        });
+        const hookContent = fs.readFileSync(path.join(hooksDir, 'pre-commit'), 'utf-8');
+
+        // The hook must call node directly with forward-slashed paths
+        // — not the .cmd shim — so no console window allocates per call.
+        expect(hookContent).toContain('"C:/Program Files/nodejs/node.exe"');
+        expect(hookContent).toContain('/node_modules/@rely-ai/caliber/dist/bin.js"');
+        expect(hookContent).not.toContain('caliber.cmd');
+        // Forward slashes on the resolved paths — no Windows-style
+        // ``C:\`` or ``\\`` segments leaked from the where output.
+        // (\\033 ANSI escapes inside echo are fine and expected.)
+        expect(hookContent).not.toMatch(/C:\\/);
+        expect(hookContent).not.toMatch(/\\nodejs\\/);
+        expect(hookContent).not.toMatch(/\\node_modules\\/);
+        // Guard checks node, not caliber.cmd.
+        expect(hookContent).toContain('[ -x "C:/Program Files/nodejs/node.exe" ]');
+      } finally {
+        process.chdir(origCwd);
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it('falls back to .cmd shim when bin.js is missing (pnpm / custom layout)', async () => {
+      const { resetResolvedCaliber } = await import('../resolve-caliber.js');
+      resetResolvedCaliber();
+
+      const tmpDir = makeTmpDir();
+      const gitDir = path.join(tmpDir, '.git');
+      const hooksDir = path.join(gitDir, 'hooks');
+      fs.mkdirSync(hooksDir, { recursive: true });
+
+      // .cmd present but no node_modules tree alongside — simulates pnpm
+      // (which symlinks the bin) or a yarn-classic layout.
+      const fakeCmd = path.join(tmpDir, 'fake-caliber.cmd');
+      fs.writeFileSync(fakeCmd, '');
+
+      mockedExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === 'string' && cmd.includes('where caliber')) {
+          return fakeCmd + '\n';
+        }
+        if (typeof cmd === 'string' && cmd.includes('where node')) {
+          return WIN_NODE + '\n';
+        }
+        if (typeof cmd === 'string' && cmd.includes('rev-parse')) {
+          return `${gitDir}\n`;
+        }
+        return '';
+      });
+
+      const origCwd = process.cwd();
+      process.chdir(tmpDir);
+      try {
+        await withWin32(async () => {
+          const { installPreCommitHook } = await import('../hooks.js');
+          installPreCommitHook();
+        });
+        const hookContent = fs.readFileSync(path.join(hooksDir, 'pre-commit'), 'utf-8');
+
+        // Falls back to invoking the .cmd shim — keeps existing behaviour
+        // working rather than silently no-opping the hook.
+        expect(hookContent).toContain('caliber.cmd');
+        expect(hookContent).not.toContain('"C:/Program Files/nodejs/node.exe"');
+      } finally {
+        process.chdir(origCwd);
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it('falls back to .cmd shim when node is not on PATH', async () => {
+      const { resetResolvedCaliber } = await import('../resolve-caliber.js');
+      resetResolvedCaliber();
+
+      const tmpDir = makeTmpDir();
+      const gitDir = path.join(tmpDir, '.git');
+      const hooksDir = path.join(gitDir, 'hooks');
+      fs.mkdirSync(hooksDir, { recursive: true });
+
+      // Lay down a valid bin.js — only node is missing.
+      const fakeCmd = path.join(tmpDir, 'fake-caliber.cmd');
+      fs.writeFileSync(fakeCmd, '');
+      const expectedBinJs = path.join(
+        tmpDir,
+        'node_modules',
+        '@rely-ai',
+        'caliber',
+        'dist',
+        'bin.js',
+      );
+      fs.mkdirSync(path.dirname(expectedBinJs), { recursive: true });
+      fs.writeFileSync(expectedBinJs, '');
+
+      mockedExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === 'string' && cmd.includes('where caliber')) {
+          return fakeCmd + '\n';
+        }
+        if (typeof cmd === 'string' && cmd.includes('where node')) {
+          throw new Error('not found');
+        }
+        if (typeof cmd === 'string' && cmd.includes('rev-parse')) {
+          return `${gitDir}\n`;
+        }
+        return '';
+      });
+
+      const origCwd = process.cwd();
+      process.chdir(tmpDir);
+      try {
+        await withWin32(async () => {
+          const { installPreCommitHook } = await import('../hooks.js');
+          installPreCommitHook();
+        });
+        const hookContent = fs.readFileSync(path.join(hooksDir, 'pre-commit'), 'utf-8');
+
+        expect(hookContent).toContain('caliber.cmd');
+        expect(hookContent).not.toContain('node.exe');
+      } finally {
+        process.chdir(origCwd);
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+
+    it('does not transform on POSIX even when path looks like .cmd', async () => {
+      // Belt-and-braces: a POSIX user with a file literally named foo.cmd
+      // on PATH should not trigger the Windows-only transformation.
+      const { resetResolvedCaliber } = await import('../resolve-caliber.js');
+      resetResolvedCaliber();
+
+      const tmpDir = makeTmpDir();
+      const gitDir = path.join(tmpDir, '.git');
+      const hooksDir = path.join(gitDir, 'hooks');
+      fs.mkdirSync(hooksDir, { recursive: true });
+
+      mockedExecSync.mockImplementation((cmd: string) => {
+        if (typeof cmd === 'string' && cmd.includes('which caliber')) {
+          return '/usr/local/bin/caliber.cmd\n';
+        }
+        if (typeof cmd === 'string' && cmd.includes('rev-parse')) {
+          return `${gitDir}\n`;
+        }
+        return '';
+      });
+
+      const origCwd = process.cwd();
+      process.chdir(tmpDir);
+      try {
+        // No platform override — runs on the test host (POSIX in CI).
+        const { installPreCommitHook } = await import('../hooks.js');
+        installPreCommitHook();
+        const hookContent = fs.readFileSync(path.join(hooksDir, 'pre-commit'), 'utf-8');
+
+        // Plain absolute-path invocation, no node redirection.
+        expect(hookContent).toContain('"/usr/local/bin/caliber.cmd"');
+        expect(hookContent).not.toContain('node_modules/@rely-ai/caliber');
+      } finally {
+        process.chdir(origCwd);
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+      }
+    });
+  });
+
   describe('global install context', () => {
     beforeEach(() => {
       process.argv[1] = '/usr/local/bin/caliber';

--- a/src/lib/__tests__/hooks.test.ts
+++ b/src/lib/__tests__/hooks.test.ts
@@ -139,6 +139,16 @@ describe('pre-commit hook generation', () => {
       }
     }
 
+    async function withPosix<T>(fn: () => T | Promise<T>): Promise<T> {
+      const original = process.platform;
+      Object.defineProperty(process, 'platform', { value: 'linux', configurable: true });
+      try {
+        return await fn();
+      } finally {
+        Object.defineProperty(process, 'platform', { value: original, configurable: true });
+      }
+    }
+
     beforeEach(() => {
       delete process.env.npm_execpath;
       process.argv[1] = WIN_CALIBER_CMD;
@@ -322,8 +332,18 @@ describe('pre-commit hook generation', () => {
       const hooksDir = path.join(gitDir, 'hooks');
       fs.mkdirSync(hooksDir, { recursive: true });
 
+      // Override the WIN_CALIBER_CMD argv[1] set in beforeEach so
+      // resolveCaliber's argv-shortcut returns a POSIX-shaped path.
+      process.argv[1] = '/usr/local/bin/caliber';
+
+      // Answer both `which caliber` (POSIX) and `where caliber` (Windows)
+      // so this test passes regardless of which CLI resolveCaliber shells
+      // out to — the matrix runs on Windows runners too.
       mockedExecSync.mockImplementation((cmd: string) => {
-        if (typeof cmd === 'string' && cmd.includes('which caliber')) {
+        if (
+          typeof cmd === 'string' &&
+          (cmd.includes('which caliber') || cmd.includes('where caliber'))
+        ) {
           return '/usr/local/bin/caliber.cmd\n';
         }
         if (typeof cmd === 'string' && cmd.includes('rev-parse')) {
@@ -335,9 +355,13 @@ describe('pre-commit hook generation', () => {
       const origCwd = process.cwd();
       process.chdir(tmpDir);
       try {
-        // No platform override — runs on the test host (POSIX in CI).
-        const { installPreCommitHook } = await import('../hooks.js');
-        installPreCommitHook();
+        // Pin platform to 'linux' so this exercises the POSIX code path
+        // regardless of host runner OS — the test's premise is about the
+        // code branch, not the OS the test happens to land on.
+        await withPosix(async () => {
+          const { installPreCommitHook } = await import('../hooks.js');
+          installPreCommitHook();
+        });
         const hookContent = fs.readFileSync(path.join(hooksDir, 'pre-commit'), 'utf-8');
 
         // Plain absolute-path invocation, no node redirection.

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -1,7 +1,12 @@
 import fs from 'fs';
 import path from 'path';
 import { execSync } from 'child_process';
-import { resolveCaliber, isCaliberCommand, isNpxResolution } from './resolve-caliber.js';
+import {
+  resolveCaliber,
+  isCaliberCommand,
+  isNpxResolution,
+  pickExecutable,
+} from './resolve-caliber.js';
 import { bashPath } from '../utils/windows.js';
 
 const SETTINGS_PATH = path.join('.claude', 'settings.json');
@@ -264,6 +269,55 @@ export const removeNotificationHook = notificationHook.remove;
 const PRECOMMIT_START = '# caliber:pre-commit:start';
 const PRECOMMIT_END = '# caliber:pre-commit:end';
 
+/**
+ * On Windows, when caliber resolves to a `.cmd` shim (npm's default global
+ * install), every hook invocation goes through `cmd.exe /d /s /c` which
+ * allocates a new console window — a brief flash on every commit. Worse,
+ * npm's shim emits `title %COMSPEC%` so the flash is titled identically
+ * to an elevated cmd window, prompting users to suspect privilege
+ * escalation when there is none.
+ *
+ * The fix is to call node directly on the package's `bin.js`. The bash
+ * pre-commit hook runs `node "...bin.js" refresh` instead of invoking
+ * the shim, eliminating the cmd flash entirely. Forward-slashed paths
+ * are required for Git-for-Windows bash (same invariant as PR #195).
+ *
+ * Returns null when the transformation can't apply — non-Windows, the
+ * resolved path isn't a `.cmd`, the conventional npm layout doesn't
+ * hold (pnpm, yarn-classic, custom prefix), or `node` isn't on PATH.
+ * Callers fall back to the original `.cmd` invocation in that case.
+ */
+function tryWindowsDirectNodeInvocation(cmd: string): string | null {
+  if (process.platform !== 'win32') return null;
+  if (!/\.cmd$/i.test(cmd)) return null;
+
+  // The .cmd shim sits next to a node_modules/@rely-ai/caliber/dist/bin.js
+  // tree in the standard npm-global layout. If that file isn't where we
+  // expect (pnpm symlinks, custom prefix), bail out so the user keeps the
+  // working .cmd path.
+  const npmDir = path.dirname(cmd);
+  const binJs = path.join(npmDir, 'node_modules', '@rely-ai', 'caliber', 'dist', 'bin.js');
+  if (!fs.existsSync(binJs)) return null;
+
+  let nodePath: string;
+  try {
+    const out = execSync('where node', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+    nodePath = pickExecutable(out);
+    if (!nodePath) return null;
+  } catch {
+    return null;
+  }
+
+  // Forward-slash both paths so Git-for-Windows bash treats them as
+  // literal path strings rather than escape sequences.
+  const fwdNode = nodePath.replace(/\\/g, '/');
+  const fwdBin = binJs.replace(/\\/g, '/');
+  return `"${fwdNode}" "${fwdBin}"`;
+}
+
 function getPrecommitBlock(): string {
   const cmd = resolveCaliber();
   const npx = isNpxResolution();
@@ -288,15 +342,31 @@ function getPrecommitBlock(): string {
       invoke = cmd;
     }
   } else {
-    // cmd is an absolute path (e.g. /opt/homebrew/bin/caliber, C:\Users\...\caliber.cmd)
-    // or bare 'caliber' as last resort. bashPath() normalizes backslashes for bash.
-    const cmdBash = bashPath(cmd);
-    if (path.isAbsolute(cmd)) {
-      guard = `[ -x "${cmdBash}" ]`;
+    // First: on Windows, try to bypass the cmd-shim console flash by
+    // invoking node directly. Returns null on POSIX or when the standard
+    // npm-global layout doesn't hold (pnpm symlinks, custom prefix, etc).
+    const directNode = tryWindowsDirectNodeInvocation(cmd);
+    if (directNode) {
+      // directNode is `"<node-fwd>" "<bin.js-fwd>"` (already forward-slashed).
+      // Guard on the node binary's existence — if node moves we silently
+      // no-op the hook rather than running a stale .cmd shim that no longer
+      // matches.
+      const nodeBin = directNode.match(/^"([^"]+)"/)?.[1] ?? '';
+      guard = `[ -x "${nodeBin}" ]`;
+      invoke = directNode;
     } else {
-      guard = `[ -x "${cmdBash}" ] || command -v "${cmdBash}" >/dev/null 2>&1`;
+      // Fallback: cmd is an absolute path (e.g. /opt/homebrew/bin/caliber,
+      // C:\Users\...\caliber.cmd from a pnpm/custom-prefix layout) or bare
+      // 'caliber' as last resort. bashPath() converts \\ → / so bash
+      // quote-removal doesn't eat the backslashes on Windows.
+      const cmdBash = bashPath(cmd);
+      if (path.isAbsolute(cmd)) {
+        guard = `[ -x "${cmdBash}" ]`;
+      } else {
+        guard = `[ -x "${cmdBash}" ] || command -v "${cmdBash}" >/dev/null 2>&1`;
+      }
+      invoke = `"${cmdBash}"`;
     }
-    invoke = `"${cmdBash}"`;
   }
 
   return `${PRECOMMIT_START}


### PR DESCRIPTION
## Summary

On Windows, every `git commit` flashes a brief `cmd.exe` window on the user's interactive desktop. The flash is titled `C:\Windows\system32\cmd.exe` — visually identical to the default title of an elevated cmd window — because npm's `.cmd` shim template (`cmd-shim.js`) emits `title %COMSPEC%` before invoking node.

This PR makes Caliber's pre-commit hook generator bypass the cmd shim on Windows by deriving `bin.js` adjacent to `caliber.cmd` and emitting a direct `node "...\bin.js"` invocation instead. No cmd, no console allocation, no flash, no admin-look title.

## Repro (before this PR)

```cmd
where caliber
:: C:\Users\<u>\AppData\Roaming\npm\caliber.cmd
:: C:\Users\<u>\AppData\Roaming\npm\caliber

cat .git/hooks/pre-commit | grep caliber
:: "C:\Users\<u>\AppData\Roaming\npm\caliber.cmd" refresh --quiet ...
:: "C:\Users\<u>\AppData\Roaming\npm\caliber.cmd" learn finalize ...

git commit -m "..."
:: → two brief cmd windows pop up titled "C:\Windows\system32\cmd.exe"
```

The titled-like-admin flash has caused real user confusion in our local setup — initial reaction was "did Caliber elevate?" before SSH `whoami /priv` confirmed only `SeChangeNotifyPrivilege`, ruling out actual elevation. The `title %COMSPEC%` line in the npm-generated shim is the cosmetic culprit, but the *flash itself* is the deeper UX issue.

## Repro (after this PR)

```sh
cat .git/hooks/pre-commit | grep node
# "C:/Program Files/nodejs/node.exe" "C:/Users/<u>/AppData/Roaming/npm/node_modules/@rely-ai/caliber/dist/bin.js" refresh --quiet ...
# "C:/Program Files/nodejs/node.exe" "C:/Users/<u>/AppData/Roaming/npm/node_modules/@rely-ai/caliber/dist/bin.js" learn finalize ...
```

bash → `node` directly → no cmd shim → no flash.

## Implementation notes

- **New helper** `tryWindowsDirectNodeInvocation(cmd)` in `src/lib/hooks.ts`. Returns the direct-node form on Windows when conditions hold, `null` otherwise.
- **Conditions for the transformation:**
  1. `process.platform === 'win32'`
  2. Resolved cmd ends in `.cmd` (case-insensitive)
  3. `<dir>/node_modules/@rely-ai/caliber/dist/bin.js` exists alongside the `.cmd`
  4. `where node` succeeds and `pickExecutable` returns a path
- **Forward-slashed paths** for both `node.exe` and `bin.js` to preserve the PR #195 bash-hook invariant. Backslashes break Git-for-Windows bash escape semantics.
- **Falls back to the original `.cmd` invocation** when any condition fails — pnpm symlink layouts, yarn-classic, custom npm prefixes, `node` removed from PATH. Existing installs that don't match the npm-global layout keep working unchanged.
- **POSIX is a strict no-op** — the `process.platform !== 'win32'` early-return ensures Linux/macOS behavior is byte-for-byte identical.
- **npx context unchanged.** The transformation only fires for direct global installs. The npx code path (which has its own `.cmd` flash, but is rarer) is left as-is to avoid scope creep; could be addressed in a follow-up.
- **`resolveCaliber()` itself is untouched** so user-facing strings like `Run \`${resolveCaliber()} config\` ...` (in `llm/index.ts`, `model-recovery.ts`, `bonus.ts`, etc.) keep showing the friendly `caliber` name rather than a path-soup `node bin.js`.

## Test plan

- [x] `npm test` — full suite green (967/967, no regressions)
- [x] `npx vitest run src/lib/__tests__/hooks.test.ts` — 11/11 incl. 4 new
- [x] New tests cover: positive case (direct node invocation, forward-slashed, guard on node), bin.js-missing fallback, node-missing fallback, POSIX no-op
- [x] **Manual smoke on a real Windows 10 host (Node 25.9.0, npm-global install):**
  - `npm install -g <packed-fork>.tgz` then `caliber hooks --install` regenerated `.git/hooks/pre-commit` with the direct-node form (forward-slashed `C:/Program Files/nodejs/node.exe` + `C:/.../node_modules/@rely-ai/caliber/dist/bin.js`).
  - Process snapshot during a real `git commit` showed **zero new `cmd.exe` processes** spawned during hook execution — only node ran (and exited fast enough to miss the snapshot window).
  - Visual confirmation: no cmd window flash on the desktop during the commit. Compared against unpatched 1.47.2 which produced two visible flashes per commit on the same host.
- [ ] (Optional follow-up — not in this PR) Same treatment for the npx code path

## Related

- **#191 → PR #195**: forward-slash paths in bash hook commands. This PR keeps that invariant for both legs of the new direct-node invocation.
- **#194 → PR #196**: telemetry-flush libuv fix. Orthogonal — different code path.
