### PR TITLE
fix(opencode): use auth list for login detection, add interactive warning

### DIFF
--- a/src/commands/interactive-provider-setup.ts
+++ b/src/commands/interactive-provider-setup.ts
@@ -10,7 +10,7 @@ import {
   ensureBashShim,
 } from '../llm/cursor-acp.js';
 import { isClaudeCliAvailable, isClaudeCliLoggedIn } from '../llm/claude-cli.js';
-import { isOpenCodeAvailable } from '../llm/opencode.js';
+import { isOpenCodeAvailable, isOpenCodeLoggedIn } from '../llm/opencode.js';
 import { promptInput } from '../utils/prompt.js';
 
 const IS_WINDOWS = process.platform === 'win32';
@@ -79,6 +79,15 @@ export async function runInteractiveProviderSetup(options?: {
         console.log(chalk.dim('  Install it from: ') + chalk.hex('#83D1EB')('https://opencode.ai'));
         console.log(
           chalk.dim('  Then run ') +
+            chalk.hex('#83D1EB')('opencode auth login') +
+            chalk.dim(' to authenticate.\n'),
+        );
+        const proceed = await confirm({ message: 'Continue anyway?' });
+        if (!proceed) throw new Error('__exit__');
+      } else if (!isOpenCodeLoggedIn()) {
+        console.log(chalk.yellow('\n  OpenCode CLI found but not logged in.'));
+        console.log(
+          chalk.dim('  Run ') +
             chalk.hex('#83D1EB')('opencode auth login') +
             chalk.dim(' to authenticate.\n'),
         );

--- a/src/llm/__tests__/opencode.test.ts
+++ b/src/llm/__tests__/opencode.test.ts
@@ -635,35 +635,34 @@ describe('isOpenCodeLoggedIn', () => {
     resetOpenCodeLoginCache();
   });
 
-  it('returns true when auth status reports loggedIn true', () => {
-    execSync.mockReturnValue(Buffer.from(JSON.stringify({ loggedIn: true })));
+  it('returns true when auth list returns non-empty output', () => {
+    execSync.mockReturnValue(Buffer.from('user@example.com\n'));
     expect(isOpenCodeLoggedIn()).toBe(true);
+    expect(execSync).toHaveBeenCalledWith('opencode auth list', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
   });
 
-  it('returns false when auth status reports loggedIn false', () => {
-    execSync.mockReturnValue(Buffer.from(JSON.stringify({ loggedIn: false })));
+  it('returns false when auth list returns empty output', () => {
+    execSync.mockReturnValue(Buffer.from(''));
     expect(isOpenCodeLoggedIn()).toBe(false);
   });
 
-  it('returns false when auth status command fails', () => {
+  it('returns false when auth list command fails', () => {
     execSync.mockImplementation(() => {
       throw new Error('exit code 1');
     });
     expect(isOpenCodeLoggedIn()).toBe(false);
   });
 
-  it('returns true for non-JSON output without not logged in', () => {
-    execSync.mockReturnValue(Buffer.from('some unexpected output'));
+  it('returns true for multi-line output indicating credentials', () => {
+    execSync.mockReturnValue(Buffer.from('• iFlow api\n  \n  1 credentials\n'));
     expect(isOpenCodeLoggedIn()).toBe(true);
   });
 
-  it('returns false for non-JSON output containing not logged in', () => {
-    execSync.mockReturnValue(Buffer.from('not logged in'));
-    expect(isOpenCodeLoggedIn()).toBe(false);
-  });
-
   it('caches the result across calls', () => {
-    execSync.mockReturnValue(Buffer.from(JSON.stringify({ loggedIn: true })));
+    execSync.mockReturnValue(Buffer.from('user@example.com\n'));
     expect(isOpenCodeLoggedIn()).toBe(true);
     execSync.mockReset(); // clear mock but cache should still have value
     expect(isOpenCodeLoggedIn()).toBe(true);

--- a/src/llm/opencode.ts
+++ b/src/llm/opencode.ts
@@ -37,22 +37,18 @@ export function isOpenCodeAvailable(): boolean {
   }
 }
 
-/** Whether the user is logged in to OpenCode CLI. Uses `opencode auth status` for a zero-cost check. Result is cached for the process lifetime. */
+/** Whether the user is logged in to OpenCode CLI. Uses `opencode auth list` for a zero-cost check. Result is cached for the process lifetime. */
 export function isOpenCodeLoggedIn(): boolean {
   if (cachedLoggedIn !== null) return cachedLoggedIn;
   try {
-    const result = execSync('opencode auth status', {
-      stdio: ['ignore', 'pipe', 'pipe'],
-      timeout: 5000,
+    const result = execSync('opencode auth list', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
     });
-    const output = result.toString().trim();
-    try {
-      const status = JSON.parse(output) as { loggedIn?: boolean };
-      cachedLoggedIn = status.loggedIn === true;
-    } catch {
-      cachedLoggedIn = !output.toLowerCase().includes('not logged in');
-    }
+    // If command succeeds and returns non-empty output, user is logged in
+    cachedLoggedIn = result.toString().trim().length > 0;
   } catch {
+    // Command failed or not found - treat as not logged in
     cachedLoggedIn = false;
   }
   return cachedLoggedIn;


### PR DESCRIPTION
## Problem

The OpenCode provider uses `opencode auth status` to detect login state, which doesn't exist in OpenCode CLI v1.15.3 and similar versions. This causes authentication checks to fail and blocks users from completing `caliber init`.

Additionally, the OpenCode provider was missing the runtime login check in `createProvider()` that other seat-based providers (Cursor, Claude CLI) have. This was noted in PR #154 review feedback.

## Solution

1. **Replace `auth status` with `auth list`**: The `auth list` command is widely available across OpenCode CLI versions and returns credential info when logged in.

2. **Add interactive login warning**: During `caliber init` when OpenCode is selected, users now see a warning if not logged in, matching the cursor/claude-cli pattern.

3. **Simplify detection logic**: Check for non-empty output instead of parsing JSON. More robust.

## Changes

- `src/llm/opencode.ts`: Changed `isOpenCodeLoggedIn()` to use `auth list`, simplified logic
- `src/commands/interactive-provider-setup.ts`: Added login warning for OpenCode during setup
- `src/llm/__tests__/opencode.test.ts`: Updated test mocks for new auth command

## Testing

- All 23 OpenCode unit tests pass
- Full test suite: 1075 passed (8 pre-existing failures unrelated to this change)
- Verified with OpenCode CLI v1.15.4 - `auth list` works correctly

## Checklist

- [x] Code follows existing patterns (cursor/claude-cli)
- [x] Tests updated and passing
- [x] No breaking changes
- [x] Error messages are clear and actionable
- Addresses PR #154 review feedback

---
*Note: The runtime login check in `createProvider()` was already present in upstream v1.49.6, so only the auth list change was needed there.*