### PR TITLE
fix(hooks): anchor Stop hook on $CLAUDE_PROJECT_DIR, not $PWD

### DIFF
--- a/.claude/hooks/caliber-check-sync.sh
+++ b/.claude/hooks/caliber-check-sync.sh
@@ -3,17 +3,51 @@
 if [ "$CALIBER_SUBPROCESS" = "1" ] || [ -n "$CALIBER_SPAWNED" ]; then
   exit 0
 fi
-# Caliber only applies to git repos. Skip the nudge when there's no git context
-# (e.g. .claude/ shipped into a non-git directory, scratch dirs, model archives).
-if ! git rev-parse --git-dir >/dev/null 2>&1; then
+
+# Resolve the project root — the directory that OWNS this .claude/.
+#
+# Pre-fix (2026-05-19) this script used `git rev-parse --git-dir` against
+# $PWD. But the hook command in settings.json is
+# "$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-check-sync.sh", and Claude
+# Code inherits the SESSION cwd as $PWD — which can be a subdirectory
+# of the project that happens to be its own git repo (e.g. a Mythic-RDT/
+# checkout nested inside a non-git backup_models/ scratch dir). In that
+# layout `git rev-parse` from $PWD succeeded against the nested .git,
+# the nudge fired, and the assistant tried to install Caliber in a
+# directory where Caliber has nothing to manage.
+#
+# $CLAUDE_PROJECT_DIR is exported by Claude Code and always points at
+# the directory containing the .claude/ that registered this hook —
+# that's the only place the Caliber check makes sense. Script-relative
+# fallback handles the (rare) shell-test case where the script is
+# invoked outside Claude Code (e.g. the Caliber vitest suite).
+if [ -n "$CLAUDE_PROJECT_DIR" ]; then
+  PROJECT_DIR="$CLAUDE_PROJECT_DIR"
+else
+  script_dir=$(cd "$(dirname "$0")" 2>/dev/null && pwd) || script_dir=""
+  if [ -n "$script_dir" ]; then
+    PROJECT_DIR=$(cd "$script_dir/../.." 2>/dev/null && pwd) || PROJECT_DIR="$PWD"
+  else
+    PROJECT_DIR="$PWD"
+  fi
+fi
+
+# Caliber only applies to git repos. Skip the nudge when the project
+# root has no git context (e.g. .claude/ shipped into a non-git
+# scratch dir, model archive, or a parent dir whose only git presence
+# is in nested children). `git -C <dir>` confines the lookup to walk
+# UP from PROJECT_DIR; it never descends into children.
+if ! git -C "$PROJECT_DIR" rev-parse --git-dir >/dev/null 2>&1; then
   exit 0
 fi
-if grep -q "caliber" .git/hooks/pre-commit 2>/dev/null; then
+if grep -q "caliber" "$PROJECT_DIR/.git/hooks/pre-commit" 2>/dev/null; then
   exit 0
 fi
 
-# Use session_id from stdin if available, fall back to repo-based flag
-FLAG="/tmp/caliber-nudge-$(echo "$PWD" | shasum | cut -c1-8)"
+# Flag is keyed by PROJECT_DIR (not $PWD) so the once-per-project
+# guard still works when the assistant moves between subdirectories
+# during the session.
+FLAG="/tmp/caliber-nudge-$(echo "$PROJECT_DIR" | (shasum 2>/dev/null || sha1sum 2>/dev/null || md5sum 2>/dev/null || cksum) | cut -c1-8)"
 
 # Clean stale flags (older than 2 hours)
 find /tmp -maxdepth 1 -name "caliber-nudge-*" -mmin +120 -delete 2>/dev/null

--- a/src/lib/__tests__/caliber-hooks-shell.test.ts
+++ b/src/lib/__tests__/caliber-hooks-shell.test.ts
@@ -46,13 +46,18 @@ describe('caliber-check-sync.sh', () => {
     }
   });
 
-  it('exits 0 silently when the directory is not a git repo', () => {
+  it('exits 0 silently when the project directory is not a git repo', () => {
     // Common case: a `.claude/` directory was generated in a non-git directory
     // (scratch dir, model archive, etc.). Caliber refresh won't run there
     // anyway, so the nudge is just noise — must not fire.
+    // Set $CLAUDE_PROJECT_DIR explicitly: that's how Claude Code passes the
+    // project root into hooks, and the script now anchors its git check on
+    // it (post-2026-05-19 fix for the nested-git-in-non-git-project bug).
     const nonGitDir = fs.mkdtempSync(path.join(os.tmpdir(), 'caliber-nogit-'));
     try {
-      const { status, stdout } = runScript(nonGitDir);
+      const { status, stdout } = runScript(nonGitDir, {
+        CLAUDE_PROJECT_DIR: nonGitDir,
+      });
       expect(status).toBe(0);
       expect(stdout).not.toContain('"decision":"block"');
     } finally {
@@ -99,5 +104,55 @@ describe('caliber-check-sync.sh', () => {
     const { status, stdout } = runScript(tmpDir);
     expect(status).toBe(0);
     expect(stdout).not.toContain('"decision":"block"');
+  });
+
+  it('exits 0 when $PWD is a nested git repo but $CLAUDE_PROJECT_DIR is non-git', () => {
+    // Real-world scenario observed 2026-05-19: a backup_models/ scratch
+    // directory contains its own .claude/ but is itself NOT a git repo;
+    // however a Mythic-RDT/ subdirectory inside it IS a git repo. When
+    // Claude Code starts in the subdir, $PWD points at the nested git
+    // while $CLAUDE_PROJECT_DIR still points at the non-git owner of
+    // the .claude/. Pre-fix, `git rev-parse --git-dir` from $PWD
+    // wrongly succeeded against the nested .git and fired the nudge
+    // for a project Caliber has no business managing.
+    //
+    // The post-fix script anchors the git check on $CLAUDE_PROJECT_DIR
+    // (with a script-relative fallback for shell-test invocations).
+    const owner = fs.mkdtempSync(path.join(os.tmpdir(), 'caliber-owner-'));
+    const nested = path.join(owner, 'nested');
+    fs.mkdirSync(nested);
+    spawnSync('git', ['init', '-q'], { cwd: nested });
+    try {
+      const result = spawnSync('sh', [SCRIPT], {
+        cwd: nested, // $PWD = nested git repo
+        env: { ...process.env, CLAUDE_PROJECT_DIR: owner }, // non-git project root
+        encoding: 'utf-8',
+      });
+      const stdout = (result.stdout ?? '') + (result.stderr ?? '');
+      expect(result.status).toBe(0);
+      expect(stdout).not.toContain('"decision":"block"');
+    } finally {
+      fs.rmSync(owner, { recursive: true, force: true });
+    }
+  });
+
+  it('honors $CLAUDE_PROJECT_DIR when set, even when $PWD is unrelated', () => {
+    // Positive case: $CLAUDE_PROJECT_DIR points at a real git project
+    // whose pre-commit lacks caliber → nudge should fire. Confirms
+    // the new anchor reads the right directory's pre-commit, not
+    // whatever pre-commit happens to live under $PWD.
+    const otherPwd = fs.mkdtempSync(path.join(os.tmpdir(), 'caliber-other-pwd-'));
+    try {
+      const result = spawnSync('sh', [SCRIPT], {
+        cwd: otherPwd,
+        env: { ...process.env, CLAUDE_PROJECT_DIR: tmpDir },
+        encoding: 'utf-8',
+      });
+      const stdout = (result.stdout ?? '') + (result.stderr ?? '');
+      expect(result.status).toBe(0);
+      expect(stdout).toContain('"decision":"block"');
+    } finally {
+      fs.rmSync(otherPwd, { recursive: true, force: true });
+    }
   });
 });

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -193,15 +193,48 @@ const STOP_HOOK_SCRIPT_CONTENT = `#!/bin/sh
 if [ "$CALIBER_SUBPROCESS" = "1" ] || [ -n "$CALIBER_SPAWNED" ]; then
   exit 0
 fi
-# Caliber only applies to git repos. Skip the nudge when there's no git context
-# (e.g. .claude/ shipped into a non-git directory, scratch dirs, model archives).
-if ! git rev-parse --git-dir >/dev/null 2>&1; then
+
+# Resolve the project root — the directory that OWNS this .claude/.
+# Pre-fix this script used \`git rev-parse --git-dir\` against $PWD. But
+# the hook command in settings.json is "$CLAUDE_PROJECT_DIR/.claude/
+# hooks/caliber-check-sync.sh", and Claude Code inherits the SESSION
+# cwd as $PWD — which can be a subdirectory of the project that
+# happens to be its own git repo (e.g. a nested checkout inside a
+# non-git scratch dir). In that layout \`git rev-parse\` from $PWD
+# succeeded against the nested .git, the nudge fired, and the
+# assistant tried to install Caliber in a directory where Caliber
+# has nothing to manage.
+# $CLAUDE_PROJECT_DIR is exported by Claude Code and always points
+# at the directory containing the .claude/ that registered this
+# hook. Script-relative fallback handles the (rare) shell-test
+# invocation case where $CLAUDE_PROJECT_DIR isn't set.
+if [ -n "$CLAUDE_PROJECT_DIR" ]; then
+  PROJECT_DIR="$CLAUDE_PROJECT_DIR"
+else
+  script_dir=$(cd "$(dirname "$0")" 2>/dev/null && pwd) || script_dir=""
+  if [ -n "$script_dir" ]; then
+    PROJECT_DIR=$(cd "$script_dir/../.." 2>/dev/null && pwd) || PROJECT_DIR="$PWD"
+  else
+    PROJECT_DIR="$PWD"
+  fi
+fi
+
+# Caliber only applies to git repos. Skip the nudge when the project
+# root has no git context (e.g. .claude/ shipped into a non-git
+# scratch dir, model archive, or a parent dir whose only git presence
+# is in nested children). \`git -C <dir>\` confines the lookup to walk
+# UP from PROJECT_DIR; it never descends into children.
+if ! git -C "$PROJECT_DIR" rev-parse --git-dir >/dev/null 2>&1; then
   exit 0
 fi
-if grep -q "caliber" .git/hooks/pre-commit 2>/dev/null; then
+if grep -q "caliber" "$PROJECT_DIR/.git/hooks/pre-commit" 2>/dev/null; then
   exit 0
 fi
-FLAG="/tmp/caliber-nudge-$(echo "$PWD" | (shasum 2>/dev/null || sha1sum 2>/dev/null || md5sum 2>/dev/null || cksum) | cut -c1-8)"
+
+# Flag is keyed by PROJECT_DIR (not $PWD) so the once-per-project
+# guard still works when the assistant moves between subdirectories
+# during the session.
+FLAG="/tmp/caliber-nudge-$(echo "$PROJECT_DIR" | (shasum 2>/dev/null || sha1sum 2>/dev/null || md5sum 2>/dev/null || cksum) | cut -c1-8)"
 find /tmp -maxdepth 1 -name "caliber-nudge-*" -mmin +120 -delete 2>/dev/null
 if [ -f "$FLAG" ]; then
   exit 0


### PR DESCRIPTION
## Summary

Builds on #201 (April fix that added the `git rev-parse --git-dir` early exit for non-git directories). That guard is correct for the simple case but breaks when the project root is non-git **and contains a nested git repo** (a sub-checkout, a submodule, a third-party clone inside a scratch dir, etc.).

The Stop hook is registered in `settings.json` as:
```
$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-check-sync.sh
```

Claude Code inherits the **session cwd** as `$PWD` when it spawns the hook — and that cwd is wherever the user typed `claude`, which may be a **subdirectory** of the project that happens to be its own git repo. In that layout `git rev-parse --git-dir` from `$PWD` walked into the nested `.git` and succeeded; the nudge fired; and the assistant proceeded to suggest installing Caliber in a directory where Caliber has nothing to manage.

## Real-world repro (2026-05-19)

```
/path/to/backup_models/             (NON-git, owns .claude/)
/path/to/backup_models/Mythic-RDT/  (git submodule clone)
/path/to/backup_models/<other>/     (other ad-hoc clones)
```

A Claude session started in any of the nested git checkouts fired the nudge for `backup_models/` — which has zero Caliber relevance. The session also wrote one flag per subdirectory (the flag key was `shasum($PWD)`), so the once-per-project guard failed too — the nudge re-fired each time the assistant moved to a different subdir.

## Fix

Resolve the project root from `$CLAUDE_PROJECT_DIR` (always set by Claude Code), with a script-relative fallback for the rare case the script runs outside Claude Code (e.g. the vitest suite). Use `git -C "$PROJECT_DIR"` so the git lookup confines itself to walking UP from the project root, never descending into children. The flag file is also re-keyed on `PROJECT_DIR` so the once-per-project guard holds across subdirectory navigation within the same session.

Mirror the fix into the deployed `.claude/hooks/caliber-check-sync.sh` copy so the fork's own session honors it.

## Tests

- **Updated**: "exits 0 silently when the project directory is not a git repo" now passes `$CLAUDE_PROJECT_DIR` explicitly (matches how Claude Code actually invokes the hook). Pre-fix the test was implicitly relying on `$PWD`-based behavior, which is no longer how the script operates.
- **New**: "exits 0 when `$PWD` is a nested git repo but `$CLAUDE_PROJECT_DIR` is non-git" — the bug repro from this report, now green.
- **New**: "honors `$CLAUDE_PROJECT_DIR` when set, even when `$PWD` is unrelated" — proves the new anchor reads the right directory's `pre-commit`, not whatever `pre-commit` happens to live under `$PWD`.

Full suite: **1061/1061 passing**.

## Compatibility

- `$CLAUDE_PROJECT_DIR` has been exported by Claude Code since the introduction of hooks (and is already used by the hook command in `settings.json` template); no new dependency.
- `git -C <dir>` has been in git since 1.8.5 (2013); safe.
- The script-relative fallback uses only POSIX shell builtins (`dirname`, `cd`, `pwd`); no bashisms.
- Behavior in the pre-existing happy paths (git project, CALIBER_SUBPROCESS=1, second-run flag, caliber-in-pre-commit) is unchanged.

## Related

Builds on #201 (April 2026).

🤖 Generated with [Claude Code](https://claude.com/claude-code)