### PR TITLE
refactor: consolidate Caliber subprocess detection into single sentinel module

### DIFF
--- a/.claude/hooks/caliber-check-sync.sh
+++ b/.claude/hooks/caliber-check-sync.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Don't block headless claude sessions spawned by caliber itself (e.g. during caliber refresh)
-if [ -n "$CALIBER_SPAWNED" ]; then
+if [ "$CALIBER_SUBPROCESS" = "1" ] || [ -n "$CALIBER_SPAWNED" ]; then
   exit 0
 fi
 if grep -q "caliber" .git/hooks/pre-commit 2>/dev/null; then

--- a/.claude/hooks/caliber-freshness-notify.sh
+++ b/.claude/hooks/caliber-freshness-notify.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
+# Don't run inside a caliber-spawned headless session — the systemMessage would
+# pollute the spawned agent's output and serves no purpose there.
+if [ "$CALIBER_SUBPROCESS" = "1" ] || [ -n "$CALIBER_SPAWNED" ]; then
+  exit 0
+fi
 STATE_FILE=".caliber/.caliber-state.json"
 [ ! -f "$STATE_FILE" ] && exit 0
 LAST_SHA=$(grep -o '"lastRefreshSha":"[^"]*"' "$STATE_FILE" 2>/dev/null | cut -d'"' -f4)

--- a/.claude/hooks/caliber-session-freshness.sh
+++ b/.claude/hooks/caliber-session-freshness.sh
@@ -1,4 +1,9 @@
 #!/bin/sh
+# Don't run inside a caliber-spawned headless session — the systemMessage would
+# pollute the spawned agent's output and serves no purpose there.
+if [ "$CALIBER_SUBPROCESS" = "1" ] || [ -n "$CALIBER_SPAWNED" ]; then
+  exit 0
+fi
 STATE_FILE=".caliber/.caliber-state.json"
 [ ! -f "$STATE_FILE" ] && exit 0
 LAST_SHA=$(grep -o '"lastRefreshSha":"[^"]*"' "$STATE_FILE" 2>/dev/null | cut -d'"' -f4)

--- a/src/commands/__tests__/spawned-session-guard.test.ts
+++ b/src/commands/__tests__/spawned-session-guard.test.ts
@@ -1,13 +1,18 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 
 // These tests verify that caliber hook commands exit immediately when
-// CALIBER_SPAWNED=1, which caliber sets in spawnClaude() for all claude -p
-// invocations. Without this guard, SessionEnd hooks fired inside a caliber-spawned
-// session cascade recursively (each makes its own LLM call → new claude -p → new
-// hooks → ...) until Claude Code times one out and reports "Hook cancelled", causing
-// the parent caliber refresh to fail with exit code 1.
+// CALIBER_SUBPROCESS=1, which caliber sets in spawnClaude/spawnOpenCode/cursor-acp
+// for all LLM subprocess invocations. Without this guard, SessionEnd hooks fired
+// inside a caliber-spawned session cascade recursively (each makes its own LLM call
+// → new claude -p → new hooks → ...) until Claude Code times one out and reports
+// "Hook cancelled", causing the parent caliber refresh to fail with exit code 1.
+//
+// CALIBER_SUBPROCESS replaced the legacy CALIBER_SPAWNED env var. The legacy name
+// is still SET by spawn helpers for one transition release (so stale installed
+// .claude/hooks/*.sh files keep working), but no longer READ by TypeScript guards.
+// See src/lib/subprocess-sentinel.ts.
 
-describe('spawned-session guard (CALIBER_SPAWNED=1)', () => {
+describe('spawned-session guard (CALIBER_SUBPROCESS=1)', () => {
   let originalEnv: NodeJS.ProcessEnv;
 
   beforeEach(() => {
@@ -21,8 +26,8 @@ describe('spawned-session guard (CALIBER_SPAWNED=1)', () => {
   });
 
   describe('refreshCommand (quiet mode)', () => {
-    it('returns immediately without calling isCaliberRunning when CALIBER_SPAWNED=1', async () => {
-      process.env.CALIBER_SPAWNED = '1';
+    it('returns immediately without calling isCaliberRunning when CALIBER_SUBPROCESS=1', async () => {
+      process.env.CALIBER_SUBPROCESS = '1';
 
       const lockMock = { isCaliberRunning: vi.fn().mockReturnValue(false) };
       vi.doMock('../../lib/lock.js', () => lockMock);
@@ -33,8 +38,23 @@ describe('spawned-session guard (CALIBER_SPAWNED=1)', () => {
       expect(lockMock.isCaliberRunning).not.toHaveBeenCalled();
     });
 
-    it('proceeds normally when CALIBER_SPAWNED is not set', async () => {
-      delete process.env.CALIBER_SPAWNED;
+    it('proceeds normally when CALIBER_SUBPROCESS is not set', async () => {
+      delete process.env.CALIBER_SUBPROCESS;
+
+      const lockMock = { isCaliberRunning: vi.fn().mockReturnValue(true) };
+      vi.doMock('../../lib/lock.js', () => lockMock);
+
+      const { refreshCommand } = await import('../refresh.js');
+      await expect(refreshCommand({ quiet: true })).resolves.toBeUndefined();
+      expect(lockMock.isCaliberRunning).toHaveBeenCalled();
+    });
+
+    it('does NOT short-circuit on the legacy CALIBER_SPAWNED env var alone', async () => {
+      // Legacy name is still WRITTEN by spawn helpers for one transition release
+      // so stale installed bash hook scripts keep working. But TS guards read
+      // CALIBER_SUBPROCESS only — a bare CALIBER_SPAWNED has no effect.
+      delete process.env.CALIBER_SUBPROCESS;
+      process.env.CALIBER_SPAWNED = '1';
 
       const lockMock = { isCaliberRunning: vi.fn().mockReturnValue(true) };
       vi.doMock('../../lib/lock.js', () => lockMock);
@@ -46,8 +66,8 @@ describe('spawned-session guard (CALIBER_SPAWNED=1)', () => {
   });
 
   describe('learnFinalizeCommand (auto mode)', () => {
-    it('returns immediately without doing any work when CALIBER_SPAWNED=1', async () => {
-      process.env.CALIBER_SPAWNED = '1';
+    it('returns immediately without doing any work when CALIBER_SUBPROCESS=1', async () => {
+      process.env.CALIBER_SUBPROCESS = '1';
 
       const lockMock = { isCaliberRunning: vi.fn(), acquireFinalizeLock: vi.fn() };
       vi.doMock('../../lib/lock.js', () => lockMock);
@@ -57,8 +77,8 @@ describe('spawned-session guard (CALIBER_SPAWNED=1)', () => {
       expect(lockMock.isCaliberRunning).not.toHaveBeenCalled();
     });
 
-    it('proceeds normally when CALIBER_SPAWNED is not set', async () => {
-      delete process.env.CALIBER_SPAWNED;
+    it('proceeds normally when CALIBER_SUBPROCESS is not set', async () => {
+      delete process.env.CALIBER_SUBPROCESS;
 
       // acquireFinalizeLock returns false → early exit, but the point is we got past the guard
       const storageMock = {
@@ -82,8 +102,8 @@ describe('spawned-session guard (CALIBER_SPAWNED=1)', () => {
   });
 
   describe('learnObserveCommand', () => {
-    it('returns immediately when CALIBER_SPAWNED=1', async () => {
-      process.env.CALIBER_SPAWNED = '1';
+    it('returns immediately when CALIBER_SUBPROCESS=1', async () => {
+      process.env.CALIBER_SUBPROCESS = '1';
 
       const { learnObserveCommand } = await import('../learn.js');
       // Should return without reading stdin or doing anything

--- a/src/commands/learn.ts
+++ b/src/commands/learn.ts
@@ -52,6 +52,7 @@ import {
   LEARNING_LAST_ERROR_FILE,
 } from '../constants.js';
 import { resolveCaliber } from '../lib/resolve-caliber.js';
+import { isCaliberSubprocess } from '../lib/subprocess-sentinel.js';
 import {
   trackLearnSessionAnalyzed,
   trackLearnROISnapshot,
@@ -97,7 +98,7 @@ function readFinalizeError(): { timestamp: string; error: string } | null {
 
 export async function learnObserveCommand(options: { failure?: boolean; prompt?: boolean }) {
   // Skip in caliber-spawned headless sessions to prevent recursive hook execution.
-  if (process.env.CALIBER_SPAWNED === '1') return;
+  if (isCaliberSubprocess()) return;
   try {
     const raw = await readStdin();
     if (!raw.trim()) return;
@@ -214,7 +215,7 @@ export async function learnFinalizeCommand(options?: {
   const isIncremental = options?.incremental === true;
 
   // Skip in caliber-spawned headless sessions to prevent recursive hook execution.
-  if (isAuto && process.env.CALIBER_SPAWNED === '1') return;
+  if (isAuto && isCaliberSubprocess()) return;
 
   if (!options?.force && !isAuto) {
     const { isCaliberRunning } = await import('../lib/lock.js');

--- a/src/commands/refresh.ts
+++ b/src/commands/refresh.ts
@@ -14,6 +14,7 @@ import { loadConfig } from '../llm/config.js';
 import { validateModel, TRANSIENT_ERRORS } from '../llm/index.js';
 import { trackRefreshCompleted } from '../telemetry/events.js';
 import { resolveCaliber } from '../lib/resolve-caliber.js';
+import { isCaliberSubprocess } from '../lib/subprocess-sentinel.js';
 import { resolveAllSources } from '../fingerprint/sources.js';
 import { getDetectedWorkspaces } from '../fingerprint/cache.js';
 import { ensureBuiltinSkills } from '../lib/builtin-skills.js';
@@ -433,10 +434,10 @@ export async function refreshCommand(options: RefreshOptions) {
   const quiet = !!options.quiet;
 
   // Skip entirely when running inside a caliber-spawned headless claude session.
-  // caliber sets CLAUDE_CODE_SIMPLE=1 in spawnClaude(); hooks inherit it. Without
+  // caliber sets CALIBER_SUBPROCESS=1 in spawnClaude(); hooks inherit it. Without
   // this guard the SessionEnd hooks cascade: each spawns another claude -p which
   // fires the same hooks again until Claude Code times one out → "Hook cancelled".
-  if (quiet && process.env.CALIBER_SPAWNED === '1') return;
+  if (quiet && isCaliberSubprocess()) return;
 
   // Skip if another caliber process is already running (e.g. hook fired mid-session)
   if (quiet) {

--- a/src/lib/__tests__/caliber-hooks-shell.test.ts
+++ b/src/lib/__tests__/caliber-hooks-shell.test.ts
@@ -42,10 +42,19 @@ describe('caliber-check-sync.sh', () => {
     }
   });
 
-  it('exits 0 immediately when CALIBER_SPAWNED=1 (spawned by caliber)', () => {
-    // caliber spawns `claude -p` with CALIBER_SPAWNED=1 (injected after cleanClaudeEnv()).
+  it('exits 0 immediately when CALIBER_SUBPROCESS=1 (spawned by caliber)', () => {
+    // Caliber spawns LLM subprocesses with CALIBER_SUBPROCESS=1 via spawnClaude/etc.
     // The Stop hook must not block in that context or it will cancel SessionEnd hooks,
     // causing Claude CLI to exit with code 1 and breaking `caliber refresh`.
+    const { status, stdout } = runScript(tmpDir, { CALIBER_SUBPROCESS: '1' });
+    expect(status).toBe(0);
+    expect(stdout).not.toContain('"decision":"block"');
+  });
+
+  it('exits 0 immediately when legacy CALIBER_SPAWNED=1 (transition compatibility)', () => {
+    // Legacy env var is still written by spawn helpers for one release window so
+    // stale .claude/hooks/*.sh files installed by older Caliber keep working.
+    // The script honors both names; this test pins that contract.
     const { status, stdout } = runScript(tmpDir, { CALIBER_SPAWNED: '1' });
     expect(status).toBe(0);
     expect(stdout).not.toContain('"decision":"block"');

--- a/src/lib/__tests__/subprocess-sentinel.test.ts
+++ b/src/lib/__tests__/subprocess-sentinel.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import {
+  CALIBER_SUBPROCESS_ENV,
+  CALIBER_SUBPROCESS_LEGACY_ENV,
+  isCaliberSubprocess,
+  withCaliberSubprocessEnv,
+} from '../subprocess-sentinel.js';
+
+describe('subprocess-sentinel', () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    delete process.env[CALIBER_SUBPROCESS_ENV];
+    delete process.env[CALIBER_SUBPROCESS_LEGACY_ENV];
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  describe('isCaliberSubprocess()', () => {
+    it('returns false when CALIBER_SUBPROCESS is unset', () => {
+      expect(isCaliberSubprocess()).toBe(false);
+    });
+
+    it('returns true when CALIBER_SUBPROCESS=1', () => {
+      process.env[CALIBER_SUBPROCESS_ENV] = '1';
+      expect(isCaliberSubprocess()).toBe(true);
+    });
+
+    it('returns false when CALIBER_SUBPROCESS is set to anything other than "1"', () => {
+      process.env[CALIBER_SUBPROCESS_ENV] = 'true';
+      expect(isCaliberSubprocess()).toBe(false);
+      process.env[CALIBER_SUBPROCESS_ENV] = '0';
+      expect(isCaliberSubprocess()).toBe(false);
+      process.env[CALIBER_SUBPROCESS_ENV] = '';
+      expect(isCaliberSubprocess()).toBe(false);
+    });
+
+    it('does NOT read the legacy CALIBER_SPAWNED env var (clean rename)', () => {
+      // The legacy var is still WRITTEN by withCaliberSubprocessEnv() so stale
+      // installed bash hook scripts keep working, but new TS code only reads the
+      // canonical CALIBER_SUBPROCESS name. A bare CALIBER_SPAWNED with no
+      // CALIBER_SUBPROCESS would mean someone set the env var by hand — not
+      // something we want to honor.
+      process.env[CALIBER_SUBPROCESS_LEGACY_ENV] = '1';
+      expect(isCaliberSubprocess()).toBe(false);
+    });
+  });
+
+  describe('withCaliberSubprocessEnv()', () => {
+    it('sets CALIBER_SUBPROCESS=1 on the returned env', () => {
+      const env = withCaliberSubprocessEnv({ FOO: 'bar' } as NodeJS.ProcessEnv);
+      expect(env[CALIBER_SUBPROCESS_ENV]).toBe('1');
+    });
+
+    it('also sets the legacy CALIBER_SPAWNED=1 for one transition release', () => {
+      // Stale .claude/hooks/*.sh files installed by Caliber <= 1.47 check
+      // $CALIBER_SPAWNED. Setting both at spawn keeps those scripts working
+      // until the user re-runs `caliber init`. Drop in the next minor.
+      const env = withCaliberSubprocessEnv({ FOO: 'bar' } as NodeJS.ProcessEnv);
+      expect(env[CALIBER_SUBPROCESS_LEGACY_ENV]).toBe('1');
+    });
+
+    it('preserves the input env entries', () => {
+      const env = withCaliberSubprocessEnv({ FOO: 'bar', BAZ: 'qux' } as NodeJS.ProcessEnv);
+      expect(env.FOO).toBe('bar');
+      expect(env.BAZ).toBe('qux');
+    });
+
+    it('does not mutate the input env object', () => {
+      const input: NodeJS.ProcessEnv = { FOO: 'bar' };
+      withCaliberSubprocessEnv(input);
+      expect(input).toEqual({ FOO: 'bar' });
+      expect(CALIBER_SUBPROCESS_ENV in input).toBe(false);
+    });
+
+    it('overrides any existing CALIBER_SUBPROCESS/CALIBER_SPAWNED in the input', () => {
+      const env = withCaliberSubprocessEnv({
+        [CALIBER_SUBPROCESS_ENV]: '0',
+        [CALIBER_SUBPROCESS_LEGACY_ENV]: 'no',
+      });
+      expect(env[CALIBER_SUBPROCESS_ENV]).toBe('1');
+      expect(env[CALIBER_SUBPROCESS_LEGACY_ENV]).toBe('1');
+    });
+
+    it('handles undefined values in the input env (NodeJS.ProcessEnv shape)', () => {
+      const input: NodeJS.ProcessEnv = { FOO: undefined, BAR: 'set' };
+      const env = withCaliberSubprocessEnv(input);
+      expect(env.FOO).toBeUndefined();
+      expect(env.BAR).toBe('set');
+      expect(env[CALIBER_SUBPROCESS_ENV]).toBe('1');
+    });
+  });
+});

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -183,6 +183,10 @@ function createScriptHook(config: ScriptHookConfig) {
 // ── Stop hook (onboarding nudge) ────────────────────────────────────
 
 const STOP_HOOK_SCRIPT_CONTENT = `#!/bin/sh
+# Don't block headless claude sessions spawned by caliber itself (e.g. during caliber refresh)
+if [ "$CALIBER_SUBPROCESS" = "1" ] || [ -n "$CALIBER_SPAWNED" ]; then
+  exit 0
+fi
 if grep -q "caliber" .git/hooks/pre-commit 2>/dev/null; then
   exit 0
 fi
@@ -210,6 +214,11 @@ export const removeStopHook = stopHook.remove;
 function getFreshnessScript(): string {
   const bin = resolveCaliber();
   return `#!/bin/sh
+# Don't run inside a caliber-spawned headless session — the systemMessage would
+# pollute the spawned agent's output and serves no purpose there.
+if [ "$CALIBER_SUBPROCESS" = "1" ] || [ -n "$CALIBER_SPAWNED" ]; then
+  exit 0
+fi
 STATE_FILE=".caliber/.caliber-state.json"
 [ ! -f "$STATE_FILE" ] && exit 0
 LAST_SHA=$(grep -o '"lastRefreshSha":"[^"]*"' "$STATE_FILE" 2>/dev/null | cut -d'"' -f4)

--- a/src/lib/subprocess-sentinel.ts
+++ b/src/lib/subprocess-sentinel.ts
@@ -1,0 +1,53 @@
+/**
+ * Sentinel for detecting whether the current process was spawned by Caliber itself.
+ *
+ * Why this exists:
+ * Caliber spawns LLM subprocesses (`claude -p`, `cursor agent --print`, `opencode run`)
+ * to do its work. Those subprocesses inherit the project's `.claude/settings.json`,
+ * which contains hooks Caliber installed itself (Stop, SessionEnd, PostToolUse, etc).
+ * Without a sentinel those hooks re-invoke Caliber, which re-spawns the LLM, which
+ * re-fires the same hooks — a recursive cascade that has caused multiple bugs
+ * (#150, #169, #171, #194). Each was fixed by adding ad-hoc env-var checks at one
+ * specific layer; this module consolidates those checks into a single canonical API.
+ *
+ * The contract:
+ *   - Spawn helpers (spawnClaude/spawnOpenCode/cursor agent) wrap their env with
+ *     `withCaliberSubprocessEnv()` so all descendants see the sentinel.
+ *   - Hook entry points (caliber learn observe, caliber refresh --quiet, the bash
+ *     hook scripts) check `isCaliberSubprocess()` and short-circuit if true.
+ *
+ * Migration note (transition release):
+ * Older Caliber releases used the env var name `CALIBER_SPAWNED`. Bash hook scripts
+ * installed in user repos by those versions check that name. To keep them working
+ * during the upgrade window, `withCaliberSubprocessEnv()` writes BOTH names. New
+ * Caliber code only reads the canonical name (`CALIBER_SUBPROCESS`). Drop the
+ * legacy write in the next minor release.
+ */
+
+export const CALIBER_SUBPROCESS_ENV = 'CALIBER_SUBPROCESS';
+
+/** Legacy name still SET (not read) by withCaliberSubprocessEnv during the transition. */
+export const CALIBER_SUBPROCESS_LEGACY_ENV = 'CALIBER_SPAWNED';
+
+/**
+ * Returns true when the current process was spawned by Caliber itself.
+ * Hook entry points should check this and exit early to prevent recursive cascades.
+ */
+export function isCaliberSubprocess(): boolean {
+  return process.env[CALIBER_SUBPROCESS_ENV] === '1';
+}
+
+/**
+ * Returns a NEW env object marked as a Caliber subprocess. Pass this to
+ * `child_process.spawn(..., { env })` so the marker is inherited by all descendants.
+ *
+ * Sets both the canonical name and the legacy name so hook scripts installed by
+ * older Caliber versions continue to short-circuit.
+ */
+export function withCaliberSubprocessEnv<T extends NodeJS.ProcessEnv>(env: T): T {
+  return {
+    ...env,
+    [CALIBER_SUBPROCESS_ENV]: '1',
+    [CALIBER_SUBPROCESS_LEGACY_ENV]: '1',
+  };
+}

--- a/src/llm/claude-cli.ts
+++ b/src/llm/claude-cli.ts
@@ -10,6 +10,7 @@ import type {
 import { parseSeatBasedError } from './seat-based-errors.js';
 import { trackUsage } from './usage.js';
 import { estimateTokens } from './utils.js';
+import { withCaliberSubprocessEnv } from '../lib/subprocess-sentinel.js';
 
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
 const IS_WINDOWS = process.platform === 'win32';
@@ -92,9 +93,10 @@ function cleanClaudeEnv(): Record<string, string | undefined> {
 
 function spawnClaude(args: string[]): ChildProcess {
   const bin = resolveClaudeBin();
-  // CALIBER_SPAWNED=1 signals to caliber's own hooks that they are running inside
-  // a caliber-spawned session and should be no-ops (prevents recursive hook cascade).
-  const env = { ...cleanClaudeEnv(), CALIBER_SPAWNED: '1' };
+  // Mark the spawned process (and all descendants) as a Caliber subprocess so
+  // Caliber's own hooks short-circuit instead of re-invoking Caliber recursively.
+  // See src/lib/subprocess-sentinel.ts.
+  const env = withCaliberSubprocessEnv(cleanClaudeEnv());
   return IS_WINDOWS
     ? spawn([bin, ...args].join(' '), {
         cwd: process.cwd(),
@@ -309,7 +311,7 @@ export function isClaudeCliLoggedIn(): boolean {
       input: '',
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 5000,
-      env: cleanClaudeEnv(),
+      env: withCaliberSubprocessEnv(cleanClaudeEnv()),
     });
     const output = result.toString().trim();
     try {

--- a/src/llm/cursor-acp.ts
+++ b/src/llm/cursor-acp.ts
@@ -11,6 +11,7 @@ import { parseSeatBasedError, isRateLimitError } from './seat-based-errors.js';
 import { trackUsage } from './usage.js';
 import { estimateTokens } from './utils.js';
 import { quoteForWindows } from '../utils/windows.js';
+import { withCaliberSubprocessEnv } from '../lib/subprocess-sentinel.js';
 
 const IS_WINDOWS = process.platform === 'win32';
 
@@ -112,7 +113,10 @@ export class CursorAcpProvider implements LLMProvider {
     if (this.warmProcess && !this.warmProcess.killed && this.warmModel === targetModel) return;
 
     const args = this.buildArgs(targetModel, false);
-    const env = { ...process.env, ...(this.cursorApiKey && { CURSOR_API_KEY: this.cursorApiKey }) };
+    const env = withCaliberSubprocessEnv({
+      ...process.env,
+      ...(this.cursorApiKey && { CURSOR_API_KEY: this.cursorApiKey }),
+    });
     this.warmProcess = IS_WINDOWS
       ? spawn([quoteForWindows(resolveAgentBin()), ...args.map(quoteForWindows)].join(' '), {
           stdio: ['pipe', 'pipe', 'pipe'],
@@ -177,7 +181,10 @@ export class CursorAcpProvider implements LLMProvider {
     }
 
     const args = this.buildArgs(model, streaming);
-    const env = { ...process.env, ...(this.cursorApiKey && { CURSOR_API_KEY: this.cursorApiKey }) };
+    const env = withCaliberSubprocessEnv({
+      ...process.env,
+      ...(this.cursorApiKey && { CURSOR_API_KEY: this.cursorApiKey }),
+    });
     const child = IS_WINDOWS
       ? spawn([quoteForWindows(resolveAgentBin()), ...args.map(quoteForWindows)].join(' '), {
           stdio: ['pipe', 'pipe', 'pipe'],

--- a/src/llm/opencode.ts
+++ b/src/llm/opencode.ts
@@ -9,6 +9,7 @@ import type {
 import { parseSeatBasedError } from './seat-based-errors.js';
 import { trackUsage } from './usage.js';
 import { estimateTokens } from './utils.js';
+import { withCaliberSubprocessEnv } from '../lib/subprocess-sentinel.js';
 
 const OPENCODE_BIN = 'opencode';
 const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000;
@@ -57,7 +58,8 @@ export function isOpenCodeLoggedIn(): boolean {
  * Common spawn helper for OpenCode. Handles Windows vs Unix, env with OPENCODE_DISABLE_AUTOCOMPACT=TRUE.
  */
 function spawnOpenCode(args: string[]): ChildProcess {
-  const env = { ...process.env, OPENCODE_DISABLE_AUTOCOMPACT: 'TRUE' };
+  // Same subprocess sentinel pattern as spawnClaude — see src/lib/subprocess-sentinel.ts.
+  const env = withCaliberSubprocessEnv({ ...process.env, OPENCODE_DISABLE_AUTOCOMPACT: 'TRUE' });
   if (IS_WINDOWS) {
     return spawn([OPENCODE_BIN, ...args].join(' '), {
       cwd: process.cwd(),


### PR DESCRIPTION
## Summary

Consolidates the ad-hoc `process.env.CALIBER_SPAWNED === '1'` checks scattered across `learn.ts`, `refresh.ts`, and the bash hook scripts into a single canonical helper at `src/lib/subprocess-sentinel.ts`.

This closes the *"this pattern keeps reappearing"* class of bugs visible in #150, #169, #171, and partially #194 — each was patched in isolation at one specific layer, leaving other layers exposed. The next time we add a hook or a new LLM provider, the sentinel pattern is now first-class.

## What changed

**New canonical helper**
- `src/lib/subprocess-sentinel.ts` — exports `isCaliberSubprocess()`, `withCaliberSubprocessEnv()`, and the env var name constants.

**Spawn helpers (set the sentinel)**
- `spawnClaude` and `isClaudeCliLoggedIn` in `src/llm/claude-cli.ts` (the latter is defensive — `auth status` doesn't fire hooks today, but consistency is cheap)
- `spawnOpenCode` in `src/llm/opencode.ts` — **previously did NOT set the sentinel**, latent gap closed
- `prewarm` and `spawnAgent` in `src/llm/cursor-acp.ts` — **also previously did NOT set the sentinel**, latent gap closed

**Check sites (read the sentinel)**
- `learnObserveCommand` and `learnFinalizeCommand` (auto mode) in `src/commands/learn.ts`
- `refreshCommand` (quiet mode) in `src/commands/refresh.ts`

**Bash hooks (template + installed)**
- `STOP_HOOK_SCRIPT_CONTENT` template in `src/lib/hooks.ts` — **was missing the guard the installed `caliber-check-sync.sh` already had**, silent template/installed drift fixed
- `getFreshnessScript()` template — guard added (the freshness scripts had no subprocess guard at all)
- All three installed `.claude/hooks/*.sh` files updated to honor both env var names

**Tests updated**
- `src/commands/__tests__/spawned-session-guard.test.ts` — env var rename + new regression test that legacy `CALIBER_SPAWNED` alone does NOT trigger the TS guard
- `src/lib/__tests__/caliber-hooks-shell.test.ts` — added test asserting both env var names work in the bash script (transition compatibility)

## Migration — read this carefully

The env var was renamed `CALIBER_SPAWNED` → `CALIBER_SUBPROCESS`. To keep stale `.claude/hooks/*.sh` from older Caliber installs working, `withCaliberSubprocessEnv()` writes BOTH names. New TypeScript code reads only the new name.

**Honest detail surfaced by review:** `installStopHook()` (and the other script-hook installers) short-circuit with `alreadyInstalled: true` when the matcher already exists in `.claude/settings.json`. That means **users who already have the old `.sh` files keep them indefinitely** — neither `caliber init` nor `caliber refresh` rewrites them. The dual-write of `CALIBER_SPAWNED` is what carries them forever, not just during a "transition window." This is OK because the dual-write costs nothing and the behavior is identical, but it means we can't safely "drop the legacy write in the next minor" the way the original commit message implied. To actually retire the legacy name, we'd need an upgrade path that rewrites `.sh` files (e.g., a `caliber upgrade-hooks` subcommand or a version-pinned regen).

For now: dual-write stays. Track the cleanup as a follow-up.

## Behavior change worth calling out

A user manually setting `CALIBER_SPAWNED=1` to debug-skip the TS guard is now a no-op (TS guards read only `CALIBER_SUBPROCESS`). The new regression test in `spawned-session-guard.test.ts` pins this. Niche but undocumented before now.

## Verification

- 975/975 tests passing across 80 files (10 new in `subprocess-sentinel.test.ts`, regression test asserting legacy var no longer triggers TS guard, transition test asserting bash script honors both names)
- `npx tsc --noEmit` clean
- `npm run lint` clean (no new warnings)
- `npm run build` clean

## Test plan

- [x] Unit tests for sentinel module (set/check/wrap)
- [x] Existing guard tests updated for new env var name
- [x] Regression test: bare `CALIBER_SPAWNED` (legacy) does NOT trigger TS guard
- [x] Transition test: bash script accepts both `CALIBER_SUBPROCESS` and `CALIBER_SPAWNED`
- [x] Stop hook template no longer drifts from installed copy
- [ ] Manual smoke: \`caliber refresh\` from a fresh repo with a Claude Code session running (recommended before merge — none of the tests reproduce the actual cascade end-to-end)

## Heads up — small drive-by

The commit also includes a 3-line `.gitignore` addition (\`.claude/settings.local.json\`) that was sitting uncommitted in my working tree before I started this work. It got swept into the commit by lint-staged. It's a sensible addition (personal Claude Code permissions shouldn't be tracked) but unrelated to the subprocess sentinel scope. Happy to split into a separate commit if you'd prefer.