### PR TITLE
fix(writers): make pre-commit block paths target-aware

### DIFF
--- a/src/writers/__tests__/pre-commit-block.test.ts
+++ b/src/writers/__tests__/pre-commit-block.test.ts
@@ -99,6 +99,76 @@ describe('pre-commit-block', () => {
       expect(result).toContain('npx @rely-ai/caliber');
       expect(result).toContain('/setup-caliber');
     });
+
+    it('uses only Claude managed paths for Claude-only active targets', async () => {
+      process.argv[1] = '/usr/local/bin/caliber';
+      delete process.env.npm_execpath;
+      mockedExecSync.mockReturnValue('/usr/local/bin/caliber\n');
+
+      const { appendPreCommitBlock } = await import('../pre-commit-block.js');
+      const result = appendPreCommitBlock('# My Project', 'claude', ['claude']);
+
+      expect(result).toContain(
+        'caliber refresh && git add CLAUDE.md .claude/ CALIBER_LEARNINGS.md 2>/dev/null',
+      );
+      expect(result).not.toContain('.cursor/');
+      expect(result).not.toContain('.cursorrules');
+      expect(result).not.toContain('.github/copilot-instructions.md');
+      expect(result).not.toContain('.github/instructions/');
+      expect(result).not.toContain('AGENTS.md');
+      expect(result).not.toContain('.agents/');
+      expect(result).not.toContain('.opencode/');
+    });
+
+    it('adds Cursor paths when Claude and Cursor are active', async () => {
+      process.argv[1] = '/usr/local/bin/caliber';
+      delete process.env.npm_execpath;
+      mockedExecSync.mockReturnValue('/usr/local/bin/caliber\n');
+
+      const { appendPreCommitBlock } = await import('../pre-commit-block.js');
+      const result = appendPreCommitBlock('# My Project', 'claude', ['claude', 'cursor']);
+
+      expect(result).toContain(
+        'caliber refresh && git add CLAUDE.md .claude/ CALIBER_LEARNINGS.md .cursor/ .cursorrules 2>/dev/null',
+      );
+      expect(result).not.toContain('.github/copilot-instructions.md');
+      expect(result).not.toContain('.github/instructions/');
+      expect(result).not.toContain('AGENTS.md');
+      expect(result).not.toContain('.agents/');
+      expect(result).not.toContain('.opencode/');
+    });
+
+    it('preserves all managed paths when active targets are not passed', async () => {
+      process.argv[1] = '/usr/local/bin/caliber';
+      delete process.env.npm_execpath;
+      mockedExecSync.mockReturnValue('/usr/local/bin/caliber\n');
+
+      const { appendPreCommitBlock } = await import('../pre-commit-block.js');
+      const result = appendPreCommitBlock('# My Project', 'claude');
+
+      expect(result).toContain(
+        'caliber refresh && git add CLAUDE.md .claude/ .cursor/ .cursorrules .github/copilot-instructions.md .github/instructions/ AGENTS.md CALIBER_LEARNINGS.md .agents/ .opencode/ 2>/dev/null',
+      );
+    });
+
+    it('includes all managed paths when every target is active', async () => {
+      process.argv[1] = '/usr/local/bin/caliber';
+      delete process.env.npm_execpath;
+      mockedExecSync.mockReturnValue('/usr/local/bin/caliber\n');
+
+      const { appendPreCommitBlock } = await import('../pre-commit-block.js');
+      const result = appendPreCommitBlock('# My Project', 'claude', [
+        'claude',
+        'cursor',
+        'github-copilot',
+        'codex',
+        'opencode',
+      ]);
+
+      expect(result).toContain(
+        'caliber refresh && git add CLAUDE.md .claude/ CALIBER_LEARNINGS.md .cursor/ .cursorrules .github/copilot-instructions.md .github/instructions/ AGENTS.md .agents/ .opencode/ 2>/dev/null',
+      );
+    });
   });
 
   describe('appendSyncBlock', () => {
@@ -162,6 +232,26 @@ describe('pre-commit-block', () => {
 
       expect(rule.content).toContain('caliber refresh');
       expect(rule.content).not.toContain('npx');
+    });
+
+    it('uses only Cursor managed paths for Cursor-only active targets', async () => {
+      process.argv[1] = '/usr/local/bin/caliber';
+      delete process.env.npm_execpath;
+      mockedExecSync.mockReturnValue('/usr/local/bin/caliber\n');
+
+      const { getCursorPreCommitRule } = await import('../pre-commit-block.js');
+      const rule = getCursorPreCommitRule(['cursor']);
+
+      expect(rule.content).toContain(
+        'caliber refresh && git add .cursor/ .cursorrules 2>/dev/null',
+      );
+      expect(rule.content).not.toContain('CLAUDE.md');
+      expect(rule.content).not.toContain('CALIBER_LEARNINGS.md');
+      expect(rule.content).not.toContain('.github/copilot-instructions.md');
+      expect(rule.content).not.toContain('.github/instructions/');
+      expect(rule.content).not.toContain('AGENTS.md');
+      expect(rule.content).not.toContain('.agents/');
+      expect(rule.content).not.toContain('.opencode/');
     });
   });
 

--- a/src/writers/claude/index.ts
+++ b/src/writers/claude/index.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { appendManagedBlocks } from '../pre-commit-block.js';
+import { appendManagedBlocks, type WriteTarget } from '../pre-commit-block.js';
 
 interface ClaudeConfig {
   claudeMd: string;
@@ -9,13 +9,13 @@ interface ClaudeConfig {
   mcpServers?: Record<string, { command: string; args?: string[]; env?: Record<string, string> }>;
 }
 
-export function writeClaudeConfig(config: ClaudeConfig): string[] {
+export function writeClaudeConfig(
+  config: ClaudeConfig,
+  activeTargets?: ReadonlyArray<WriteTarget>,
+): string[] {
   const written: string[] = [];
 
-  fs.writeFileSync(
-    'CLAUDE.md',
-    appendManagedBlocks(config.claudeMd),
-  );
+  fs.writeFileSync('CLAUDE.md', appendManagedBlocks(config.claudeMd, 'claude', activeTargets));
   written.push('CLAUDE.md');
 
   if (config.rules?.length) {

--- a/src/writers/codex/index.ts
+++ b/src/writers/codex/index.ts
@@ -1,19 +1,19 @@
 import fs from 'fs';
 import path from 'path';
-import { appendManagedBlocks } from '../pre-commit-block.js';
+import { appendManagedBlocks, type WriteTarget } from '../pre-commit-block.js';
 
 interface CodexConfig {
   agentsMd: string;
   skills?: Array<{ name: string; description: string; content: string }>;
 }
 
-export function writeCodexConfig(config: CodexConfig): string[] {
+export function writeCodexConfig(
+  config: CodexConfig,
+  activeTargets?: ReadonlyArray<WriteTarget>,
+): string[] {
   const written: string[] = [];
 
-  fs.writeFileSync(
-    'AGENTS.md',
-    appendManagedBlocks(config.agentsMd, 'codex'),
-  );
+  fs.writeFileSync('AGENTS.md', appendManagedBlocks(config.agentsMd, 'codex', activeTargets));
   written.push('AGENTS.md');
 
   if (config.skills?.length) {

--- a/src/writers/cursor/index.ts
+++ b/src/writers/cursor/index.ts
@@ -4,6 +4,7 @@ import {
   getCursorPreCommitRule,
   getCursorLearningsRule,
   getCursorSyncRule,
+  type WriteTarget,
 } from '../pre-commit-block.js';
 
 interface CursorConfig {
@@ -13,7 +14,10 @@ interface CursorConfig {
   mcpServers?: Record<string, { command: string; args?: string[]; env?: Record<string, string> }>;
 }
 
-export function writeCursorConfig(config: CursorConfig): string[] {
+export function writeCursorConfig(
+  config: CursorConfig,
+  activeTargets?: ReadonlyArray<WriteTarget>,
+): string[] {
   const written: string[] = [];
 
   if (config.cursorrules) {
@@ -21,7 +25,7 @@ export function writeCursorConfig(config: CursorConfig): string[] {
     written.push('.cursorrules');
   }
 
-  const preCommitRule = getCursorPreCommitRule();
+  const preCommitRule = getCursorPreCommitRule(activeTargets);
   const learningsRule = getCursorLearningsRule();
   const syncRule = getCursorSyncRule();
   const allRules = [...(config.rules || []), preCommitRule, learningsRule, syncRule];

--- a/src/writers/github-copilot/index.ts
+++ b/src/writers/github-copilot/index.ts
@@ -1,20 +1,23 @@
 import fs from 'fs';
 import path from 'path';
-import { appendManagedBlocks } from '../pre-commit-block.js';
+import { appendManagedBlocks, type WriteTarget } from '../pre-commit-block.js';
 
 interface CopilotConfig {
   instructions: string;
   instructionFiles?: Array<{ filename: string; content: string }>;
 }
 
-export function writeGithubCopilotConfig(config: CopilotConfig): string[] {
+export function writeGithubCopilotConfig(
+  config: CopilotConfig,
+  activeTargets?: ReadonlyArray<WriteTarget>,
+): string[] {
   const written: string[] = [];
 
   if (config.instructions) {
     fs.mkdirSync('.github', { recursive: true });
     fs.writeFileSync(
       path.join('.github', 'copilot-instructions.md'),
-      appendManagedBlocks(config.instructions, 'copilot'),
+      appendManagedBlocks(config.instructions, 'copilot', activeTargets),
     );
     written.push('.github/copilot-instructions.md');
   }

--- a/src/writers/index.ts
+++ b/src/writers/index.ts
@@ -33,26 +33,27 @@ export function writeSetup(setup: AgentSetup): {
   const backupDir = existingFiles.length > 0 ? createBackup(existingFiles) : undefined;
 
   const written: string[] = [];
+  const activeTargets = setup.targetAgent;
 
   if (setup.targetAgent.includes('claude') && setup.claude) {
-    written.push(...writeClaudeConfig(setup.claude));
+    written.push(...writeClaudeConfig(setup.claude, activeTargets));
   }
 
   if (setup.targetAgent.includes('cursor') && setup.cursor) {
-    written.push(...writeCursorConfig(setup.cursor));
+    written.push(...writeCursorConfig(setup.cursor, activeTargets));
   }
 
   if (setup.targetAgent.includes('codex') && setup.codex) {
-    written.push(...writeCodexConfig(setup.codex));
+    written.push(...writeCodexConfig(setup.codex, activeTargets));
   }
 
   if (setup.targetAgent.includes('opencode') && setup.opencode) {
     const agentsMdAlreadyWritten = written.includes('AGENTS.md');
-    written.push(...writeOpencodeConfig(setup.opencode, agentsMdAlreadyWritten));
+    written.push(...writeOpencodeConfig(setup.opencode, agentsMdAlreadyWritten, activeTargets));
   }
 
   if (setup.targetAgent.includes('github-copilot') && setup.copilot) {
-    written.push(...writeGithubCopilotConfig(setup.copilot));
+    written.push(...writeGithubCopilotConfig(setup.copilot, activeTargets));
   }
 
   const deleted: string[] = [];

--- a/src/writers/opencode/index.ts
+++ b/src/writers/opencode/index.ts
@@ -1,6 +1,10 @@
 import fs from 'fs';
 import path from 'path';
-import { appendPreCommitBlock, appendLearningsBlock } from '../pre-commit-block.js';
+import {
+  appendPreCommitBlock,
+  appendLearningsBlock,
+  type WriteTarget,
+} from '../pre-commit-block.js';
 import { buildSkillContent } from '../../lib/builtin-skills.js';
 
 interface OpencodeConfig {
@@ -11,13 +15,14 @@ interface OpencodeConfig {
 export function writeOpencodeConfig(
   config: OpencodeConfig,
   agentsMdAlreadyWritten = false,
+  activeTargets?: ReadonlyArray<WriteTarget>,
 ): string[] {
   const written: string[] = [];
 
   if (!agentsMdAlreadyWritten) {
     fs.writeFileSync(
       'AGENTS.md',
-      appendLearningsBlock(appendPreCommitBlock(config.agentsMd, 'codex')),
+      appendLearningsBlock(appendPreCommitBlock(config.agentsMd, 'codex', activeTargets)),
     );
     written.push('AGENTS.md');
   }

--- a/src/writers/pre-commit-block.ts
+++ b/src/writers/pre-commit-block.ts
@@ -2,12 +2,28 @@ import { displayCaliberName } from '../lib/resolve-caliber.js';
 import { DEFAULT_MODELS } from '../llm/config.js';
 
 export type ConfigPlatform = 'claude' | 'copilot' | 'codex';
+export type WriteTarget = 'claude' | 'cursor' | 'codex' | 'opencode' | 'github-copilot';
 
 const BLOCK_START = '<!-- caliber:managed:pre-commit -->';
 const BLOCK_END = '<!-- /caliber:managed:pre-commit -->';
 
-const MANAGED_DOC_PATHS =
+const ALL_MANAGED_DOC_PATHS =
   'CLAUDE.md .claude/ .cursor/ .cursorrules .github/copilot-instructions.md .github/instructions/ AGENTS.md CALIBER_LEARNINGS.md .agents/ .opencode/';
+
+const MANAGED_DOC_PATHS_BY_TARGET: Record<WriteTarget, string[]> = {
+  claude: ['CLAUDE.md', '.claude/', 'CALIBER_LEARNINGS.md'],
+  cursor: ['.cursor/', '.cursorrules'],
+  codex: ['AGENTS.md', '.agents/'],
+  opencode: ['.opencode/'],
+  'github-copilot': ['.github/copilot-instructions.md', '.github/instructions/'],
+};
+
+export function buildManagedDocPaths(activeTargets?: ReadonlyArray<WriteTarget>): string {
+  if (!activeTargets?.length) return ALL_MANAGED_DOC_PATHS;
+
+  const paths = activeTargets.flatMap((target) => MANAGED_DOC_PATHS_BY_TARGET[target]);
+  return [...new Set(paths)].join(' ');
+}
 
 function getCaliberNotFoundFallback(platform: ConfigPlatform, bin: string): string {
   switch (platform) {
@@ -24,8 +40,12 @@ npx @rely-ai/caliber refresh
   }
 }
 
-function getPreCommitBlock(platform: ConfigPlatform = 'claude'): string {
+function getPreCommitBlock(
+  platform: ConfigPlatform = 'claude',
+  activeTargets?: ReadonlyArray<WriteTarget>,
+): string {
   const bin = displayCaliberName();
+  const managedDocPaths = buildManagedDocPaths(activeTargets);
   return `${BLOCK_START}
 ## Before Committing
 
@@ -39,7 +59,7 @@ grep -q "caliber" .git/hooks/pre-commit 2>/dev/null && echo "hook-active" || ech
 - If **hook-active**: the hook handles sync automatically — just commit normally. Tell the user: "Caliber will sync your agent configs automatically via the pre-commit hook."
 - If **no-hook**: run Caliber manually before committing:
   1. Tell the user: "Caliber: Syncing agent configs with your latest changes..."
-  2. Run: \`${bin} refresh && git add ${MANAGED_DOC_PATHS} 2>/dev/null\`
+  2. Run: \`${bin} refresh && git add ${managedDocPaths} 2>/dev/null\`
   3. After it completes, briefly tell the user what Caliber updated. Then proceed with the commit.
 
 **Valid \`${bin} refresh\` options:** \`--quiet\` (suppress output) and \`--dry-run\` (preview without writing). Do not pass any other flags — options like \`--auto-approve\`, \`--debug\`, or \`--force\` do not exist and will cause errors.
@@ -52,8 +72,9 @@ ${BLOCK_END}`;
 
 const CURSOR_RULE_FILENAME = 'caliber-pre-commit.mdc';
 
-function getCursorRuleContent(): string {
+function getCursorRuleContent(activeTargets?: ReadonlyArray<WriteTarget>): string {
   const bin = displayCaliberName();
+  const managedDocPaths = buildManagedDocPaths(activeTargets);
   return `---
 description: Run Caliber sync before git commits to keep agent configs up to date
 alwaysApply: true
@@ -62,7 +83,7 @@ Before every git commit, check if the Caliber pre-commit hook is installed:
 Run: \`grep -q "caliber" .git/hooks/pre-commit 2>/dev/null && echo "hook-active" || echo "no-hook"\`
 
 If hook-active: just commit normally — Caliber syncs automatically via the hook. Tell the user: "Caliber will sync your agent configs automatically."
-If no-hook: run \`${bin} refresh && git add ${MANAGED_DOC_PATHS} 2>/dev/null\` before committing, and tell the user what was updated.
+If no-hook: run \`${bin} refresh && git add ${managedDocPaths} 2>/dev/null\` before committing, and tell the user what was updated.
 
 Valid \`${bin} refresh\` options: \`--quiet\` and \`--dry-run\` only. Do not pass \`--auto-approve\`, \`--debug\`, \`--force\`, or any other flags.
 \`${bin} config\` takes no flags — it is interactive. Do not pass \`--provider\`, \`--api-key\`, or \`--endpoint\`.
@@ -105,14 +126,21 @@ export function hasPreCommitBlock(content: string): boolean {
   return false;
 }
 
-export function appendPreCommitBlock(content: string, platform: ConfigPlatform = 'claude'): string {
+export function appendPreCommitBlock(
+  content: string,
+  platform: ConfigPlatform = 'claude',
+  activeTargets?: ReadonlyArray<WriteTarget>,
+): string {
   if (hasPreCommitBlock(content)) return content;
   const trimmed = content.trimEnd();
-  return trimmed + '\n\n' + getPreCommitBlock(platform) + '\n';
+  return trimmed + '\n\n' + getPreCommitBlock(platform, activeTargets) + '\n';
 }
 
-export function getCursorPreCommitRule(): { filename: string; content: string } {
-  return { filename: CURSOR_RULE_FILENAME, content: getCursorRuleContent() };
+export function getCursorPreCommitRule(activeTargets?: ReadonlyArray<WriteTarget>): {
+  filename: string;
+  content: string;
+} {
+  return { filename: CURSOR_RULE_FILENAME, content: getCursorRuleContent(activeTargets) };
 }
 
 // ── Learnings reference block ────────────────────────────────────────
@@ -196,7 +224,11 @@ export function appendModelBlock(content: string): string {
 const SYNC_BLOCK_START = '<!-- caliber:managed:sync -->';
 const SYNC_BLOCK_END = '<!-- /caliber:managed:sync -->';
 
-function getSyncSetupInstruction(platform: ConfigPlatform): string {
+function getSyncSetupInstruction(
+  platform: ConfigPlatform,
+  activeTargets?: ReadonlyArray<WriteTarget>,
+): string {
+  const managedDocPaths = buildManagedDocPaths(activeTargets);
   switch (platform) {
     case 'claude':
       return `If the pre-commit hook is not set up, run \`/setup-caliber\` to configure everything automatically.`;
@@ -207,19 +239,22 @@ function getSyncSetupInstruction(platform: ConfigPlatform): string {
 \`\`\`bash
 npx @rely-ai/caliber hooks --install
 npx @rely-ai/caliber refresh
-git add ${MANAGED_DOC_PATHS} 2>/dev/null
+git add ${managedDocPaths} 2>/dev/null
 \`\`\``;
   }
 }
 
-function getSyncBlock(platform: ConfigPlatform = 'claude'): string {
+function getSyncBlock(
+  platform: ConfigPlatform = 'claude',
+  activeTargets?: ReadonlyArray<WriteTarget>,
+): string {
   const bin = displayCaliberName();
   return `${SYNC_BLOCK_START}
 ## Context Sync
 
 This project uses [Caliber](https://github.com/caliber-ai-org/ai-setup) to keep AI agent configs in sync across Claude Code, Cursor, Copilot, and Codex.
 Configs update automatically before each commit via \`${bin} refresh\`.
-${getSyncSetupInstruction(platform)}
+${getSyncSetupInstruction(platform, activeTargets)}
 ${SYNC_BLOCK_END}`;
 }
 
@@ -233,16 +268,25 @@ export function hasSyncBlock(content: string): boolean {
   return false;
 }
 
-export function appendSyncBlock(content: string, platform: ConfigPlatform = 'claude'): string {
+export function appendSyncBlock(
+  content: string,
+  platform: ConfigPlatform = 'claude',
+  activeTargets?: ReadonlyArray<WriteTarget>,
+): string {
   if (hasSyncBlock(content)) return content;
   const trimmed = content.trimEnd();
-  return trimmed + '\n\n' + getSyncBlock(platform) + '\n';
+  return trimmed + '\n\n' + getSyncBlock(platform, activeTargets) + '\n';
 }
 
-export function appendManagedBlocks(content: string, platform: ConfigPlatform = 'claude'): string {
+export function appendManagedBlocks(
+  content: string,
+  platform: ConfigPlatform = 'claude',
+  activeTargets?: ReadonlyArray<WriteTarget>,
+): string {
   return appendSyncBlock(
-    appendModelBlock(appendLearningsBlock(appendPreCommitBlock(content, platform))),
+    appendModelBlock(appendLearningsBlock(appendPreCommitBlock(content, platform, activeTargets))),
     platform,
+    activeTargets,
   );
 }
 

--- a/src/writers/refresh.ts
+++ b/src/writers/refresh.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { appendManagedBlocks } from './pre-commit-block.js';
+import { appendManagedBlocks, type WriteTarget } from './pre-commit-block.js';
 
 interface RefreshDocs {
   agentsMd?: string | null;
@@ -25,8 +25,20 @@ function writeFileGroup(
   });
 }
 
+function getActiveTargets(docs: RefreshDocs): WriteTarget[] {
+  const activeTargets: WriteTarget[] = [];
+  if (docs.claudeMd || docs.claudeRules) activeTargets.push('claude');
+  if (docs.cursorrules || docs.cursorRules) activeTargets.push('cursor');
+  if (docs.agentsMd) activeTargets.push('codex');
+  if (docs.copilotInstructions || docs.copilotInstructionFiles) {
+    activeTargets.push('github-copilot');
+  }
+  return activeTargets;
+}
+
 export function writeRefreshDocs(docs: RefreshDocs, dir: string = '.'): string[] {
   const written: string[] = [];
+  const activeTargets = getActiveTargets(docs);
   const p = (relPath: string): string =>
     (dir === '.' ? relPath : path.join(dir, relPath)).replace(/\\/g, '/');
   const ensureParent = (filePath: string): void => {
@@ -37,14 +49,14 @@ export function writeRefreshDocs(docs: RefreshDocs, dir: string = '.'): string[]
   if (docs.agentsMd) {
     const filePath = p('AGENTS.md');
     ensureParent(filePath);
-    fs.writeFileSync(filePath, appendManagedBlocks(docs.agentsMd, 'codex'));
+    fs.writeFileSync(filePath, appendManagedBlocks(docs.agentsMd, 'codex', activeTargets));
     written.push(filePath);
   }
 
   if (docs.claudeMd) {
     const filePath = p('CLAUDE.md');
     ensureParent(filePath);
-    fs.writeFileSync(filePath, appendManagedBlocks(docs.claudeMd));
+    fs.writeFileSync(filePath, appendManagedBlocks(docs.claudeMd, 'claude', activeTargets));
     written.push(filePath);
   }
 
@@ -73,7 +85,10 @@ export function writeRefreshDocs(docs: RefreshDocs, dir: string = '.'): string[]
   if (docs.copilotInstructions) {
     const filePath = p(path.join('.github', 'copilot-instructions.md'));
     ensureParent(filePath);
-    fs.writeFileSync(filePath, appendManagedBlocks(docs.copilotInstructions, 'copilot'));
+    fs.writeFileSync(
+      filePath,
+      appendManagedBlocks(docs.copilotInstructions, 'copilot', activeTargets),
+    );
     written.push(filePath);
   }
 


### PR DESCRIPTION
## What

Make the embedded `caliber refresh && git add ...` command in `CLAUDE.md` (and peer files for codex / copilot) only list the paths that the active write targets actually create.

## Why

Reported in #204. When `caliber init --agent claude --auto-approve` runs with only Claude active, the generated `CLAUDE.md` still embeds a managed pre-commit block whose `git add` line lists `.cursor/`, `.cursorrules`, `.github/copilot-instructions.md`, `.github/instructions/`, `AGENTS.md`, `.agents/`, and `.opencode/` - none of which exist on a Claude-only target. The `2>/dev/null` mutes git's complaint, but caliber's own `score-refine.ts` rubric penalises invalid path refs, so the file lowers caliber's own grounding score, and downstream LLMs reading CLAUDE.md pick up the bogus paths and propagate them into hallucinated tool calls.

## Testing

- `npm run test`: 84 files / 1063 tests pass (added 5 cases to `pre-commit-block.test.ts`: Claude-only, Claude+Cursor, all-targets, fallback-all-paths regression baseline, Cursor-only rule)
- `npx tsc --noEmit`: clean
- `npm run lint`: 0 errors (existing warnings only)
- `npx prettier --check` on the 9 touched files: clean
- Manual verification:
  - `appendPreCommitBlock(content, 'claude', ['claude'])` -> `git add CLAUDE.md .claude/ CALIBER_LEARNINGS.md`
  - `appendPreCommitBlock(content, 'claude', ['claude', 'cursor'])` -> adds `.cursor/ .cursorrules`
  - `appendPreCommitBlock(content, 'claude')` (no activeTargets) -> preserves the full historical path string

Diff: 9 files, +207/-45 (most of the +207 is the new test cases).

Closes #204