### PR TITLE
fix(refresh): guard null response in docsUpdated check

### DIFF
--- a/src/commands/refresh.ts
+++ b/src/commands/refresh.ts
@@ -215,6 +215,15 @@ async function refreshDir(
     }
   }
 
+  // parseJsonResponse returns whatever JSON.parse yields, including `null`,
+  // which the RefreshResponse type cast hides at compile time. Treat a null
+  // response as a no-op refresh instead of crashing with "Cannot read
+  // properties of null (reading 'docsUpdated')". Refs #209.
+  if (!response) {
+    spinner?.succeed(`${prefix}No doc updates needed (empty response)`);
+    return { written: [], fileChanges: [], syncedAgents: [], changesSummary: null };
+  }
+
   if (!response.docsUpdated || response.docsUpdated.length === 0) {
     spinner?.succeed(`${prefix}No doc updates needed`);
     return { written: [], fileChanges: [], syncedAgents: [], changesSummary: null };


### PR DESCRIPTION
## What

Guard against a `null` response in `refreshDir` so `caliber refresh` doesn't crash with `Cannot read properties of null (reading 'docsUpdated')` when the LLM returns a literal `null` payload.

## Why

`parseJsonResponse<RefreshResponse>` in `src/llm/utils.ts` returns whatever `JSON.parse` yields, including `null`. The generic type cast hides the runtime possibility at compile time, so `response = await refreshDocs(...)` can be `null` even though TypeScript believes it's `RefreshResponse`. The next line (`if (!response.docsUpdated || ...)`) then crashes.

The reporter in #209 hits this on every workspace in a 14-workspace monorepo with `provider: claude-cli`: 14 sub-workspaces fail identically with the same null-deref message, after the Claude CLI returns successfully (no auth errors). Their hypothesis ("optional-chain or defaulted accessor") matches the fix shape.

The new guard sits one line above the existing `if (!response.docsUpdated || response.docsUpdated.length === 0)` no-op branch and returns the same shape, so a null response degrades to "no doc updates needed (empty response)" instead of throwing.

The deeper "why is the LLM returning null?" question is left for follow-up. Possibilities: the claude-cli provider stripping the JSON envelope, or the model genuinely emitting `null` on certain prompt shapes.

## Testing

- `npx vitest run src/commands/__tests__/refresh.test.ts` -> 11 tests pass
- `npx tsc --noEmit` -> clean
- `npx prettier --check src/commands/refresh.ts` -> all matched files use Prettier code style

No unit test for the new branch: `refreshDir` is not exported from `src/commands/refresh.ts`. Testing the null-response path would require either exporting the helper or mocking the `llmCall` chain. Happy to do either if preferred.

Closes #209