### PR TITLE
fix(hooks): skip Stop nudge when not in a git repo + sync template

### DIFF
--- a/.claude/hooks/caliber-check-sync.sh
+++ b/.claude/hooks/caliber-check-sync.sh
@@ -3,6 +3,11 @@
 if [ "$CALIBER_SUBPROCESS" = "1" ] || [ -n "$CALIBER_SPAWNED" ]; then
   exit 0
 fi
+# Caliber only applies to git repos. Skip the nudge when there's no git context
+# (e.g. .claude/ shipped into a non-git directory, scratch dirs, model archives).
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  exit 0
+fi
 if grep -q "caliber" .git/hooks/pre-commit 2>/dev/null; then
   exit 0
 fi

--- a/src/lib/__tests__/caliber-hooks-shell.test.ts
+++ b/src/lib/__tests__/caliber-hooks-shell.test.ts
@@ -8,6 +8,10 @@ const SCRIPT = path.resolve(process.cwd(), '.claude/hooks/caliber-check-sync.sh'
 
 function makeTmpDir(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'caliber-hooks-test-'));
+  // `git init -q` makes it a real repo so `git rev-parse --git-dir` succeeds.
+  // The hook now early-exits when not in a git repo, so a bare `.git/hooks/`
+  // skeleton is no longer enough — we need an actual repository.
+  spawnSync('git', ['init', '-q'], { cwd: dir });
   fs.mkdirSync(path.join(dir, '.git', 'hooks'), { recursive: true });
   return dir;
 }
@@ -39,6 +43,20 @@ describe('caliber-check-sync.sh', () => {
       for (const f of files) fs.unlinkSync(path.join(os.tmpdir(), f));
     } catch {
       // best-effort
+    }
+  });
+
+  it('exits 0 silently when the directory is not a git repo', () => {
+    // Common case: a `.claude/` directory was generated in a non-git directory
+    // (scratch dir, model archive, etc.). Caliber refresh won't run there
+    // anyway, so the nudge is just noise — must not fire.
+    const nonGitDir = fs.mkdtempSync(path.join(os.tmpdir(), 'caliber-nogit-'));
+    try {
+      const { status, stdout } = runScript(nonGitDir);
+      expect(status).toBe(0);
+      expect(stdout).not.toContain('"decision":"block"');
+    } finally {
+      fs.rmSync(nonGitDir, { recursive: true, force: true });
     }
   });
 

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -193,6 +193,11 @@ const STOP_HOOK_SCRIPT_CONTENT = `#!/bin/sh
 if [ "$CALIBER_SUBPROCESS" = "1" ] || [ -n "$CALIBER_SPAWNED" ]; then
   exit 0
 fi
+# Caliber only applies to git repos. Skip the nudge when there's no git context
+# (e.g. .claude/ shipped into a non-git directory, scratch dirs, model archives).
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+  exit 0
+fi
 if grep -q "caliber" .git/hooks/pre-commit 2>/dev/null; then
   exit 0
 fi


### PR DESCRIPTION
## Summary

The Stop hook (`.claude/hooks/caliber-check-sync.sh`) fires the
"Caliber agent config sync is not set up — run /setup-caliber?" nudge
in directories that aren't git repos. Once `.claude/` exists,
`grep -q "caliber" .git/hooks/pre-commit 2>/dev/null` exits non-zero
because `.git/` doesn't exist, so the script falls through to the
nudge. Caliber `init` / `refresh` can't run there anyway, so the
nudge is pure noise.

Reproducer:

    mkdir -p /tmp/notrepo/.claude/hooks
    cd /tmp/notrepo
    sh ~/.../caliber-check-sync.sh   # outputs "decision":"block"

I hit this myself with a Claude Code session running in a directory
that isn't a git repo, and verified the fix resolves it.

## Fix

Add `git rev-parse --git-dir >/dev/null 2>&1 || exit 0` near the top
of both copies (the deployed script in this repo and the
`STOP_HOOK_SCRIPT_CONTENT` template in `src/lib/hooks.ts` that ships
to user projects).

Sits after the existing
`CALIBER_SUBPROCESS=1 || CALIBER_SPAWNED` early-exit so caliber-spawned
sessions still bypass it; sits before the pre-commit grep so a
no-`.git` directory short-circuits cleanly.

## Tests

- New: `'exits 0 silently when the directory is not a git repo'` —
  creates a non-git tempdir, runs the hook, asserts exit 0 + no
  block decision.
- `makeTmpDir()` now does a real `git init -q` because the new check
  rejects bare `.git/hooks/` skeletons (which the previous setup
  was relying on without realizing it).
- Full suite locally: **1009/1009 passing**.

## Test plan

- [x] `npm test src/lib/__tests__/caliber-hooks-shell.test.ts` — 6/6
- [x] `npm test` — 1009/1009
- [x] Manual repro in `/tmp/notrepo` (non-git): pre-fix outputs
  block, post-fix exits 0
- [x] Manual repro in a real git repo without caliber pre-commit:
  pre-fix outputs block, post-fix outputs block (unchanged behavior)
- [x] Manual repro with caliber in pre-commit: exits 0 (unchanged)
- [x] Manual repro with `CALIBER_SUBPROCESS=1`: exits 0 (unchanged)
- [x] Manual repro with `CALIBER_SPAWNED=1`: exits 0 (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)