### PR TITLE
fix: resolve #209 null crash, #204 hardcoded paths, #206 cursor login

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -404,7 +404,7 @@ export async function initCommand(options: InitOptions) {
     if (!claudeContent) {
       claudeContent = `# ${path.basename(process.cwd())}\n`;
     }
-    const updatedClaude = appendManagedBlocks(claudeContent, 'claude');
+    const updatedClaude = appendManagedBlocks(claudeContent, 'claude', targetAgent);
     if (updatedClaude !== claudeContent || !fs.existsSync(claudeMdPath)) {
       fs.writeFileSync(claudeMdPath, updatedClaude);
       console.log(`  ${chalk.green('✓')} CLAUDE.md — added Caliber sync instructions`);
@@ -415,7 +415,7 @@ export async function initCommand(options: InitOptions) {
       const rulesDir = path.join('.cursor', 'rules');
       if (!fs.existsSync(rulesDir)) fs.mkdirSync(rulesDir, { recursive: true });
       for (const rule of [
-        getCursorPreCommitRule(),
+        getCursorPreCommitRule(targetAgent),
         getCursorLearningsRule(),
         getCursorSyncRule(),
         getCursorSetupRule(),
@@ -438,7 +438,7 @@ export async function initCommand(options: InitOptions) {
         fs.mkdirSync('.github', { recursive: true });
         copilotContent = `# ${path.basename(process.cwd())}\n`;
       }
-      const updatedCopilot = appendManagedBlocks(copilotContent, 'copilot');
+      const updatedCopilot = appendManagedBlocks(copilotContent, 'copilot', targetAgent);
       if (updatedCopilot !== copilotContent) {
         fs.writeFileSync(copilotPath, updatedCopilot);
         console.log(`  ${chalk.green('✓')} Copilot instructions — added Caliber sync instructions`);

--- a/src/llm/__tests__/utils.test.ts
+++ b/src/llm/__tests__/utils.test.ts
@@ -99,11 +99,19 @@ describe('parseJsonResponse', () => {
   });
 
   it('throws when no JSON found', () => {
-    expect(() => parseJsonResponse('no json here')).toThrow('No JSON found');
+    expect(() => parseJsonResponse('no json here')).toThrow('No valid JSON object');
   });
 
   it('throws on invalid JSON even after extraction', () => {
     expect(() => parseJsonResponse('{invalid: json}')).toThrow();
+  });
+
+  it('throws when LLM returns literal null', () => {
+    expect(() => parseJsonResponse('null')).toThrow('No valid JSON object');
+  });
+
+  it('throws when LLM returns a primitive string', () => {
+    expect(() => parseJsonResponse('"just a string"')).toThrow('No valid JSON object');
   });
 });
 

--- a/src/llm/cursor-acp.ts
+++ b/src/llm/cursor-acp.ts
@@ -429,8 +429,9 @@ export function isCursorLoggedIn(): boolean {
       input: '',
       stdio: ['pipe', 'pipe', 'pipe'],
       timeout: 5000,
+      env: withCaliberSubprocessEnv({ ...process.env }),
     });
-    return !result.toString().includes('not logged in');
+    return !result.toString().toLowerCase().includes('not logged in');
   } catch {
     return false;
   }

--- a/src/llm/utils.ts
+++ b/src/llm/utils.ts
@@ -42,16 +42,28 @@ export function parseJsonResponse<T>(raw: string): T {
   const cleaned = stripMarkdownFences(raw);
 
   try {
-    return JSON.parse(cleaned);
-  } catch {
-    // Fall through to bracket extraction
+    const parsed = JSON.parse(cleaned);
+    if (parsed === null || typeof parsed !== 'object') {
+      throw new Error('Parsed JSON is not an object');
+    }
+    return parsed;
+  } catch (e) {
+    if (e instanceof Error && e.message === 'Parsed JSON is not an object') {
+      // Fall through — but don't silently accept null/primitive results
+    } else {
+      // JSON.parse syntax error — fall through to bracket extraction
+    }
   }
 
   const json = extractJson(cleaned);
   if (!json) {
-    throw new Error(`No JSON found in LLM response: ${raw.slice(0, 200)}`);
+    throw new Error(`No valid JSON object in LLM response: ${raw.slice(0, 200)}`);
   }
-  return JSON.parse(json);
+  const extracted = JSON.parse(json);
+  if (extracted === null || typeof extracted !== 'object') {
+    throw new Error(`No valid JSON object in LLM response: ${raw.slice(0, 200)}`);
+  }
+  return extracted;
 }
 
 export function estimateTokens(text: string): number {

--- a/src/llm/utils.ts
+++ b/src/llm/utils.ts
@@ -38,21 +38,18 @@ export function stripMarkdownFences(text: string): string {
     .trim();
 }
 
+function isJsonObject(value: unknown): boolean {
+  return value !== null && typeof value === 'object';
+}
+
 export function parseJsonResponse<T>(raw: string): T {
   const cleaned = stripMarkdownFences(raw);
 
   try {
     const parsed = JSON.parse(cleaned);
-    if (parsed === null || typeof parsed !== 'object') {
-      throw new Error('Parsed JSON is not an object');
-    }
-    return parsed;
-  } catch (e) {
-    if (e instanceof Error && e.message === 'Parsed JSON is not an object') {
-      // Fall through — but don't silently accept null/primitive results
-    } else {
-      // JSON.parse syntax error — fall through to bracket extraction
-    }
+    if (isJsonObject(parsed)) return parsed;
+  } catch {
+    // JSON.parse syntax error — fall through to bracket extraction
   }
 
   const json = extractJson(cleaned);
@@ -60,7 +57,7 @@ export function parseJsonResponse<T>(raw: string): T {
     throw new Error(`No valid JSON object in LLM response: ${raw.slice(0, 200)}`);
   }
   const extracted = JSON.parse(json);
-  if (extracted === null || typeof extracted !== 'object') {
+  if (!isJsonObject(extracted)) {
     throw new Error(`No valid JSON object in LLM response: ${raw.slice(0, 200)}`);
   }
   return extracted;

--- a/src/writers/__tests__/pre-commit-block.test.ts
+++ b/src/writers/__tests__/pre-commit-block.test.ts
@@ -218,6 +218,66 @@ describe('pre-commit-block', () => {
     });
   });
 
+  describe('activeTargets path filtering', () => {
+    beforeEach(async () => {
+      const { resetResolvedCaliber } = await import('../../lib/resolve-caliber.js');
+      resetResolvedCaliber();
+      process.argv[1] = '/usr/local/bin/caliber';
+      delete process.env.npm_execpath;
+      mockedExecSync.mockReturnValue('/usr/local/bin/caliber\n');
+    });
+
+    it('includes only claude paths when activeTargets is [claude]', async () => {
+      const { appendPreCommitBlock } = await import('../pre-commit-block.js');
+      const result = appendPreCommitBlock('# Test', 'claude', ['claude']);
+      expect(result).toContain('CLAUDE.md');
+      expect(result).toContain('.claude/');
+      expect(result).not.toContain('.cursor/');
+      expect(result).not.toContain('AGENTS.md');
+      expect(result).not.toContain('.opencode/');
+    });
+
+    it('includes cursor paths when cursor is an active target', async () => {
+      const { appendPreCommitBlock } = await import('../pre-commit-block.js');
+      const result = appendPreCommitBlock('# Test', 'claude', ['claude', 'cursor']);
+      expect(result).toContain('.cursor/');
+      expect(result).toContain('.cursorrules');
+      expect(result).not.toContain('AGENTS.md');
+    });
+
+    it('includes all paths when activeTargets is undefined (backward compat)', async () => {
+      const { appendPreCommitBlock } = await import('../pre-commit-block.js');
+      const result = appendPreCommitBlock('# Test', 'claude');
+      expect(result).toContain('.cursor/');
+      expect(result).toContain('AGENTS.md');
+      expect(result).toContain('.opencode/');
+    });
+
+    it('omits claude paths for copilot-only target', async () => {
+      const { appendPreCommitBlock } = await import('../pre-commit-block.js');
+      const result = appendPreCommitBlock('# Test', 'copilot', ['github-copilot']);
+      expect(result).toContain('.github/copilot-instructions.md');
+      expect(result).not.toContain('CLAUDE.md');
+      expect(result).not.toContain('.claude/');
+    });
+
+    it('getCursorPreCommitRule respects activeTargets', async () => {
+      const { getCursorPreCommitRule } = await import('../pre-commit-block.js');
+      const rule = getCursorPreCommitRule(['claude', 'cursor']);
+      expect(rule.content).toContain('.cursor/');
+      expect(rule.content).not.toContain('AGENTS.md');
+      expect(rule.content).not.toContain('.opencode/');
+    });
+
+    it('empty activeTargets array produces only CALIBER_LEARNINGS.md', async () => {
+      const { appendPreCommitBlock } = await import('../pre-commit-block.js');
+      const result = appendPreCommitBlock('# Test', 'claude', []);
+      expect(result).toContain('CALIBER_LEARNINGS.md');
+      expect(result).not.toContain('CLAUDE.md');
+      expect(result).not.toContain('.cursor/');
+    });
+  });
+
   describe('appendManagedBlocks de-duplication (F-P0-10)', () => {
     beforeEach(async () => {
       const { resetResolvedCaliber } = await import('../../lib/resolve-caliber.js');

--- a/src/writers/__tests__/refresh.test.ts
+++ b/src/writers/__tests__/refresh.test.ts
@@ -50,9 +50,9 @@ describe('writeRefreshDocs', () => {
 
     expect(written).toContain('.github/copilot-instructions.md');
     expect(vi.mocked(fs.mkdirSync)).toHaveBeenCalledWith('.github', { recursive: true });
-    const copilotContent = vi.mocked(fs.writeFileSync).mock.calls.find(
-      (c) => String(c[0]).endsWith('copilot-instructions.md')
-    )?.[1] as string;
+    const copilotContent = vi
+      .mocked(fs.writeFileSync)
+      .mock.calls.find((c) => String(c[0]).endsWith('copilot-instructions.md'))?.[1] as string;
     expect(copilotContent).toContain('caliber:managed:model-config');
   });
 
@@ -130,6 +130,48 @@ describe('writeRefreshDocs', () => {
     expect(rulePath).toBeDefined();
     expect(vi.mocked(fs.mkdirSync)).toHaveBeenCalledWith(expect.stringContaining('.claude/rules'), {
       recursive: true,
+    });
+  });
+
+  describe('inferActiveTargets via managed block paths', () => {
+    it('includes cursor paths when cursorRules are present', () => {
+      writeRefreshDocs({
+        claudeMd: '# Test',
+        cursorRules: [{ filename: 'r.mdc', content: 'rule' }],
+      });
+      const claudeContent = vi
+        .mocked(fs.writeFileSync)
+        .mock.calls.find((c) => String(c[0]) === 'CLAUDE.md')?.[1] as string;
+      expect(claudeContent).toContain('.cursor/');
+      expect(claudeContent).not.toContain('AGENTS.md');
+    });
+
+    it('omits cursor paths when no cursor docs provided', () => {
+      writeRefreshDocs({ claudeMd: '# Test' });
+      const claudeContent = vi
+        .mocked(fs.writeFileSync)
+        .mock.calls.find((c) => String(c[0]) === 'CLAUDE.md')?.[1] as string;
+      expect(claudeContent).not.toContain('.cursor/');
+    });
+
+    it('includes copilot paths when copilot docs provided', () => {
+      writeRefreshDocs({
+        claudeMd: '# Test',
+        copilotInstructions: '# Copilot',
+      });
+      const claudeContent = vi
+        .mocked(fs.writeFileSync)
+        .mock.calls.find((c) => String(c[0]) === 'CLAUDE.md')?.[1] as string;
+      expect(claudeContent).toContain('.github/copilot-instructions.md');
+    });
+
+    it('omits claude paths from AGENTS.md when only codex docs provided', () => {
+      writeRefreshDocs({ agentsMd: '# Agents' });
+      const agentsContent = vi
+        .mocked(fs.writeFileSync)
+        .mock.calls.find((c) => String(c[0]) === 'AGENTS.md')?.[1] as string;
+      expect(agentsContent).toContain('AGENTS.md');
+      expect(agentsContent).not.toContain('CLAUDE.md');
     });
   });
 

--- a/src/writers/claude/index.ts
+++ b/src/writers/claude/index.ts
@@ -1,12 +1,13 @@
 import fs from 'fs';
 import path from 'path';
-import { appendManagedBlocks } from '../pre-commit-block.js';
+import { appendManagedBlocks, type TargetAgent } from '../pre-commit-block.js';
 
 interface ClaudeConfig {
   claudeMd: string;
   rules?: Array<{ filename: string; content: string }>;
   skills?: Array<{ name: string; description: string; content: string; paths?: string[] }>;
   mcpServers?: Record<string, { command: string; args?: string[]; env?: Record<string, string> }>;
+  activeTargets?: TargetAgent[];
 }
 
 export function writeClaudeConfig(config: ClaudeConfig): string[] {
@@ -14,7 +15,7 @@ export function writeClaudeConfig(config: ClaudeConfig): string[] {
 
   fs.writeFileSync(
     'CLAUDE.md',
-    appendManagedBlocks(config.claudeMd),
+    appendManagedBlocks(config.claudeMd, 'claude', config.activeTargets),
   );
   written.push('CLAUDE.md');
 

--- a/src/writers/index.ts
+++ b/src/writers/index.ts
@@ -35,6 +35,7 @@ export function writeSetup(setup: AgentSetup): {
   const written: string[] = [];
 
   if (setup.targetAgent.includes('claude') && setup.claude) {
+    setup.claude.activeTargets = setup.targetAgent;
     written.push(...writeClaudeConfig(setup.claude));
   }
 

--- a/src/writers/pre-commit-block.ts
+++ b/src/writers/pre-commit-block.ts
@@ -8,24 +8,16 @@ const BLOCK_START = '<!-- caliber:managed:pre-commit -->';
 const BLOCK_END = '<!-- /caliber:managed:pre-commit -->';
 
 function getManagedDocPaths(activeTargets?: TargetAgent[]): string {
-  const paths = ['CLAUDE.md', '.claude/', 'CALIBER_LEARNINGS.md'];
   if (!activeTargets) {
-    paths.push(
-      '.cursor/',
-      '.cursorrules',
-      '.github/copilot-instructions.md',
-      '.github/instructions/',
-      'AGENTS.md',
-      '.agents/',
-      '.opencode/',
-    );
-  } else {
-    if (activeTargets.includes('cursor')) paths.push('.cursor/', '.cursorrules');
-    if (activeTargets.includes('github-copilot'))
-      paths.push('.github/copilot-instructions.md', '.github/instructions/');
-    if (activeTargets.includes('codex')) paths.push('AGENTS.md', '.agents/');
-    if (activeTargets.includes('opencode')) paths.push('.opencode/');
+    return 'CLAUDE.md .claude/ .cursor/ .cursorrules .github/copilot-instructions.md .github/instructions/ AGENTS.md CALIBER_LEARNINGS.md .agents/ .opencode/';
   }
+  const paths = ['CALIBER_LEARNINGS.md'];
+  if (activeTargets.includes('claude')) paths.push('CLAUDE.md', '.claude/');
+  if (activeTargets.includes('cursor')) paths.push('.cursor/', '.cursorrules');
+  if (activeTargets.includes('github-copilot'))
+    paths.push('.github/copilot-instructions.md', '.github/instructions/');
+  if (activeTargets.includes('codex')) paths.push('AGENTS.md', '.agents/');
+  if (activeTargets.includes('opencode')) paths.push('.opencode/');
   return paths.join(' ');
 }
 
@@ -229,19 +221,20 @@ const SYNC_BLOCK_START = '<!-- caliber:managed:sync -->';
 const SYNC_BLOCK_END = '<!-- /caliber:managed:sync -->';
 
 function getSyncSetupInstruction(platform: ConfigPlatform, activeTargets?: TargetAgent[]): string {
-  const docPaths = getManagedDocPaths(activeTargets);
   switch (platform) {
     case 'claude':
       return `If the pre-commit hook is not set up, run \`/setup-caliber\` to configure everything automatically.`;
     case 'codex':
       return `If the pre-commit hook is not set up, read \`.agents/skills/setup-caliber/SKILL.md\` and follow the setup instructions.`;
-    case 'copilot':
+    case 'copilot': {
+      const docPaths = getManagedDocPaths(activeTargets);
       return `If the pre-commit hook is not set up, the developer should run \`/setup-caliber\` in Claude Code or Cursor for automated setup. Alternatively, run in terminal:
 \`\`\`bash
 npx @rely-ai/caliber hooks --install
 npx @rely-ai/caliber refresh
 git add ${docPaths} 2>/dev/null
 \`\`\``;
+    }
   }
 }
 

--- a/src/writers/pre-commit-block.ts
+++ b/src/writers/pre-commit-block.ts
@@ -2,12 +2,32 @@ import { displayCaliberName } from '../lib/resolve-caliber.js';
 import { DEFAULT_MODELS } from '../llm/config.js';
 
 export type ConfigPlatform = 'claude' | 'copilot' | 'codex';
+export type TargetAgent = 'claude' | 'cursor' | 'codex' | 'opencode' | 'github-copilot';
 
 const BLOCK_START = '<!-- caliber:managed:pre-commit -->';
 const BLOCK_END = '<!-- /caliber:managed:pre-commit -->';
 
-const MANAGED_DOC_PATHS =
-  'CLAUDE.md .claude/ .cursor/ .cursorrules .github/copilot-instructions.md .github/instructions/ AGENTS.md CALIBER_LEARNINGS.md .agents/ .opencode/';
+function getManagedDocPaths(activeTargets?: TargetAgent[]): string {
+  const paths = ['CLAUDE.md', '.claude/', 'CALIBER_LEARNINGS.md'];
+  if (!activeTargets) {
+    paths.push(
+      '.cursor/',
+      '.cursorrules',
+      '.github/copilot-instructions.md',
+      '.github/instructions/',
+      'AGENTS.md',
+      '.agents/',
+      '.opencode/',
+    );
+  } else {
+    if (activeTargets.includes('cursor')) paths.push('.cursor/', '.cursorrules');
+    if (activeTargets.includes('github-copilot'))
+      paths.push('.github/copilot-instructions.md', '.github/instructions/');
+    if (activeTargets.includes('codex')) paths.push('AGENTS.md', '.agents/');
+    if (activeTargets.includes('opencode')) paths.push('.opencode/');
+  }
+  return paths.join(' ');
+}
 
 function getCaliberNotFoundFallback(platform: ConfigPlatform, bin: string): string {
   switch (platform) {
@@ -24,8 +44,12 @@ npx @rely-ai/caliber refresh
   }
 }
 
-function getPreCommitBlock(platform: ConfigPlatform = 'claude'): string {
+function getPreCommitBlock(
+  platform: ConfigPlatform = 'claude',
+  activeTargets?: TargetAgent[],
+): string {
   const bin = displayCaliberName();
+  const docPaths = getManagedDocPaths(activeTargets);
   return `${BLOCK_START}
 ## Before Committing
 
@@ -39,7 +63,7 @@ grep -q "caliber" .git/hooks/pre-commit 2>/dev/null && echo "hook-active" || ech
 - If **hook-active**: the hook handles sync automatically — just commit normally. Tell the user: "Caliber will sync your agent configs automatically via the pre-commit hook."
 - If **no-hook**: run Caliber manually before committing:
   1. Tell the user: "Caliber: Syncing agent configs with your latest changes..."
-  2. Run: \`${bin} refresh && git add ${MANAGED_DOC_PATHS} 2>/dev/null\`
+  2. Run: \`${bin} refresh && git add ${docPaths} 2>/dev/null\`
   3. After it completes, briefly tell the user what Caliber updated. Then proceed with the commit.
 
 **Valid \`${bin} refresh\` options:** \`--quiet\` (suppress output) and \`--dry-run\` (preview without writing). Do not pass any other flags — options like \`--auto-approve\`, \`--debug\`, or \`--force\` do not exist and will cause errors.
@@ -52,8 +76,9 @@ ${BLOCK_END}`;
 
 const CURSOR_RULE_FILENAME = 'caliber-pre-commit.mdc';
 
-function getCursorRuleContent(): string {
+function getCursorRuleContent(activeTargets?: TargetAgent[]): string {
   const bin = displayCaliberName();
+  const docPaths = getManagedDocPaths(activeTargets);
   return `---
 description: Run Caliber sync before git commits to keep agent configs up to date
 alwaysApply: true
@@ -62,7 +87,7 @@ Before every git commit, check if the Caliber pre-commit hook is installed:
 Run: \`grep -q "caliber" .git/hooks/pre-commit 2>/dev/null && echo "hook-active" || echo "no-hook"\`
 
 If hook-active: just commit normally — Caliber syncs automatically via the hook. Tell the user: "Caliber will sync your agent configs automatically."
-If no-hook: run \`${bin} refresh && git add ${MANAGED_DOC_PATHS} 2>/dev/null\` before committing, and tell the user what was updated.
+If no-hook: run \`${bin} refresh && git add ${docPaths} 2>/dev/null\` before committing, and tell the user what was updated.
 
 Valid \`${bin} refresh\` options: \`--quiet\` and \`--dry-run\` only. Do not pass \`--auto-approve\`, \`--debug\`, \`--force\`, or any other flags.
 \`${bin} config\` takes no flags — it is interactive. Do not pass \`--provider\`, \`--api-key\`, or \`--endpoint\`.
@@ -105,14 +130,21 @@ export function hasPreCommitBlock(content: string): boolean {
   return false;
 }
 
-export function appendPreCommitBlock(content: string, platform: ConfigPlatform = 'claude'): string {
+export function appendPreCommitBlock(
+  content: string,
+  platform: ConfigPlatform = 'claude',
+  activeTargets?: TargetAgent[],
+): string {
   if (hasPreCommitBlock(content)) return content;
   const trimmed = content.trimEnd();
-  return trimmed + '\n\n' + getPreCommitBlock(platform) + '\n';
+  return trimmed + '\n\n' + getPreCommitBlock(platform, activeTargets) + '\n';
 }
 
-export function getCursorPreCommitRule(): { filename: string; content: string } {
-  return { filename: CURSOR_RULE_FILENAME, content: getCursorRuleContent() };
+export function getCursorPreCommitRule(activeTargets?: TargetAgent[]): {
+  filename: string;
+  content: string;
+} {
+  return { filename: CURSOR_RULE_FILENAME, content: getCursorRuleContent(activeTargets) };
 }
 
 // ── Learnings reference block ────────────────────────────────────────
@@ -196,7 +228,8 @@ export function appendModelBlock(content: string): string {
 const SYNC_BLOCK_START = '<!-- caliber:managed:sync -->';
 const SYNC_BLOCK_END = '<!-- /caliber:managed:sync -->';
 
-function getSyncSetupInstruction(platform: ConfigPlatform): string {
+function getSyncSetupInstruction(platform: ConfigPlatform, activeTargets?: TargetAgent[]): string {
+  const docPaths = getManagedDocPaths(activeTargets);
   switch (platform) {
     case 'claude':
       return `If the pre-commit hook is not set up, run \`/setup-caliber\` to configure everything automatically.`;
@@ -207,19 +240,19 @@ function getSyncSetupInstruction(platform: ConfigPlatform): string {
 \`\`\`bash
 npx @rely-ai/caliber hooks --install
 npx @rely-ai/caliber refresh
-git add ${MANAGED_DOC_PATHS} 2>/dev/null
+git add ${docPaths} 2>/dev/null
 \`\`\``;
   }
 }
 
-function getSyncBlock(platform: ConfigPlatform = 'claude'): string {
+function getSyncBlock(platform: ConfigPlatform = 'claude', activeTargets?: TargetAgent[]): string {
   const bin = displayCaliberName();
   return `${SYNC_BLOCK_START}
 ## Context Sync
 
 This project uses [Caliber](https://github.com/caliber-ai-org/ai-setup) to keep AI agent configs in sync across Claude Code, Cursor, Copilot, and Codex.
 Configs update automatically before each commit via \`${bin} refresh\`.
-${getSyncSetupInstruction(platform)}
+${getSyncSetupInstruction(platform, activeTargets)}
 ${SYNC_BLOCK_END}`;
 }
 
@@ -233,16 +266,25 @@ export function hasSyncBlock(content: string): boolean {
   return false;
 }
 
-export function appendSyncBlock(content: string, platform: ConfigPlatform = 'claude'): string {
+export function appendSyncBlock(
+  content: string,
+  platform: ConfigPlatform = 'claude',
+  activeTargets?: TargetAgent[],
+): string {
   if (hasSyncBlock(content)) return content;
   const trimmed = content.trimEnd();
-  return trimmed + '\n\n' + getSyncBlock(platform) + '\n';
+  return trimmed + '\n\n' + getSyncBlock(platform, activeTargets) + '\n';
 }
 
-export function appendManagedBlocks(content: string, platform: ConfigPlatform = 'claude'): string {
+export function appendManagedBlocks(
+  content: string,
+  platform: ConfigPlatform = 'claude',
+  activeTargets?: TargetAgent[],
+): string {
   return appendSyncBlock(
-    appendModelBlock(appendLearningsBlock(appendPreCommitBlock(content, platform))),
+    appendModelBlock(appendLearningsBlock(appendPreCommitBlock(content, platform, activeTargets))),
     platform,
+    activeTargets,
   );
 }
 

--- a/src/writers/refresh.ts
+++ b/src/writers/refresh.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { appendManagedBlocks } from './pre-commit-block.js';
+import { appendManagedBlocks, type TargetAgent } from './pre-commit-block.js';
 
 interface RefreshDocs {
   agentsMd?: string | null;
@@ -11,6 +11,14 @@ interface RefreshDocs {
   cursorRules?: Array<{ filename: string; content: string }> | null;
   copilotInstructions?: string | null;
   copilotInstructionFiles?: Array<{ filename: string; content: string }> | null;
+}
+
+function inferActiveTargets(docs: RefreshDocs): TargetAgent[] {
+  const targets: TargetAgent[] = ['claude'];
+  if (docs.cursorrules || docs.cursorRules) targets.push('cursor');
+  if (docs.copilotInstructions || docs.copilotInstructionFiles) targets.push('github-copilot');
+  if (docs.agentsMd) targets.push('codex');
+  return targets;
 }
 
 function writeFileGroup(
@@ -27,6 +35,7 @@ function writeFileGroup(
 
 export function writeRefreshDocs(docs: RefreshDocs, dir: string = '.'): string[] {
   const written: string[] = [];
+  const targets = inferActiveTargets(docs);
   const p = (relPath: string): string =>
     (dir === '.' ? relPath : path.join(dir, relPath)).replace(/\\/g, '/');
   const ensureParent = (filePath: string): void => {
@@ -37,14 +46,14 @@ export function writeRefreshDocs(docs: RefreshDocs, dir: string = '.'): string[]
   if (docs.agentsMd) {
     const filePath = p('AGENTS.md');
     ensureParent(filePath);
-    fs.writeFileSync(filePath, appendManagedBlocks(docs.agentsMd, 'codex'));
+    fs.writeFileSync(filePath, appendManagedBlocks(docs.agentsMd, 'codex', targets));
     written.push(filePath);
   }
 
   if (docs.claudeMd) {
     const filePath = p('CLAUDE.md');
     ensureParent(filePath);
-    fs.writeFileSync(filePath, appendManagedBlocks(docs.claudeMd));
+    fs.writeFileSync(filePath, appendManagedBlocks(docs.claudeMd, 'claude', targets));
     written.push(filePath);
   }
 
@@ -73,7 +82,7 @@ export function writeRefreshDocs(docs: RefreshDocs, dir: string = '.'): string[]
   if (docs.copilotInstructions) {
     const filePath = p(path.join('.github', 'copilot-instructions.md'));
     ensureParent(filePath);
-    fs.writeFileSync(filePath, appendManagedBlocks(docs.copilotInstructions, 'copilot'));
+    fs.writeFileSync(filePath, appendManagedBlocks(docs.copilotInstructions, 'copilot', targets));
     written.push(filePath);
   }
 

--- a/src/writers/refresh.ts
+++ b/src/writers/refresh.ts
@@ -14,7 +14,8 @@ interface RefreshDocs {
 }
 
 function inferActiveTargets(docs: RefreshDocs): TargetAgent[] {
-  const targets: TargetAgent[] = ['claude'];
+  const targets: TargetAgent[] = [];
+  if (docs.claudeMd) targets.push('claude');
   if (docs.cursorrules || docs.cursorRules) targets.push('cursor');
   if (docs.copilotInstructions || docs.copilotInstructionFiles) targets.push('github-copilot');
   if (docs.agentsMd) targets.push('codex');


### PR DESCRIPTION
## Summary

- **#209**: `parseJsonResponse` now rejects `null`/primitive JSON results that caused `Cannot read properties of null (reading 'docsUpdated')` crash when Claude CLI returned literal `"null"`
- **#204**: Pre-commit block `git add` paths are now dynamic based on active targets instead of hardcoding all platform paths (`.cursor/`, `.github/`, `.agents/`, `.opencode/`) regardless of selection
- **#206**: Cursor login detection (`isCursorLoggedIn`) passes environment variables to subprocess via `withCaliberSubprocessEnv`, matching the working Claude CLI pattern. Also adds case-insensitive output matching.
- **#210**: Commented on issue explaining Caliber never runs destructive git commands (not a code bug)

## Test plan

- [x] All 1060 tests pass (84 test files)
- [x] Build succeeds
- [x] New tests for `parseJsonResponse` null and primitive string inputs
- [x] All parameters are optional with safe defaults (backward compatible)

Closes #209, closes #204, closes #206