### PR TITLE
v1.49.1: install audit P0 batch 2 (cascade fix, dedup, timeout) — stacked on #202

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## v1.49.2 (2026-04-30)
+
+### Bug Fixes (install audit batch 2)
+
+- **refresh, learn**: skip silently when `--quiet` / `--auto` and inside a user-initiated Claude Code session (`CLAUDECODE=1` && `!CALIBER_SUBPROCESS`). Eliminates the "Hook cancelled" stderr noise + ~15s latency on every interactive `claude -p` in a Caliber-equipped repo. (F-P0-9)
+- **writers**: managed-block injection (CLAUDE.md, AGENTS.md, copilot-instructions.md, cursor rules) now detects unmarked inlined sections and skips re-adding them. Eliminates ~50 lines of duplicate content per CLAUDE.md after init. (F-P0-10)
+- **generate**: bump default `CALIBER_STREAM_INACTIVITY_TIMEOUT_MS` from 120000 → 300000. Surface env-var hint at 60s of silence instead of waiting for the hard timeout. Fixes "Model produced no output" failures on large-prompt repos (caliber-dogfood scale, ~300 files). (F-P0-2)
+
+These complete fixes #2, #9, and #10 from the install audit P0 list. Combined with v1.49.0, six of the eight verified P0s are now resolved (F-P0-6 was indirectly fixed by v1.49.0's hook auto-upgrade). See `docs/superpowers/specs/2026-04-29-caliber-install-audit-findings.md` for the full findings list and the v1.49.0 correction note for F-P0-7/8/11.
+
 ## v1.49.1 (2026-04-29)
 
 ### Other

--- a/docs/superpowers/plans/2026-04-29-caliber-install-audit-fixes-2.md
+++ b/docs/superpowers/plans/2026-04-29-caliber-install-audit-fixes-2.md
@@ -1,0 +1,868 @@
+# Caliber install-audit P0 fixes — batch 2
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the next 3 verified P0 fixes from the install audit so the worst remaining install-reliability + UX problems are gone before any messaging redesign.
+
+**Architecture:** Three surgical, independent fixes. Each is a small focused change with a tight unit test. They share no code paths so they ship as three commits on one branch as a single PR. Branched off `alonp98/install-audit` (PR #202) so they sit on top of batch 1 — when #202 lands, this branch needs a trivial rebase.
+
+**Tech Stack:** TypeScript (Node ≥ 20), tsup build, vitest tests, prettier+eslint. Branch: `alonp98/install-audit-fixes-2` off `alonp98/install-audit`.
+
+**Source spec:** `docs/superpowers/specs/2026-04-29-caliber-install-audit-findings.md`
+
+**Pre-batch correction (lands as a doc-only commit at the start):** The audit-findings doc cited F-P0-7 (Phase 1 returns `{}` silently) and F-P0-8 (Phase 2 swallowed failures) based on the explore agent's structural map. Source-code review for this plan shows both are actually handled correctly in current source — Phase 1 returns `null` on parse failure (not `{}`), and Phase 2 surfaces failure counts via `callbacks.onStatus` in both call sites. F-P0-11 was a derived finding from those two, so it's also moot. The findings doc gets a correction block.
+
+---
+
+## Scope check
+
+Three verified-real P0s, each in a different code area:
+1. **F-P0-9: SessionEnd hook cascade** on user-initiated `claude -p` (`src/commands/refresh.ts`, `src/commands/learn.ts`).
+2. **F-P0-10: CLAUDE.md duplicated sections** when init inlines content that managed-block injection then re-adds (`src/writers/pre-commit-block.ts`).
+3. **F-P0-2: Large-prompt inactivity timeout** that fires before the model produces its first token on big repos (`src/ai/generate.ts`).
+
+Plus 1 correction commit at the front for the inaccurate F-P0-7/8/11 findings.
+
+**Deferred to follow-up:** all P1s and P2s — they're polish on top of P0s.
+
+---
+
+## File structure
+
+| File | Responsibility | Change |
+|------|----------------|--------|
+| `docs/superpowers/specs/2026-04-29-caliber-install-audit-findings.md` | Audit findings doc | Add correction note for F-P0-7/8/11 |
+| `src/commands/refresh.ts` | `caliber refresh` command entry | Short-circuit when `--quiet` AND running inside Claude Code AND not a caliber subprocess |
+| `src/commands/learn.ts` | `caliber learn finalize` command entry | Same short-circuit pattern, gated on `--auto` flag |
+| `src/commands/__tests__/refresh.test.ts` | Existing test file | Add tests for the short-circuit behavior |
+| `src/commands/__tests__/learn-finalize-cascade.test.ts` | New test file | Test for the learn-finalize short-circuit |
+| `src/writers/pre-commit-block.ts` | Managed-block injection (CLAUDE.md) | `appendXBlock` functions detect existing unmarked content and skip re-injection |
+| `src/writers/__tests__/pre-commit-block.test.ts` | Existing test file | Add tests for de-duplication behavior |
+| `src/ai/generate.ts` | Generation pipeline | Bump `DEFAULT_INACTIVITY_TIMEOUT_MS` from 120000 → 300000; surface env-var hint in mid-stream status when waiting > 60s |
+| `package.json` | Build manifest | Bump version to `1.49.1` (patch — these are bug fixes, no API changes) |
+| `CHANGELOG.md` | Release notes | Add entry for 1.49.1 with the 3 fixes |
+
+---
+
+## Task 0: Pre-flight + branch setup
+
+**Files:** none — environment check + branch creation only
+
+- [ ] **Step 1: Confirm we're on the install-audit branch with PR #202 pushed**
+
+```bash
+cd /Users/alonpe/personal/caliber
+git branch --show-current
+git status --short
+gh pr view 202 --json state,headRefName 2>&1 | head -5
+```
+
+Expected: branch is `alonp98/install-audit`, only the standard untracked files (`.claude/settings.local.json` etc), PR #202 is OPEN with headRefName `alonp98/install-audit`.
+
+- [ ] **Step 2: Create the new branch off the current one**
+
+```bash
+git checkout -b alonp98/install-audit-fixes-2
+git log --oneline | head -3
+```
+
+Expected: new branch created, HEAD points to the v1.49.0 release commit (`e83fb51` or whatever was the latest on the audit branch).
+
+- [ ] **Step 3: Confirm baseline tests are green**
+
+```bash
+npm test 2>&1 | tail -5
+node dist/bin.js --version
+```
+
+Expected: `Tests 1035 passed (1035)`, version `1.49.0`. If anything is red, STOP.
+
+---
+
+## Task 1: Audit-findings correction
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-04-29-caliber-install-audit-findings.md`
+
+- [ ] **Step 1: Add a correction block at the top of the Findings section**
+
+Open the findings doc and find the heading `## Findings`. Insert ABOVE the `### P0 — Blocks install or causes data-loss-like outcomes` subheading:
+
+```markdown
+> **2026-04-29 correction (after closer source review):** Findings F-P0-7, F-P0-8, and F-P0-11 below were based on the explore agent's structural map of `src/ai/generate.ts`, which mischaracterized two failure paths.
+>
+> - **F-P0-7** claimed Phase 1 returns `{}` silently on JSON parse failure. Actual source returns `null` (`src/ai/generate.ts` — see the `try { setup = JSON.parse... } catch {}` block followed by `if (setup) { resolve(...) } else { resolve({ setup: null, ... }) }`). The caller (`init.ts:643`) properly handles `null` and writes the error log.
+> - **F-P0-8** claimed Phase 2 skill failures are swallowed by `Promise.allSettled`. Actual source surfaces failures at both call sites via `callbacks.onStatus` with messages like `"Warning: 2 of 5 skills failed to generate"` (lines 174–186 and 644–655 in `src/ai/generate.ts`).
+> - **F-P0-11** was a derived finding from F-P0-7 + F-P0-8. Since both are non-issues in current source, this is also moot.
+>
+> The corrected findings count: **8 P0** (was 11), 22 P1, 22 P2. The next batch of fixes (PR for `alonp98/install-audit-fixes-2`) addresses F-P0-9 (SessionEnd cascade), F-P0-10 (duplicated CLAUDE.md sections), and F-P0-2 (large-prompt timeout). F-P0-6 was already addressed in PR #202 via the hook auto-upgrade (F-P0-4).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-04-29-caliber-install-audit-findings.md
+git commit -m "docs(audit): correct F-P0-7/8/11 — were false positives from agent
+
+Source review for the next fix batch revealed F-P0-7 (Phase 1 returns
+{} on parse failure) and F-P0-8 (Phase 2 failures swallowed) are not
+actual bugs. The explore agent's structural map of generate.ts
+mischaracterized two failure paths. Phase 1 returns null on parse
+failure (caller handles correctly). Phase 2 surfaces failure counts
+via callbacks.onStatus at both call sites.
+
+F-P0-11 was derived from those two, so it's also moot.
+
+Updated count: 8 verified P0s (was 11). Next fix batch
+(install-audit-fixes-2) addresses the three highest-impact
+remaining: F-P0-9, F-P0-10, F-P0-2."
+```
+
+---
+
+## Task 2: F-P0-9 — SessionEnd hook short-circuit
+
+**Files:**
+- Modify: `src/commands/refresh.ts` (early-exit check at command entry)
+- Modify: `src/commands/learn.ts` (same check in `learnFinalizeCommand`)
+- Modify: `src/commands/__tests__/refresh.test.ts`
+- Create: `src/commands/__tests__/learn-finalize-cascade.test.ts`
+
+### Task 2a: Add the shared detection helper
+
+- [ ] **Step 1: Add an exported helper to subprocess-sentinel.ts**
+
+Open `src/lib/subprocess-sentinel.ts`. After the existing `isCaliberSubprocess()` function, append:
+
+```typescript
+/**
+ * True when this caliber invocation is firing as a SessionEnd / hook
+ * cascade from inside an unrelated (user-initiated) Claude Code session.
+ *
+ * Specifically: we're inside a Claude Code session (CLAUDECODE=1) that
+ * caliber did NOT spawn (CALIBER_SUBPROCESS != 1). In that situation
+ * the user's `claude -p` triggered our SessionEnd hook, which invoked
+ * `caliber refresh --quiet` (or `caliber learn finalize --auto`).
+ * Doing real LLM work here would spawn ANOTHER claude session, which
+ * Claude Code's hook timeout cancels mid-cascade, producing visible
+ * "Hook cancelled" stderr noise on every interactive `claude -p`
+ * the user runs in a Caliber-equipped repo.
+ *
+ * Hook entry points should call this first and exit 0 if true.
+ *
+ * Audit finding: F-P0-9 in
+ * docs/superpowers/specs/2026-04-29-caliber-install-audit-findings.md
+ */
+export function isHookCascadeFromUserClaudeSession(): boolean {
+  const inClaudeSession = process.env.CLAUDECODE === '1';
+  const isCaliberSpawned = process.env[CALIBER_SUBPROCESS_ENV] === '1';
+  return inClaudeSession && !isCaliberSpawned;
+}
+```
+
+- [ ] **Step 2: Add tests for the helper**
+
+In `src/lib/__tests__/subprocess-sentinel.test.ts` (file already exists per pre-flight grep), append:
+
+```typescript
+import { isHookCascadeFromUserClaudeSession } from '../subprocess-sentinel.js';
+
+describe('isHookCascadeFromUserClaudeSession (F-P0-9)', () => {
+  let savedEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    savedEnv = { ...process.env };
+    delete process.env.CLAUDECODE;
+    delete process.env.CALIBER_SUBPROCESS;
+    delete process.env.CALIBER_SPAWNED;
+  });
+
+  afterEach(() => {
+    Object.assign(process.env, savedEnv);
+  });
+
+  it('returns false when not in any claude session', () => {
+    expect(isHookCascadeFromUserClaudeSession()).toBe(false);
+  });
+
+  it('returns true when in a user-initiated claude session (CLAUDECODE=1, no CALIBER_SUBPROCESS)', () => {
+    process.env.CLAUDECODE = '1';
+    expect(isHookCascadeFromUserClaudeSession()).toBe(true);
+  });
+
+  it('returns false when in a caliber-spawned claude session (CLAUDECODE=1 + CALIBER_SUBPROCESS=1)', () => {
+    process.env.CLAUDECODE = '1';
+    process.env.CALIBER_SUBPROCESS = '1';
+    expect(isHookCascadeFromUserClaudeSession()).toBe(false);
+  });
+
+  it('returns false when CALIBER_SUBPROCESS=1 even without CLAUDECODE', () => {
+    process.env.CALIBER_SUBPROCESS = '1';
+    expect(isHookCascadeFromUserClaudeSession()).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 3: Run new tests + full suite + type check + build**
+
+```bash
+npx vitest run src/lib/__tests__/subprocess-sentinel.test.ts -t "isHookCascadeFromUserClaudeSession"
+npm test 2>&1 | tail -5
+npx tsc --noEmit 2>&1 | head -3
+npm run build 2>&1 | tail -3
+```
+
+Expected: 4 new tests pass, full suite green (1039 total = 1035 + 4), type check + build clean.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/lib/subprocess-sentinel.ts src/lib/__tests__/subprocess-sentinel.test.ts
+git commit -m "feat(subprocess-sentinel): add isHookCascadeFromUserClaudeSession helper
+
+Detects when caliber is firing as a SessionEnd / hook cascade from
+inside an unrelated (user-initiated) Claude Code session.
+
+True when CLAUDECODE=1 (we're inside Claude Code) AND
+CALIBER_SUBPROCESS != 1 (we did NOT spawn this claude). In that case
+hook entry points (refresh --quiet, learn finalize --auto) should
+exit 0 to avoid the cascade that produces visible 'Hook cancelled'
+stderr noise on every interactive claude -p.
+
+Audit finding: F-P0-9. Used by next two commits."
+```
+
+### Task 2b: Wire the check into `caliber refresh --quiet`
+
+- [ ] **Step 1: Read the top of refresh.ts to find the entry point**
+
+```bash
+sed -n '1,40p' src/commands/refresh.ts
+```
+
+Identify the exported `refreshCommand()` function and the imports section.
+
+- [ ] **Step 2: Add the import**
+
+In the imports block of `src/commands/refresh.ts`, add:
+
+```typescript
+import { isHookCascadeFromUserClaudeSession } from '../lib/subprocess-sentinel.js';
+```
+
+- [ ] **Step 3: Add the early-exit check at the start of `refreshCommand`**
+
+At the very top of the `refreshCommand` function body (after the option destructuring but before any other logic), insert:
+
+```typescript
+  // F-P0-9: when --quiet is set, we're being invoked from a hook (likely a
+  // SessionEnd hook firing inside a user's claude -p session). If we proceed,
+  // we'd spawn ANOTHER claude session for the LLM call, which Claude Code's
+  // hook timeout cancels mid-cascade — producing the visible "Hook cancelled"
+  // noise on every interactive claude -p the user runs in a caliber repo.
+  // Skip silently in that case; the user can still run `caliber refresh`
+  // (without --quiet) manually for an explicit refresh.
+  if (options.quiet && isHookCascadeFromUserClaudeSession()) {
+    return;
+  }
+```
+
+(The exact variable name for the quiet flag depends on `refreshCommand`'s signature — read the function and adapt. If `options.quiet` doesn't exist, search for the actual parameter shape.)
+
+- [ ] **Step 4: Add a test in refresh.test.ts**
+
+Append to `src/commands/__tests__/refresh.test.ts`:
+
+```typescript
+describe('refresh hook-cascade short-circuit (F-P0-9)', () => {
+  let savedEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    savedEnv = { ...process.env };
+    delete process.env.CLAUDECODE;
+    delete process.env.CALIBER_SUBPROCESS;
+  });
+
+  afterEach(() => {
+    Object.assign(process.env, savedEnv);
+  });
+
+  it('skips when --quiet and inside user-initiated Claude Code session', async () => {
+    process.env.CLAUDECODE = '1';
+    delete process.env.CALIBER_SUBPROCESS;
+
+    const { refreshCommand } = await import('../refresh.js');
+    // Should return without throwing or invoking any LLM call.
+    // (The default LLM mock from src/test/setup.ts would let any LLM call succeed,
+    // so the only way to verify "skipped" is that the command returns quickly
+    // and produces no setup file changes — but we can also assert it doesn't throw.)
+    await expect(refreshCommand({ quiet: true })).resolves.toBeUndefined();
+  });
+
+  it('proceeds when --quiet but NOT in a Claude Code session', async () => {
+    delete process.env.CLAUDECODE;
+    delete process.env.CALIBER_SUBPROCESS;
+    // Default mock returns empty config, so refresh exits early on no-config.
+    // The point is: it doesn't short-circuit on the hook-cascade path.
+    // (Test depends on how refresh.ts handles no-config — verify behavior matches.)
+    const { refreshCommand } = await import('../refresh.js');
+    await expect(refreshCommand({ quiet: true })).resolves.toBeUndefined();
+  });
+
+  it('proceeds when in caliber-spawned claude session (CALIBER_SUBPROCESS=1)', async () => {
+    process.env.CLAUDECODE = '1';
+    process.env.CALIBER_SUBPROCESS = '1';
+    const { refreshCommand } = await import('../refresh.js');
+    await expect(refreshCommand({ quiet: true })).resolves.toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 5: Run tests + build**
+
+```bash
+npx vitest run src/commands/__tests__/refresh.test.ts -t "hook-cascade"
+npm test 2>&1 | tail -5
+npx tsc --noEmit 2>&1 | head -3
+npm run build 2>&1 | tail -3
+```
+
+Expected: 3 new tests pass, full suite green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/commands/refresh.ts src/commands/__tests__/refresh.test.ts
+git commit -m "fix(refresh): skip --quiet refresh when fired from user claude -p hook cascade
+
+Every interactive 'claude -p' in a caliber-equipped repo emits two
+'Hook cancelled' stderr lines and adds ~15s of latency. Root cause:
+SessionEnd hooks (caliber refresh --quiet, caliber learn finalize
+--auto) try to spawn ANOTHER claude session for the LLM call, which
+Claude Code's hook timeout cancels mid-cascade.
+
+Fix: when --quiet AND we detect we're inside a user-initiated Claude
+Code session (CLAUDECODE=1 && !CALIBER_SUBPROCESS), refresh skips
+silently. The user's interactive 'caliber refresh' (no --quiet) still
+works normally.
+
+Audit finding: F-P0-9."
+```
+
+### Task 2c: Same short-circuit for `caliber learn finalize --auto`
+
+- [ ] **Step 1: Add the import to learn.ts**
+
+In `src/commands/learn.ts` imports block, add (or extend the existing subprocess-sentinel import):
+
+```typescript
+import {
+  isCaliberSubprocess,
+  isHookCascadeFromUserClaudeSession,
+} from '../lib/subprocess-sentinel.js';
+```
+
+(Replace the existing `import { isCaliberSubprocess } from '../lib/subprocess-sentinel.js';` if present.)
+
+- [ ] **Step 2: Find the `learnFinalizeCommand` function**
+
+```bash
+grep -n 'export.*learnFinalizeCommand\|function learnFinalizeCommand' src/commands/learn.ts
+```
+
+- [ ] **Step 3: Add the early-exit check at the top of `learnFinalizeCommand`**
+
+At the very top of the function body (after option destructuring), insert:
+
+```typescript
+  // F-P0-9: same short-circuit as refresh. The --auto flag indicates we
+  // were invoked from a hook, not by the user manually running 'caliber
+  // learn finalize'. If --auto AND we're inside a user-initiated claude
+  // session, exit silently to break the cascade.
+  if (options?.auto && isHookCascadeFromUserClaudeSession()) {
+    return;
+  }
+```
+
+- [ ] **Step 4: Add a test**
+
+Create `src/commands/__tests__/learn-finalize-cascade.test.ts`:
+
+```typescript
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+describe('learn finalize hook-cascade short-circuit (F-P0-9)', () => {
+  let savedEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    savedEnv = { ...process.env };
+    delete process.env.CLAUDECODE;
+    delete process.env.CALIBER_SUBPROCESS;
+  });
+
+  afterEach(() => {
+    Object.assign(process.env, savedEnv);
+  });
+
+  it('skips when --auto and inside user-initiated Claude Code session', async () => {
+    process.env.CLAUDECODE = '1';
+    delete process.env.CALIBER_SUBPROCESS;
+    const { learnFinalizeCommand } = await import('../learn.js');
+    await expect(learnFinalizeCommand({ auto: true })).resolves.toBeUndefined();
+  });
+
+  it('proceeds when --auto but NOT in a Claude Code session', async () => {
+    delete process.env.CLAUDECODE;
+    const { learnFinalizeCommand } = await import('../learn.js');
+    // Should not short-circuit on the cascade path. May still no-op for other
+    // reasons (no events, etc.) — we only care that the cascade check doesn't fire.
+    await expect(learnFinalizeCommand({ auto: true })).resolves.toBeUndefined();
+  });
+
+  it('proceeds when in caliber-spawned claude session (CALIBER_SUBPROCESS=1)', async () => {
+    process.env.CLAUDECODE = '1';
+    process.env.CALIBER_SUBPROCESS = '1';
+    const { learnFinalizeCommand } = await import('../learn.js');
+    await expect(learnFinalizeCommand({ auto: true })).resolves.toBeUndefined();
+  });
+});
+```
+
+- [ ] **Step 5: Run tests + build**
+
+```bash
+npx vitest run src/commands/__tests__/learn-finalize-cascade.test.ts
+npm test 2>&1 | tail -5
+npx tsc --noEmit 2>&1 | head -3
+npm run build 2>&1 | tail -3
+```
+
+Expected: 3 new tests pass, full suite green.
+
+- [ ] **Step 6: Smoke test against the live audit machine**
+
+```bash
+# Invoke claude -p inside this caliber repo and verify NO 'Hook cancelled' lines
+time claude -p "respond with the single word ok" 2>&1 | tail -5
+```
+
+Expected: response is `ok`, NO `SessionEnd hook [...] failed: Hook cancelled` lines in stderr, latency < 5s (down from ~16s pre-fix).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/commands/learn.ts src/commands/__tests__/learn-finalize-cascade.test.ts
+git commit -m "fix(learn): skip --auto finalize when fired from user claude -p hook cascade
+
+Same root cause as the previous refresh fix: SessionEnd's
+'caliber learn finalize --auto' invocation spawns claude -p for LLM
+work, Claude Code's hook timeout cancels it, producing 'Hook cancelled'
+stderr noise on every user-initiated claude -p.
+
+Fix: when --auto AND we detect a user-initiated Claude Code session
+(CLAUDECODE=1 && !CALIBER_SUBPROCESS), exit silently. Manual
+'caliber learn finalize' (no --auto) still works normally.
+
+Combined with the previous refresh fix, this eliminates the
+double-cascade entirely. Verified empirically on the audit machine:
+'time claude -p \"ok\"' goes from ~16s with two Hook cancelled
+lines to ~3s clean.
+
+Audit finding: F-P0-9 (paired commit with previous)."
+```
+
+---
+
+## Task 3: F-P0-10 — appendManagedBlocks de-duplication
+
+**Files:**
+- Modify: `src/writers/pre-commit-block.ts` (each `hasXBlock` function detects existing unmarked content)
+- Modify: `src/writers/__tests__/pre-commit-block.test.ts`
+
+### Task 3a: De-duplicate the pre-commit "Before Committing" block
+
+- [ ] **Step 1: Read the existing `hasPreCommitBlock` function**
+
+In `src/writers/pre-commit-block.ts`, find:
+
+```typescript
+export function hasPreCommitBlock(content: string): boolean {
+  return content.includes(BLOCK_START);
+}
+```
+
+This only matches the marker comment. The bug: when init inlines the "Before Committing" section without markers, then a later refresh calls `appendManagedBlocks`, `hasPreCommitBlock` returns false → the block is added → CLAUDE.md ends up with both copies.
+
+- [ ] **Step 2: Replace with a content-aware match**
+
+Replace the function with:
+
+```typescript
+// F-P0-10: detect both the marker form AND the unmarked inlined form.
+// Init inlines this section via the LLM prompt context; without this
+// detection, refresh's appendManagedBlocks() would add a marker-wrapped
+// duplicate, producing visible duplicate sections in CLAUDE.md.
+const PRECOMMIT_HEADING_RE = /^##\s+Before Committing\s*$/m;
+
+export function hasPreCommitBlock(content: string): boolean {
+  if (content.includes(BLOCK_START)) return true;
+  // Treat any "## Before Committing" heading that mentions caliber as
+  // an existing inlined version of this block.
+  if (PRECOMMIT_HEADING_RE.test(content) && /caliber/i.test(content)) return true;
+  return false;
+}
+```
+
+- [ ] **Step 3: Apply the same pattern to the other three managed blocks**
+
+For each of `hasLearningsBlock`, `hasModelBlock`, `hasSyncBlock` in the same file, add a heading-based detection.
+
+Replace:
+
+```typescript
+export function hasLearningsBlock(content: string): boolean {
+  return content.includes(LEARNINGS_BLOCK_START);
+}
+```
+
+with:
+
+```typescript
+const LEARNINGS_HEADING_RE = /^##\s+Session Learnings\s*$/m;
+export function hasLearningsBlock(content: string): boolean {
+  if (content.includes(LEARNINGS_BLOCK_START)) return true;
+  if (LEARNINGS_HEADING_RE.test(content) && /CALIBER_LEARNINGS/.test(content)) return true;
+  return false;
+}
+```
+
+Replace:
+
+```typescript
+export function hasModelBlock(content: string): boolean {
+  return content.includes(MODEL_BLOCK_START);
+}
+```
+
+with:
+
+```typescript
+const MODEL_HEADING_RE = /^##\s+Model Configuration\s*$/m;
+export function hasModelBlock(content: string): boolean {
+  if (content.includes(MODEL_BLOCK_START)) return true;
+  if (MODEL_HEADING_RE.test(content) && /CALIBER_MODEL/.test(content)) return true;
+  return false;
+}
+```
+
+Replace:
+
+```typescript
+export function hasSyncBlock(content: string): boolean {
+  return content.includes(SYNC_BLOCK_START);
+}
+```
+
+with:
+
+```typescript
+const SYNC_HEADING_RE = /^##\s+Context Sync\s*$/m;
+export function hasSyncBlock(content: string): boolean {
+  if (content.includes(SYNC_BLOCK_START)) return true;
+  if (SYNC_HEADING_RE.test(content) && /caliber-ai-org\/ai-setup/.test(content)) return true;
+  return false;
+}
+```
+
+- [ ] **Step 4: Add tests**
+
+Append to `src/writers/__tests__/pre-commit-block.test.ts`:
+
+```typescript
+describe('appendManagedBlocks de-duplication (F-P0-10)', () => {
+  beforeEach(async () => {
+    const { resetResolvedCaliber } = await import('../../lib/resolve-caliber.js');
+    resetResolvedCaliber();
+    process.argv[1] = '/usr/local/bin/caliber';
+    delete process.env.npm_execpath;
+    mockedExecSync.mockReturnValue('/usr/local/bin/caliber\n');
+  });
+
+  it('hasPreCommitBlock detects unmarked inlined "Before Committing" with caliber', async () => {
+    const { hasPreCommitBlock } = await import('../pre-commit-block.js');
+    const inlined = '# proj\n\n## Before Committing\n\nRun `caliber refresh` before commit.\n';
+    expect(hasPreCommitBlock(inlined)).toBe(true);
+  });
+
+  it('hasPreCommitBlock returns false for unrelated "Before Committing" heading', async () => {
+    const { hasPreCommitBlock } = await import('../pre-commit-block.js');
+    const unrelated = '# proj\n\n## Before Committing\n\nRun npm test.\n';
+    expect(hasPreCommitBlock(unrelated)).toBe(false);
+  });
+
+  it('appendPreCommitBlock does NOT duplicate when inlined version exists', async () => {
+    const { appendPreCommitBlock } = await import('../pre-commit-block.js');
+    const inlined = '# proj\n\n## Before Committing\n\nRun `caliber refresh` before commit.\n';
+    const out = appendPreCommitBlock(inlined, 'claude');
+    // Should return content unchanged — no marker block appended.
+    expect(out).toBe(inlined);
+    // Definitely no two "Before Committing" headings.
+    expect((out.match(/## Before Committing/g) || []).length).toBe(1);
+  });
+
+  it('hasLearningsBlock detects unmarked inlined "Session Learnings" with CALIBER_LEARNINGS', async () => {
+    const { hasLearningsBlock } = await import('../pre-commit-block.js');
+    const inlined = '# proj\n\n## Session Learnings\n\nRead CALIBER_LEARNINGS.md for patterns.\n';
+    expect(hasLearningsBlock(inlined)).toBe(true);
+  });
+
+  it('hasModelBlock detects unmarked inlined "Model Configuration" with CALIBER_MODEL', async () => {
+    const { hasModelBlock } = await import('../pre-commit-block.js');
+    const inlined = '# proj\n\n## Model Configuration\n\nUse CALIBER_MODEL env var to pin.\n';
+    expect(hasModelBlock(inlined)).toBe(true);
+  });
+
+  it('hasSyncBlock detects unmarked inlined "Context Sync" with caliber-ai-org link', async () => {
+    const { hasSyncBlock } = await import('../pre-commit-block.js');
+    const inlined =
+      '# proj\n\n## Context Sync\n\nThis project uses [Caliber](https://github.com/caliber-ai-org/ai-setup).\n';
+    expect(hasSyncBlock(inlined)).toBe(true);
+  });
+
+  it('appendManagedBlocks on already-inlined CLAUDE.md is a no-op', async () => {
+    const { appendManagedBlocks } = await import('../pre-commit-block.js');
+    const inlined = `# proj
+
+## Before Committing
+
+Run \`caliber refresh\` before commit.
+
+## Session Learnings
+
+Read CALIBER_LEARNINGS.md for patterns.
+
+## Model Configuration
+
+Use CALIBER_MODEL env var to pin.
+
+## Context Sync
+
+This project uses [Caliber](https://github.com/caliber-ai-org/ai-setup).
+`;
+    const out = appendManagedBlocks(inlined, 'claude');
+    expect(out).toBe(inlined);
+    expect((out.match(/## Before Committing/g) || []).length).toBe(1);
+    expect((out.match(/## Session Learnings/g) || []).length).toBe(1);
+    expect((out.match(/## Model Configuration/g) || []).length).toBe(1);
+    expect((out.match(/## Context Sync/g) || []).length).toBe(1);
+  });
+});
+```
+
+- [ ] **Step 5: Run tests + build**
+
+```bash
+npx vitest run src/writers/__tests__/pre-commit-block.test.ts -t "F-P0-10"
+npm test 2>&1 | tail -5
+npx tsc --noEmit 2>&1 | head -3
+npm run build 2>&1 | tail -3
+```
+
+Expected: 7 new tests pass, full suite green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/writers/pre-commit-block.ts src/writers/__tests__/pre-commit-block.test.ts
+git commit -m "fix(writers): de-duplicate managed CLAUDE.md sections
+
+Init inlines the 'Before Committing', 'Session Learnings', 'Model
+Configuration', and 'Context Sync' sections via the LLM prompt
+context. The subsequent appendManagedBlocks() call (and refresh) only
+checked for the marker comment, not the heading content, so it added
+a marker-wrapped DUPLICATE on top of the inlined version. Result:
+~50 redundant lines per CLAUDE.md, with both an unmarked and a marked
+copy of each section. The unmarked copies would later be edited by
+LLM refresh while the marked ones were protected — confusing for
+agents and noisy for humans.
+
+Each hasXBlock() function now also returns true if the heading is
+present alongside a Caliber-specific marker phrase (e.g. 'caliber'
+in pre-commit, 'CALIBER_LEARNINGS' for learnings). When the inlined
+version is detected, append is a no-op.
+
+Audit finding: F-P0-10."
+```
+
+---
+
+## Task 4: F-P0-2 — bump default inactivity timeout + improve mid-stream message
+
+**Files:**
+- Modify: `src/ai/generate.ts` (DEFAULT_INACTIVITY_TIMEOUT_MS constant + status callback)
+- Modify: `src/ai/__tests__/stream-error.test.ts` (or wherever the timeout constant is tested)
+
+- [ ] **Step 1: Find the timeout constant**
+
+```bash
+grep -n 'DEFAULT_INACTIVITY_TIMEOUT\|CALIBER_STREAM_INACTIVITY' src/ai/generate.ts
+```
+
+Identify the constant definition + the env-var override + the timer setup site.
+
+- [ ] **Step 2: Bump the default**
+
+Change the constant from 120_000 (2 min) to 300_000 (5 min). The env var override still works for users with even larger repos.
+
+```typescript
+// Bumped 120_000 → 300_000 per F-P0-2: large-repo prompts (caliber-dogfood
+// 314 files) consistently exceeded the 2min first-token window on Vertex.
+// Most repos finish under 60s; the bump trades a worst-case slow failure
+// for a better default-success rate. CALIBER_STREAM_INACTIVITY_TIMEOUT_MS
+// env var still overrides when users need to push higher.
+export const DEFAULT_INACTIVITY_TIMEOUT_MS = 300_000;
+```
+
+- [ ] **Step 3: Improve the mid-stream "still waiting" message at 60s**
+
+Find the `setInactivityTimer` function (or however the timer is structured). Add a "soft warning" callback at 60s — keep the timeout itself at 300s, but at 60s of silence emit a status message via callbacks.onStatus that surfaces the env-var hint.
+
+Locate the `setInactivityTimer()` function. Adapt its body to fire a soft warning at 60s (or 1/5 of the timeout, whichever is shorter), then a hard fail at the full timeout. Pseudo-shape (adapt to actual code):
+
+```typescript
+function setInactivityTimer() {
+  clearInactivityTimer();
+  const SOFT_WARN_MS = 60_000;
+  if (config.callbacks) {
+    softTimer = setTimeout(() => {
+      config.callbacks?.onStatus(
+        'Model is taking longer than usual on this prompt — large repos may need more time. Set CALIBER_STREAM_INACTIVITY_TIMEOUT_MS to override.',
+      );
+    }, SOFT_WARN_MS);
+  }
+  inactivityTimer = setTimeout(() => {
+    // existing timeout-fail logic
+  }, inactivityTimeoutMs);
+}
+```
+
+(Read the actual function body and adapt — the exact structure depends on what's there. Soft timer must be cleared in `clearInactivityTimer` too.)
+
+- [ ] **Step 4: Add tests**
+
+Find or create a test that asserts `DEFAULT_INACTIVITY_TIMEOUT_MS === 300_000`:
+
+```typescript
+import { DEFAULT_INACTIVITY_TIMEOUT_MS } from '../generate.js';
+
+describe('default timeouts (F-P0-2)', () => {
+  it('inactivity timeout default is 5 minutes (300_000 ms)', () => {
+    expect(DEFAULT_INACTIVITY_TIMEOUT_MS).toBe(300_000);
+  });
+});
+```
+
+- [ ] **Step 5: Run tests + build**
+
+```bash
+npm test 2>&1 | tail -5
+npx tsc --noEmit 2>&1 | head -3
+npm run build 2>&1 | tail -3
+```
+
+Expected: full suite green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/ai/generate.ts src/ai/__tests__/
+git commit -m "fix(generate): bump default stream-inactivity timeout to 5min
+
+Audit found large-repo prompts (caliber-dogfood, 314 files) consistently
+exceeded the 2min first-token window with the default
+CALIBER_STREAM_INACTIVITY_TIMEOUT_MS=120000, especially on Vertex
+where TTFT is higher than direct Anthropic. Users hit a confusing
+'Model produced no output' failure on first run.
+
+Bumped default to 300_000 (5 min). Most repos finish under 60s; this
+trades a worst-case slow failure for a better default success rate.
+The env var still overrides for even bigger repos.
+
+Also adds a soft 60s warning ('Model is taking longer than usual')
+that surfaces the env-var hint mid-stream — so users on truly massive
+prompts get the override pointer before the hard timeout fires.
+
+Audit finding: F-P0-2."
+```
+
+---
+
+## Task 5: Wrap-up — version bump + CHANGELOG + final verification
+
+**Files:**
+- Modify: `package.json` (1.49.0 → 1.49.1)
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Bump version**
+
+In `package.json` line 3:
+```json
+"version": "1.49.1",
+```
+
+- [ ] **Step 2: Add CHANGELOG entry**
+
+Prepend after the title (above the v1.49.0 entry):
+
+```markdown
+## v1.49.1 (2026-04-29)
+
+### Bug Fixes (install audit batch 2)
+
+- **refresh, learn**: skip silently when `--quiet` / `--auto` and inside a user-initiated Claude Code session (CLAUDECODE=1 && !CALIBER_SUBPROCESS). Eliminates the "Hook cancelled" stderr noise + ~15s latency on every interactive `claude -p` in a Caliber-equipped repo. (F-P0-9)
+- **writers**: managed-block injection (CLAUDE.md, AGENTS.md, copilot-instructions.md, cursor rules) detects unmarked inlined sections and skips re-adding them. Eliminates ~50 lines of duplicate content per CLAUDE.md after init. (F-P0-10)
+- **generate**: bump default `CALIBER_STREAM_INACTIVITY_TIMEOUT_MS` from 120000 → 300000. Surface env-var hint at 60s of silence instead of waiting for the hard timeout. Fixes "Model produced no output" failures on large-prompt repos (caliber-dogfood scale, ~300 files). (F-P0-2)
+
+These complete fixes #2, #9, and #10 from the install audit P0 list. Combined with v1.49.0, six of the eight verified P0s are now resolved (F-P0-6 was indirectly fixed by v1.49.0's hook auto-upgrade).
+```
+
+- [ ] **Step 3: Run full pipeline**
+
+```bash
+npm test 2>&1 | tail -5
+npm run lint 2>&1 | grep -E '(error|^✖)' | head -5
+npx tsc --noEmit 2>&1 | head -5
+npm run build 2>&1 | tail -3
+node dist/bin.js --version
+```
+
+Expected: tests pass, 0 lint errors (warnings fine), type-check clean, build success, version `1.49.1`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json CHANGELOG.md
+git commit -m "chore: release 1.49.1
+
+Three install-audit batch-2 P0 fixes:
+- fix(refresh, learn): skip hook-cascade in user claude -p sessions
+- fix(writers): de-duplicate managed CLAUDE.md sections
+- fix(generate): bump default stream-inactivity timeout to 5min
+
+Plus a docs correction: F-P0-7/8/11 from the audit findings doc were
+false positives from the explore agent; current source handles those
+paths correctly.
+
+After this batch, 6 of 8 verified P0s from the install audit are
+resolved. Remaining P0s: F-P0-2 partial (timeout bump landed,
+adaptive scaling deferred), other lower-priority finds in P1/P2."
+```
+
+- [ ] **Step 5: Final state check**
+
+```bash
+git log --oneline alonp98/install-audit..HEAD | head -10
+git diff alonp98/install-audit..HEAD --stat | tail -5
+```
+
+Expected: 7 new commits beyond the audit branch (1 docs + 1 sentinel + 1 refresh + 1 learn + 1 writers + 1 generate + 1 release), source files changed across `src/lib/`, `src/commands/`, `src/writers/`, `src/ai/`, plus tests and `package.json`/`CHANGELOG.md`.

--- a/docs/superpowers/specs/2026-04-29-caliber-install-audit-findings.md
+++ b/docs/superpowers/specs/2026-04-29-caliber-install-audit-findings.md
@@ -32,6 +32,14 @@ The user's instinct was right. The README rewrite would have polished a flow tha
 
 ## Findings
 
+> **2026-04-29 correction (after closer source review):** Findings F-P0-7, F-P0-8, and F-P0-11 below were based on the explore agent's structural map of `src/ai/generate.ts`, which mischaracterized two failure paths.
+>
+> - **F-P0-7** claimed Phase 1 returns `{}` silently on JSON parse failure. Actual source returns `null` (`src/ai/generate.ts` — see the `try { setup = JSON.parse... } catch {}` block followed by `if (setup) { resolve(...) } else { resolve({ setup: null, ... }) }`). The caller (`init.ts:643`) properly handles `null` and writes the error log.
+> - **F-P0-8** claimed Phase 2 skill failures are swallowed by `Promise.allSettled`. Actual source surfaces failures at both call sites via `callbacks.onStatus` with messages like `"Warning: 2 of 5 skills failed to generate"` (lines 174–186 and 644–655 in `src/ai/generate.ts`).
+> - **F-P0-11** was a derived finding from F-P0-7 + F-P0-8. Since both are non-issues in current source, this is also moot.
+>
+> The corrected findings count: **8 P0** (was 11), 22 P1, 22 P2. The next batch of fixes (PR for `alonp98/install-audit-fixes-2`) addresses F-P0-9 (SessionEnd cascade), F-P0-10 (duplicated CLAUDE.md sections), and F-P0-2 (large-prompt timeout). F-P0-6 was already addressed in v1.49.0 via the hook auto-upgrade (F-P0-4).
+
 ### P0 — Blocks install or causes data-loss-like outcomes
 
 #### F-P0-1: `cleanClaudeEnv()` strips `CLAUDE_CODE_USE_VERTEX`, breaking Vertex-backed auth

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rely-ai/caliber",
-  "version": "1.49.1",
+  "version": "1.49.2",
   "description": "AI context infrastructure for coding agents — keeps CLAUDE.md, Cursor rules, and skills in sync as your codebase evolves",
   "type": "module",
   "bin": {

--- a/src/ai/__tests__/generate-timeout.test.ts
+++ b/src/ai/__tests__/generate-timeout.test.ts
@@ -758,8 +758,8 @@ describe('parseEnvTimeout', () => {
 
 // ─── DEFAULT_INACTIVITY_TIMEOUT_MS export test ──────────────────────────────
 
-describe('DEFAULT_INACTIVITY_TIMEOUT_MS', () => {
-  it('is 120 seconds', () => {
-    expect(DEFAULT_INACTIVITY_TIMEOUT_MS).toBe(120_000);
+describe('DEFAULT_INACTIVITY_TIMEOUT_MS (F-P0-2)', () => {
+  it('is 5 minutes (300_000 ms) — bumped from 120_000 for large-prompt support', () => {
+    expect(DEFAULT_INACTIVITY_TIMEOUT_MS).toBe(300_000);
   });
 });

--- a/src/ai/generate.ts
+++ b/src/ai/generate.ts
@@ -36,7 +36,15 @@ const GENERATION_MAX_TOKENS = 64000;
 const MODEL_MAX_OUTPUT_TOKENS = 128000;
 const MAX_RETRIES = 5;
 
-export const DEFAULT_INACTIVITY_TIMEOUT_MS = 120_000;
+// F-P0-2: bumped 120_000 → 300_000 because large-repo prompts (caliber-dogfood
+// 314 files) consistently exceeded the 2min first-token window on Vertex.
+// Most repos finish under 60s; the bump trades a worst-case slow failure
+// for a better default-success rate. CALIBER_STREAM_INACTIVITY_TIMEOUT_MS env
+// var still overrides when users need to push higher.
+export const DEFAULT_INACTIVITY_TIMEOUT_MS = 300_000;
+// Surface an env-var hint after this much silence — gives users on huge
+// prompts a pointer to the override before the hard timeout fires.
+const SOFT_INACTIVITY_WARN_MS = 60_000;
 const DEFAULT_TOTAL_TIMEOUT_MS = 600_000;
 
 export function parseEnvTimeout(envVar: string, defaultMs: number, minMs = 5000): number {
@@ -174,9 +182,10 @@ export async function generateSetup(
   const { succeeded, failed: failedCount, failedNames } = mergeSkillResults(skillResults, setup);
 
   if (failedCount > 0 && callbacks) {
-    const msg = succeeded === 0
-      ? `${failedCount} skill${failedCount === 1 ? '' : 's'} failed to generate — config saved without skills`
-      : `Warning: ${failedCount} of ${failedCount + succeeded} skill${failedCount === 1 ? '' : 's'} failed to generate`;
+    const msg =
+      succeeded === 0
+        ? `${failedCount} skill${failedCount === 1 ? '' : 's'} failed to generate — config saved without skills`
+        : `Warning: ${failedCount} of ${failedCount + succeeded} skill${failedCount === 1 ? '' : 's'} failed to generate`;
     callbacks.onStatus(msg);
     for (const name of failedNames) {
       callbacks.onStatus(`  → ${name}`);
@@ -413,16 +422,35 @@ async function streamGeneration(config: StreamGenerationConfig): Promise<Generat
       let settled = false;
 
       let inactivityTimer: ReturnType<typeof setTimeout> | null = null;
+      let softWarnTimer: ReturnType<typeof setTimeout> | null = null;
+      let softWarnFired = false;
 
       function clearInactivityTimer() {
         if (inactivityTimer) {
           clearTimeout(inactivityTimer);
           inactivityTimer = null;
         }
+        if (softWarnTimer) {
+          clearTimeout(softWarnTimer);
+          softWarnTimer = null;
+        }
       }
 
       function resetInactivityTimer() {
         if (inactivityTimer) clearTimeout(inactivityTimer);
+        if (softWarnTimer) clearTimeout(softWarnTimer);
+        // F-P0-2: surface the env-var hint at SOFT_INACTIVITY_WARN_MS so users
+        // on truly large prompts see the override pointer mid-stream rather
+        // than waiting for the hard timeout. Fires at most once per attempt.
+        if (config.callbacks && !softWarnFired && SOFT_INACTIVITY_WARN_MS < inactivityTimeoutMs) {
+          softWarnTimer = setTimeout(() => {
+            if (settled) return;
+            softWarnFired = true;
+            config.callbacks?.onStatus(
+              'Model is taking longer than usual on this prompt — large repos may need more time. Set CALIBER_STREAM_INACTIVITY_TIMEOUT_MS to override.',
+            );
+          }, SOFT_INACTIVITY_WARN_MS);
+        }
         inactivityTimer = setTimeout(() => {
           if (settled) return;
           settled = true;

--- a/src/commands/__tests__/learn-finalize-cascade.test.ts
+++ b/src/commands/__tests__/learn-finalize-cascade.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+// F-P0-9: learn finalize must skip silently when fired from a SessionEnd hook
+// inside a user-initiated `claude -p` session (CLAUDECODE=1 + !CALIBER_SUBPROCESS).
+// Otherwise the hook spawns another claude -p for the LLM call, which Claude Code's
+// hook timeout cancels mid-cascade — producing visible "Hook cancelled" stderr noise.
+
+describe('learn finalize hook-cascade short-circuit (F-P0-9)', () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    originalEnv = { ...process.env };
+    vi.resetModules();
+    delete process.env.CLAUDECODE;
+    delete process.env.CALIBER_SUBPROCESS;
+    delete process.env.CALIBER_SPAWNED;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    vi.resetModules();
+  });
+
+  it('skips when --auto AND inside user-initiated Claude Code session', async () => {
+    process.env.CLAUDECODE = '1';
+    delete process.env.CALIBER_SUBPROCESS;
+
+    const lockMock = { isCaliberRunning: vi.fn(), acquireFinalizeLock: vi.fn() };
+    vi.doMock('../../lib/lock.js', () => lockMock);
+
+    const { learnFinalizeCommand } = await import('../learn.js');
+    await expect(learnFinalizeCommand({ auto: true })).resolves.toBeUndefined();
+    // The cascade short-circuit fires before any lock check.
+    expect(lockMock.isCaliberRunning).not.toHaveBeenCalled();
+  });
+
+  it('proceeds (does not short-circuit on cascade) when --auto + caliber-spawned', async () => {
+    process.env.CLAUDECODE = '1';
+    process.env.CALIBER_SUBPROCESS = '1';
+    // CALIBER_SUBPROCESS=1 path: existing isCaliberSubprocess() guard fires first
+    // (covered by spawned-session-guard.test.ts). The new cascade check only
+    // fires when CALIBER_SUBPROCESS is NOT set. This test asserts no crash.
+    const { learnFinalizeCommand } = await import('../learn.js');
+    await expect(learnFinalizeCommand({ auto: true })).resolves.toBeUndefined();
+  });
+
+  it('proceeds when --auto but no CLAUDECODE (e.g. pre-commit hook)', async () => {
+    delete process.env.CLAUDECODE;
+    delete process.env.CALIBER_SUBPROCESS;
+    // Refresh proceeds past the cascade short-circuit. Will return undefined
+    // eventually for other reasons (no events to analyze, etc.) — test asserts no throw.
+    const { learnFinalizeCommand } = await import('../learn.js');
+    await expect(learnFinalizeCommand({ auto: true })).resolves.toBeUndefined();
+  });
+
+  it('proceeds (no cascade short-circuit) when CLAUDECODE=1 but NOT --auto', async () => {
+    process.env.CLAUDECODE = '1';
+    delete process.env.CALIBER_SUBPROCESS;
+    // The cascade check is gated on isAuto. A user manually running
+    // `caliber learn finalize` from an interactive Claude Code terminal
+    // should still work normally.
+    const { learnFinalizeCommand } = await import('../learn.js');
+    await expect(learnFinalizeCommand({})).resolves.toBeUndefined();
+  });
+});

--- a/src/commands/__tests__/refresh.test.ts
+++ b/src/commands/__tests__/refresh.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from 'vitest';
-import { collectFilesToWrite } from '../refresh.js';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { collectFilesToWrite, refreshCommand } from '../refresh.js';
 
 describe('collectFilesToWrite', () => {
   it('returns empty array for empty docs', () => {
@@ -90,5 +90,43 @@ describe('collectFilesToWrite', () => {
   it('returns root paths when dir is "."', () => {
     const files = collectFilesToWrite({ claudeMd: '# Root' }, '.');
     expect(files).toContain('CLAUDE.md');
+  });
+});
+
+describe('refreshCommand hook-cascade short-circuit (F-P0-9)', () => {
+  let savedEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    savedEnv = { ...process.env };
+    delete process.env.CLAUDECODE;
+    delete process.env.CALIBER_SUBPROCESS;
+    delete process.env.CALIBER_SPAWNED;
+  });
+
+  afterEach(() => {
+    Object.assign(process.env, savedEnv);
+  });
+
+  it('skips silently when --quiet AND inside user-initiated Claude Code session', async () => {
+    process.env.CLAUDECODE = '1';
+    delete process.env.CALIBER_SUBPROCESS;
+    // Should return immediately without throwing — no LLM call, no fingerprint.
+    await expect(refreshCommand({ quiet: true })).resolves.toBeUndefined();
+  });
+
+  it('does NOT short-circuit when --quiet but in caliber-spawned claude session', async () => {
+    process.env.CLAUDECODE = '1';
+    process.env.CALIBER_SUBPROCESS = '1';
+    // CALIBER_SUBPROCESS=1 path: existing isCaliberSubprocess() guard fires first.
+    // Either way this returns undefined, but the test asserts no throw.
+    await expect(refreshCommand({ quiet: true })).resolves.toBeUndefined();
+  });
+
+  it('does NOT short-circuit when --quiet but no CLAUDECODE (e.g. pre-commit hook)', async () => {
+    delete process.env.CLAUDECODE;
+    delete process.env.CALIBER_SUBPROCESS;
+    // Refresh proceeds past the short-circuit. Will return undefined eventually
+    // because the test env has no real config / no real repo. Asserts no throw.
+    await expect(refreshCommand({ quiet: true })).resolves.toBeUndefined();
   });
 });

--- a/src/commands/__tests__/spawned-session-guard.test.ts
+++ b/src/commands/__tests__/spawned-session-guard.test.ts
@@ -18,6 +18,12 @@ describe('spawned-session guard (CALIBER_SUBPROCESS=1)', () => {
   beforeEach(() => {
     originalEnv = { ...process.env };
     vi.resetModules();
+    // F-P0-9 (added in v1.49.1): refresh/finalize also short-circuit when
+    // CLAUDECODE=1 + !CALIBER_SUBPROCESS (user-initiated claude -p session).
+    // These tests pre-date that check and exercise the CALIBER_SUBPROCESS guard
+    // in isolation. Clear CLAUDECODE so the new guard doesn't fire and mask
+    // what we're trying to test here.
+    delete process.env.CLAUDECODE;
   });
 
   afterEach(() => {

--- a/src/commands/learn.ts
+++ b/src/commands/learn.ts
@@ -52,7 +52,10 @@ import {
   LEARNING_LAST_ERROR_FILE,
 } from '../constants.js';
 import { displayCaliberName } from '../lib/resolve-caliber.js';
-import { isCaliberSubprocess } from '../lib/subprocess-sentinel.js';
+import {
+  isCaliberSubprocess,
+  isHookCascadeFromUserClaudeSession,
+} from '../lib/subprocess-sentinel.js';
 import {
   trackLearnSessionAnalyzed,
   trackLearnROISnapshot,
@@ -216,6 +219,14 @@ export async function learnFinalizeCommand(options?: {
 
   // Skip in caliber-spawned headless sessions to prevent recursive hook execution.
   if (isAuto && isCaliberSubprocess()) return;
+
+  // F-P0-9: when --auto, also skip if we detect we're firing as a SessionEnd
+  // hook inside a user-initiated `claude -p`. Doing real LLM work here would
+  // spawn ANOTHER claude session, which Claude Code's hook timeout cancels —
+  // producing visible "Hook cancelled" stderr noise on every interactive
+  // claude -p the user runs in a caliber-equipped repo. Manual
+  // 'caliber learn finalize' (no --auto) still works.
+  if (isAuto && isHookCascadeFromUserClaudeSession()) return;
 
   if (!options?.force && !isAuto) {
     const { isCaliberRunning } = await import('../lib/lock.js');

--- a/src/commands/refresh.ts
+++ b/src/commands/refresh.ts
@@ -14,7 +14,10 @@ import { loadConfig } from '../llm/config.js';
 import { validateModel, TRANSIENT_ERRORS } from '../llm/index.js';
 import { trackRefreshCompleted } from '../telemetry/events.js';
 import { displayCaliberName } from '../lib/resolve-caliber.js';
-import { isCaliberSubprocess } from '../lib/subprocess-sentinel.js';
+import {
+  isCaliberSubprocess,
+  isHookCascadeFromUserClaudeSession,
+} from '../lib/subprocess-sentinel.js';
 import { resolveAllSources } from '../fingerprint/sources.js';
 import { getDetectedWorkspaces } from '../fingerprint/cache.js';
 import { ensureBuiltinSkills } from '../lib/builtin-skills.js';
@@ -438,6 +441,14 @@ export async function refreshCommand(options: RefreshOptions) {
   // this guard the SessionEnd hooks cascade: each spawns another claude -p which
   // fires the same hooks again until Claude Code times one out → "Hook cancelled".
   if (quiet && isCaliberSubprocess()) return;
+
+  // F-P0-9: when --quiet, also skip if we detect we're firing as a SessionEnd
+  // hook inside a user-initiated `claude -p`. The hook would otherwise spawn
+  // ANOTHER claude session for the LLM call, which Claude Code's hook timeout
+  // cancels mid-cascade — producing visible "Hook cancelled" stderr noise on
+  // every interactive claude -p the user runs in a caliber-equipped repo.
+  // The user can still run `caliber refresh` (no --quiet) for an explicit refresh.
+  if (quiet && isHookCascadeFromUserClaudeSession()) return;
 
   // Skip if another caliber process is already running (e.g. hook fired mid-session)
   if (quiet) {

--- a/src/lib/__tests__/subprocess-sentinel.test.ts
+++ b/src/lib/__tests__/subprocess-sentinel.test.ts
@@ -3,6 +3,7 @@ import {
   CALIBER_SUBPROCESS_ENV,
   CALIBER_SUBPROCESS_LEGACY_ENV,
   isCaliberSubprocess,
+  isHookCascadeFromUserClaudeSession,
   withCaliberSubprocessEnv,
 } from '../subprocess-sentinel.js';
 
@@ -91,6 +92,34 @@ describe('subprocess-sentinel', () => {
       expect(env.FOO).toBeUndefined();
       expect(env.BAR).toBe('set');
       expect(env[CALIBER_SUBPROCESS_ENV]).toBe('1');
+    });
+  });
+
+  describe('isHookCascadeFromUserClaudeSession (F-P0-9)', () => {
+    beforeEach(() => {
+      delete process.env.CLAUDECODE;
+      delete process.env[CALIBER_SUBPROCESS_ENV];
+      delete process.env[CALIBER_SUBPROCESS_LEGACY_ENV];
+    });
+
+    it('returns false when not in any claude session', () => {
+      expect(isHookCascadeFromUserClaudeSession()).toBe(false);
+    });
+
+    it('returns true when in a user-initiated claude session (CLAUDECODE=1, no CALIBER_SUBPROCESS)', () => {
+      process.env.CLAUDECODE = '1';
+      expect(isHookCascadeFromUserClaudeSession()).toBe(true);
+    });
+
+    it('returns false when in a caliber-spawned claude session (CLAUDECODE=1 + CALIBER_SUBPROCESS=1)', () => {
+      process.env.CLAUDECODE = '1';
+      process.env[CALIBER_SUBPROCESS_ENV] = '1';
+      expect(isHookCascadeFromUserClaudeSession()).toBe(false);
+    });
+
+    it('returns false when CALIBER_SUBPROCESS=1 even without CLAUDECODE', () => {
+      process.env[CALIBER_SUBPROCESS_ENV] = '1';
+      expect(isHookCascadeFromUserClaudeSession()).toBe(false);
     });
   });
 });

--- a/src/lib/__tests__/subprocess-sentinel.test.ts
+++ b/src/lib/__tests__/subprocess-sentinel.test.ts
@@ -96,17 +96,30 @@ describe('subprocess-sentinel', () => {
   });
 
   describe('isHookCascadeFromUserClaudeSession (F-P0-9)', () => {
+    let originalIsTTY: boolean | undefined;
+
     beforeEach(() => {
       delete process.env.CLAUDECODE;
       delete process.env[CALIBER_SUBPROCESS_ENV];
       delete process.env[CALIBER_SUBPROCESS_LEGACY_ENV];
+      // Default to non-TTY (the hook-runner case). Tests that need to assert
+      // the TTY override flip it explicitly.
+      originalIsTTY = process.stdin.isTTY;
+      Object.defineProperty(process.stdin, 'isTTY', { value: false, configurable: true });
+    });
+
+    afterEach(() => {
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: originalIsTTY,
+        configurable: true,
+      });
     });
 
     it('returns false when not in any claude session', () => {
       expect(isHookCascadeFromUserClaudeSession()).toBe(false);
     });
 
-    it('returns true when in a user-initiated claude session (CLAUDECODE=1, no CALIBER_SUBPROCESS)', () => {
+    it('returns true when CLAUDECODE=1, no CALIBER_SUBPROCESS, stdin not a TTY (the cascade case)', () => {
       process.env.CLAUDECODE = '1';
       expect(isHookCascadeFromUserClaudeSession()).toBe(true);
     });
@@ -119,6 +132,14 @@ describe('subprocess-sentinel', () => {
 
     it('returns false when CALIBER_SUBPROCESS=1 even without CLAUDECODE', () => {
       process.env[CALIBER_SUBPROCESS_ENV] = '1';
+      expect(isHookCascadeFromUserClaudeSession()).toBe(false);
+    });
+
+    it('returns false when stdin IS a TTY (user manually invoked from terminal inside Claude Code)', () => {
+      // CLAUDECODE=1 + !CALIBER_SUBPROCESS but stdin is TTY → user typed the
+      // command interactively. They want it to run, not silently no-op.
+      process.env.CLAUDECODE = '1';
+      Object.defineProperty(process.stdin, 'isTTY', { value: true, configurable: true });
       expect(isHookCascadeFromUserClaudeSession()).toBe(false);
     });
   });

--- a/src/lib/subprocess-sentinel.ts
+++ b/src/lib/subprocess-sentinel.ts
@@ -56,14 +56,23 @@ export function withCaliberSubprocessEnv<T extends NodeJS.ProcessEnv>(env: T): T
  * True when this caliber invocation is firing as a SessionEnd / hook
  * cascade from inside an unrelated (user-initiated) Claude Code session.
  *
- * Specifically: we're inside a Claude Code session (CLAUDECODE=1) that
- * caliber did NOT spawn (CALIBER_SUBPROCESS != 1). In that situation
- * the user's `claude -p` triggered our SessionEnd hook, which invoked
- * `caliber refresh --quiet` (or `caliber learn finalize --auto`).
- * Doing real LLM work here would spawn ANOTHER claude session, which
- * Claude Code's hook timeout cancels mid-cascade, producing visible
- * "Hook cancelled" stderr noise on every interactive `claude -p`
- * the user runs in a Caliber-equipped repo.
+ * Three signals must all hold:
+ *   1. We're inside a Claude Code session (`CLAUDECODE=1`).
+ *   2. Caliber did NOT spawn this process (`CALIBER_SUBPROCESS != 1`).
+ *   3. Stdin is NOT a TTY — meaning we were invoked by Claude Code's
+ *      hook runner (which pipes hook context to stdin), not by the user
+ *      typing into a terminal that happens to be inside a Claude Code session.
+ *
+ * #3 disambiguates a manual `caliber refresh --quiet` typed by a power user
+ * in an interactive Claude Code terminal (TTY → run normally) from the
+ * SessionEnd-hook-fired version (no TTY → would cascade → skip silently).
+ *
+ * Without this skip, the user's `claude -p` triggers our SessionEnd hook,
+ * which invokes `caliber refresh --quiet` (or `caliber learn finalize --auto`).
+ * Doing real LLM work here would spawn ANOTHER claude session, which Claude
+ * Code's hook timeout cancels mid-cascade, producing visible "Hook cancelled"
+ * stderr noise on every interactive `claude -p` the user runs in a
+ * Caliber-equipped repo.
  *
  * Hook entry points should call this first and exit 0 if true.
  *
@@ -73,5 +82,6 @@ export function withCaliberSubprocessEnv<T extends NodeJS.ProcessEnv>(env: T): T
 export function isHookCascadeFromUserClaudeSession(): boolean {
   const inClaudeSession = process.env.CLAUDECODE === '1';
   const isCaliberSpawned = process.env[CALIBER_SUBPROCESS_ENV] === '1';
-  return inClaudeSession && !isCaliberSpawned;
+  const isInteractiveTty = process.stdin.isTTY === true;
+  return inClaudeSession && !isCaliberSpawned && !isInteractiveTty;
 }

--- a/src/lib/subprocess-sentinel.ts
+++ b/src/lib/subprocess-sentinel.ts
@@ -51,3 +51,27 @@ export function withCaliberSubprocessEnv<T extends NodeJS.ProcessEnv>(env: T): T
     [CALIBER_SUBPROCESS_LEGACY_ENV]: '1',
   };
 }
+
+/**
+ * True when this caliber invocation is firing as a SessionEnd / hook
+ * cascade from inside an unrelated (user-initiated) Claude Code session.
+ *
+ * Specifically: we're inside a Claude Code session (CLAUDECODE=1) that
+ * caliber did NOT spawn (CALIBER_SUBPROCESS != 1). In that situation
+ * the user's `claude -p` triggered our SessionEnd hook, which invoked
+ * `caliber refresh --quiet` (or `caliber learn finalize --auto`).
+ * Doing real LLM work here would spawn ANOTHER claude session, which
+ * Claude Code's hook timeout cancels mid-cascade, producing visible
+ * "Hook cancelled" stderr noise on every interactive `claude -p`
+ * the user runs in a Caliber-equipped repo.
+ *
+ * Hook entry points should call this first and exit 0 if true.
+ *
+ * Audit finding: F-P0-9 in
+ * docs/superpowers/specs/2026-04-29-caliber-install-audit-findings.md
+ */
+export function isHookCascadeFromUserClaudeSession(): boolean {
+  const inClaudeSession = process.env.CLAUDECODE === '1';
+  const isCaliberSpawned = process.env[CALIBER_SUBPROCESS_ENV] === '1';
+  return inClaudeSession && !isCaliberSpawned;
+}

--- a/src/writers/__tests__/pre-commit-block.test.ts
+++ b/src/writers/__tests__/pre-commit-block.test.ts
@@ -266,6 +266,70 @@ describe('pre-commit-block', () => {
       expect(hasSyncBlock(inlined)).toBe(true);
     });
 
+    it('hasPreCommitBlock returns FALSE when "caliber" is in another section, not under "Before Committing"', async () => {
+      // Reviewer nit on PR #203: scope marker check to text between heading and next `## `.
+      // Here the user has a "## Before Committing" heading documenting their own
+      // pre-commit checks (no caliber), and "caliber" appears in an unrelated
+      // "## Tools We Use" section. Caliber-managed dedup must NOT fire.
+      const { hasPreCommitBlock } = await import('../pre-commit-block.js');
+      const content = `# proj
+
+## Before Committing
+
+Run npm test and lint.
+
+## Tools We Use
+
+We use \`caliber\` for some other purpose, and prettier, eslint, etc.
+`;
+      expect(hasPreCommitBlock(content)).toBe(false);
+    });
+
+    it('hasLearningsBlock returns FALSE when CALIBER_LEARNINGS is mentioned outside the "Session Learnings" section', async () => {
+      const { hasLearningsBlock } = await import('../pre-commit-block.js');
+      const content = `# proj
+
+## Session Learnings
+
+We track lessons in our own format here.
+
+## Tools
+
+The \`CALIBER_LEARNINGS\` env var configures something else.
+`;
+      expect(hasLearningsBlock(content)).toBe(false);
+    });
+
+    it('hasModelBlock returns FALSE when CALIBER_MODEL is mentioned outside "Model Configuration"', async () => {
+      const { hasModelBlock } = await import('../pre-commit-block.js');
+      const content = `# proj
+
+## Model Configuration
+
+We use claude-sonnet-4-6.
+
+## Env Vars
+
+\`CALIBER_MODEL\` is documented here for our internal tools.
+`;
+      expect(hasModelBlock(content)).toBe(false);
+    });
+
+    it('hasSyncBlock returns FALSE when caliber-ai-org link is outside "Context Sync"', async () => {
+      const { hasSyncBlock } = await import('../pre-commit-block.js');
+      const content = `# proj
+
+## Context Sync
+
+We sync via our own internal tooling.
+
+## See Also
+
+[Caliber](https://github.com/caliber-ai-org/ai-setup) is a related project.
+`;
+      expect(hasSyncBlock(content)).toBe(false);
+    });
+
     it('appendManagedBlocks on already-inlined CLAUDE.md is a no-op', async () => {
       const { appendManagedBlocks } = await import('../pre-commit-block.js');
       const inlined = `# proj

--- a/src/writers/__tests__/pre-commit-block.test.ts
+++ b/src/writers/__tests__/pre-commit-block.test.ts
@@ -217,4 +217,81 @@ describe('pre-commit-block', () => {
       expect(rule.content).toMatch(/`caliber refresh`/);
     });
   });
+
+  describe('appendManagedBlocks de-duplication (F-P0-10)', () => {
+    beforeEach(async () => {
+      const { resetResolvedCaliber } = await import('../../lib/resolve-caliber.js');
+      resetResolvedCaliber();
+      process.argv[1] = '/usr/local/bin/caliber';
+      delete process.env.npm_execpath;
+      mockedExecSync.mockReturnValue('/usr/local/bin/caliber\n');
+    });
+
+    it('hasPreCommitBlock detects unmarked inlined "Before Committing" with caliber', async () => {
+      const { hasPreCommitBlock } = await import('../pre-commit-block.js');
+      const inlined = '# proj\n\n## Before Committing\n\nRun `caliber refresh` before commit.\n';
+      expect(hasPreCommitBlock(inlined)).toBe(true);
+    });
+
+    it('hasPreCommitBlock returns false for unrelated "Before Committing" heading', async () => {
+      const { hasPreCommitBlock } = await import('../pre-commit-block.js');
+      const unrelated = '# proj\n\n## Before Committing\n\nRun npm test.\n';
+      expect(hasPreCommitBlock(unrelated)).toBe(false);
+    });
+
+    it('appendPreCommitBlock does NOT duplicate when inlined version exists', async () => {
+      const { appendPreCommitBlock } = await import('../pre-commit-block.js');
+      const inlined = '# proj\n\n## Before Committing\n\nRun `caliber refresh` before commit.\n';
+      const out = appendPreCommitBlock(inlined, 'claude');
+      expect(out).toBe(inlined);
+      expect((out.match(/## Before Committing/g) || []).length).toBe(1);
+    });
+
+    it('hasLearningsBlock detects unmarked inlined "Session Learnings" with CALIBER_LEARNINGS', async () => {
+      const { hasLearningsBlock } = await import('../pre-commit-block.js');
+      const inlined = '# proj\n\n## Session Learnings\n\nRead CALIBER_LEARNINGS.md for patterns.\n';
+      expect(hasLearningsBlock(inlined)).toBe(true);
+    });
+
+    it('hasModelBlock detects unmarked inlined "Model Configuration" with CALIBER_MODEL', async () => {
+      const { hasModelBlock } = await import('../pre-commit-block.js');
+      const inlined = '# proj\n\n## Model Configuration\n\nUse CALIBER_MODEL env var to pin.\n';
+      expect(hasModelBlock(inlined)).toBe(true);
+    });
+
+    it('hasSyncBlock detects unmarked inlined "Context Sync" with caliber-ai-org link', async () => {
+      const { hasSyncBlock } = await import('../pre-commit-block.js');
+      const inlined =
+        '# proj\n\n## Context Sync\n\nThis project uses [Caliber](https://github.com/caliber-ai-org/ai-setup).\n';
+      expect(hasSyncBlock(inlined)).toBe(true);
+    });
+
+    it('appendManagedBlocks on already-inlined CLAUDE.md is a no-op', async () => {
+      const { appendManagedBlocks } = await import('../pre-commit-block.js');
+      const inlined = `# proj
+
+## Before Committing
+
+Run \`caliber refresh\` before commit.
+
+## Session Learnings
+
+Read CALIBER_LEARNINGS.md for patterns.
+
+## Model Configuration
+
+Use CALIBER_MODEL env var to pin.
+
+## Context Sync
+
+This project uses [Caliber](https://github.com/caliber-ai-org/ai-setup).
+`;
+      const out = appendManagedBlocks(inlined, 'claude');
+      expect(out).toBe(inlined);
+      expect((out.match(/## Before Committing/g) || []).length).toBe(1);
+      expect((out.match(/## Session Learnings/g) || []).length).toBe(1);
+      expect((out.match(/## Model Configuration/g) || []).length).toBe(1);
+      expect((out.match(/## Context Sync/g) || []).length).toBe(1);
+    });
+  });
 });

--- a/src/writers/pre-commit-block.ts
+++ b/src/writers/pre-commit-block.ts
@@ -71,8 +71,16 @@ If \`${bin}\` is not found, read the setup-caliber skill from .cursor/skills/set
 `;
 }
 
+// F-P0-10: detect both the marker form AND the unmarked inlined form.
+// Init inlines this section via the LLM prompt context; without this
+// detection, refresh's appendManagedBlocks() would add a marker-wrapped
+// duplicate, producing visible duplicate sections in CLAUDE.md.
+const PRECOMMIT_HEADING_RE = /^##\s+Before Committing\s*$/m;
+
 export function hasPreCommitBlock(content: string): boolean {
-  return content.includes(BLOCK_START);
+  if (content.includes(BLOCK_START)) return true;
+  if (PRECOMMIT_HEADING_RE.test(content) && /caliber/i.test(content)) return true;
+  return false;
 }
 
 export function appendPreCommitBlock(content: string, platform: ConfigPlatform = 'claude'): string {
@@ -107,8 +115,13 @@ Read \`CALIBER_LEARNINGS.md\` for patterns and anti-patterns learned from previo
 These are auto-extracted from real tool usage — treat them as project-specific rules.
 `;
 
+// F-P0-10: same heading-based fallback for the learnings block.
+const LEARNINGS_HEADING_RE = /^##\s+Session Learnings\s*$/m;
+
 export function hasLearningsBlock(content: string): boolean {
-  return content.includes(LEARNINGS_BLOCK_START);
+  if (content.includes(LEARNINGS_BLOCK_START)) return true;
+  if (LEARNINGS_HEADING_RE.test(content) && /CALIBER_LEARNINGS/.test(content)) return true;
+  return false;
 }
 
 export function appendLearningsBlock(content: string): string {
@@ -139,8 +152,13 @@ Pin your choice (\`/model\` in Claude Code, or \`CALIBER_MODEL\` when using Cali
 ${MODEL_BLOCK_END}`;
 }
 
+// F-P0-10: same heading-based fallback for the model-config block.
+const MODEL_HEADING_RE = /^##\s+Model Configuration\s*$/m;
+
 export function hasModelBlock(content: string): boolean {
-  return content.includes(MODEL_BLOCK_START);
+  if (content.includes(MODEL_BLOCK_START)) return true;
+  if (MODEL_HEADING_RE.test(content) && /CALIBER_MODEL/.test(content)) return true;
+  return false;
 }
 
 export function appendModelBlock(content: string): string {
@@ -181,8 +199,13 @@ ${getSyncSetupInstruction(platform)}
 ${SYNC_BLOCK_END}`;
 }
 
+// F-P0-10: same heading-based fallback for the sync block.
+const SYNC_HEADING_RE = /^##\s+Context Sync\s*$/m;
+
 export function hasSyncBlock(content: string): boolean {
-  return content.includes(SYNC_BLOCK_START);
+  if (content.includes(SYNC_BLOCK_START)) return true;
+  if (SYNC_HEADING_RE.test(content) && /caliber-ai-org\/ai-setup/.test(content)) return true;
+  return false;
 }
 
 export function appendSyncBlock(content: string, platform: ConfigPlatform = 'claude'): string {

--- a/src/writers/pre-commit-block.ts
+++ b/src/writers/pre-commit-block.ts
@@ -75,11 +75,33 @@ If \`${bin}\` is not found, read the setup-caliber skill from .cursor/skills/set
 // Init inlines this section via the LLM prompt context; without this
 // detection, refresh's appendManagedBlocks() would add a marker-wrapped
 // duplicate, producing visible duplicate sections in CLAUDE.md.
+//
+// The marker phrase check is scoped to text BETWEEN the heading and the
+// next `## ` heading (or EOF) — not the whole file. This prevents false
+// positives in CLAUDE.md's that legitimately have a "Before Committing"
+// section unrelated to caliber but mention `caliber` elsewhere (e.g. in
+// a tools list or unrelated code block).
 const PRECOMMIT_HEADING_RE = /^##\s+Before Committing\s*$/m;
+
+/**
+ * Return the body of a section that starts at the first match of `headingRe`,
+ * ending at the next `## ` heading (or end of file). Returns null if the
+ * heading isn't found.
+ */
+function getSectionBody(content: string, headingRe: RegExp): string | null {
+  const match = content.match(headingRe);
+  if (!match || match.index === undefined) return null;
+  const start = match.index + match[0].length;
+  const tail = content.slice(start);
+  const nextHeadingMatch = tail.match(/^##\s/m);
+  const end = nextHeadingMatch?.index ?? tail.length;
+  return tail.slice(0, end);
+}
 
 export function hasPreCommitBlock(content: string): boolean {
   if (content.includes(BLOCK_START)) return true;
-  if (PRECOMMIT_HEADING_RE.test(content) && /caliber/i.test(content)) return true;
+  const body = getSectionBody(content, PRECOMMIT_HEADING_RE);
+  if (body && /caliber/i.test(body)) return true;
   return false;
 }
 
@@ -115,12 +137,13 @@ Read \`CALIBER_LEARNINGS.md\` for patterns and anti-patterns learned from previo
 These are auto-extracted from real tool usage — treat them as project-specific rules.
 `;
 
-// F-P0-10: same heading-based fallback for the learnings block.
+// F-P0-10: same heading-scoped fallback for the learnings block.
 const LEARNINGS_HEADING_RE = /^##\s+Session Learnings\s*$/m;
 
 export function hasLearningsBlock(content: string): boolean {
   if (content.includes(LEARNINGS_BLOCK_START)) return true;
-  if (LEARNINGS_HEADING_RE.test(content) && /CALIBER_LEARNINGS/.test(content)) return true;
+  const body = getSectionBody(content, LEARNINGS_HEADING_RE);
+  if (body && /CALIBER_LEARNINGS/.test(body)) return true;
   return false;
 }
 
@@ -152,12 +175,13 @@ Pin your choice (\`/model\` in Claude Code, or \`CALIBER_MODEL\` when using Cali
 ${MODEL_BLOCK_END}`;
 }
 
-// F-P0-10: same heading-based fallback for the model-config block.
+// F-P0-10: same heading-scoped fallback for the model-config block.
 const MODEL_HEADING_RE = /^##\s+Model Configuration\s*$/m;
 
 export function hasModelBlock(content: string): boolean {
   if (content.includes(MODEL_BLOCK_START)) return true;
-  if (MODEL_HEADING_RE.test(content) && /CALIBER_MODEL/.test(content)) return true;
+  const body = getSectionBody(content, MODEL_HEADING_RE);
+  if (body && /CALIBER_MODEL/.test(body)) return true;
   return false;
 }
 
@@ -199,12 +223,13 @@ ${getSyncSetupInstruction(platform)}
 ${SYNC_BLOCK_END}`;
 }
 
-// F-P0-10: same heading-based fallback for the sync block.
+// F-P0-10: same heading-scoped fallback for the sync block.
 const SYNC_HEADING_RE = /^##\s+Context Sync\s*$/m;
 
 export function hasSyncBlock(content: string): boolean {
   if (content.includes(SYNC_BLOCK_START)) return true;
-  if (SYNC_HEADING_RE.test(content) && /caliber-ai-org\/ai-setup/.test(content)) return true;
+  const body = getSectionBody(content, SYNC_HEADING_RE);
+  if (body && /caliber-ai-org\/ai-setup/.test(body)) return true;
   return false;
 }
 


### PR DESCRIPTION
## Summary

Stacked on #202 — base is `alonp98/install-audit`, not `master`. Once #202 lands, GitHub auto-rebases this PR's base.

Three more verified P0s from the install audit, plus a docs correction:

- **F-P0-9 — SessionEnd hook cascade** (`9d95cac`, `cfa77dc`). Every interactive `claude -p` in a Caliber-equipped repo emitted "Hook cancelled" stderr noise twice plus ~15s latency, because SessionEnd hooks (`caliber refresh --quiet`, `caliber learn finalize --auto`) tried to spawn another claude session for LLM work. Both commands now short-circuit when running inside a user-initiated Claude Code session (CLAUDECODE=1 + !CALIBER_SUBPROCESS). Manual `caliber refresh` / `caliber learn finalize` (no `--quiet`/`--auto`) still work normally. New helper: `isHookCascadeFromUserClaudeSession()` in `src/lib/subprocess-sentinel.ts` (`86f3afa`).
- **F-P0-10 — duplicated CLAUDE.md sections** (`3463491`). Init inlined the "Before Committing", "Session Learnings", "Model Configuration", and "Context Sync" sections via the LLM prompt context, and the subsequent `appendManagedBlocks()` only checked for the marker comment — adding a marker-wrapped duplicate on top of the unmarked inlined version. ~50 redundant lines per CLAUDE.md, which an agent had to parse twice. `hasXBlock()` functions now also detect the heading + a Caliber-specific marker phrase (e.g. `caliber` for pre-commit, `CALIBER_LEARNINGS` for learnings).
- **F-P0-2 — large-prompt inactivity timeout** (`7c514b8`). Default `CALIBER_STREAM_INACTIVITY_TIMEOUT_MS` bumped from 120s → 300s. Most repos finish in <60s; the bump trades a worst-case slow failure for a better default-success rate on caliber-dogfood-scale repos (~300 files). Also adds a soft 60s "model is taking longer than usual" warning that surfaces the env-var override mid-stream.

Plus an **audit-findings correction** (`f8b459d`): F-P0-7 / F-P0-8 / F-P0-11 in the original audit doc were false positives from the explore agent's structural map. Source review for this batch confirmed Phase 1 returns `null` (not `{}`) on parse failure, and Phase 2 surfaces failure counts via `callbacks.onStatus` at both call sites. The findings doc has a correction block at the top of the Findings section.

## Test Plan

- [x] Full suite: 1053/1053 (1035 baseline + 18 new across helper, refresh, learn finalize, pre-commit-block, generate-timeout)
- [x] `npx tsc --noEmit` clean
- [x] `npm run lint` 0 errors (128 pre-existing warnings, untouched)
- [x] `npm run build` produces fresh `dist/bin.js` at v1.49.1
- [x] Manual: `caliber refresh` (no flag) still works normally — only `--quiet`+CLAUDECODE+!CALIBER_SUBPROCESS triggers the new short-circuit
- [x] Manual: existing `spawned-session-guard.test.ts` still passes (had to add `delete process.env.CLAUDECODE` to its `beforeEach` so the new check doesn't mask its CALIBER_SUBPROCESS-only assertion)
- [ ] Live empirical verify of the cascade fix (requires `npm link` of source — installed v1.40.4 still on PATH for hooks; tests cover the behavior)

## After this lands

6 of the 8 verified P0s from the install audit are resolved. Remaining: a few P1 polish items + adaptive timeout scaling. Once both PR #202 and this PR are in, the messaging redesign that originally motivated the audit becomes ship-able.