### PR TITLE
fix: respect .gitignore and .caliberignore in large-file scanner

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -66,6 +66,7 @@ import {
 } from './init-helpers.js';
 import { recordScore } from '../scoring/history.js';
 import { scanLargeFiles } from '../fingerprint/large-file-scan.js';
+import { filterIgnoredWarnings } from '../fingerprint/large-file-filter.js';
 import { printLargeFileWarnings } from '../fingerprint/large-file-warn.js';
 
 const IS_WINDOWS = process.platform === 'win32';
@@ -505,7 +506,7 @@ export async function initCommand(options: InitOptions) {
     display.update(TASK_STACK, 'running');
     fingerprint = await collectFingerprint(process.cwd());
 
-    printLargeFileWarnings(scanLargeFiles(process.cwd()));
+    printLargeFileWarnings(filterIgnoredWarnings(scanLargeFiles(process.cwd()), process.cwd()));
 
     const stackParts = [...fingerprint.languages, ...fingerprint.frameworks];
     const stackSummary = stackParts.join(', ') || 'no languages';

--- a/src/commands/refresh.ts
+++ b/src/commands/refresh.ts
@@ -26,6 +26,7 @@ import { recordScore } from '../scoring/history.js';
 import { CALIBER_DIR, REFRESH_LAST_ERROR_FILE } from '../constants.js';
 import { discoverConfigDirs } from '../lib/config-discovery.js';
 import { scanLargeFiles } from '../fingerprint/large-file-scan.js';
+import { filterIgnoredWarnings } from '../fingerprint/large-file-filter.js';
 import { printLargeFileWarnings } from '../fingerprint/large-file-warn.js';
 
 function writeRefreshError(error: unknown): void {
@@ -162,7 +163,9 @@ async function refreshDir(
   const learnedSection = readLearnedSection();
   const fingerprint = await collectFingerprint(absDir);
 
-  printLargeFileWarnings(scanLargeFiles(absDir), { spinner: spinner ?? undefined });
+  printLargeFileWarnings(filterIgnoredWarnings(scanLargeFiles(absDir), absDir), {
+    spinner: spinner ?? undefined,
+  });
 
   const existingDocs = fingerprint.existingConfigs;
   const projectContext = {

--- a/src/fingerprint/__tests__/large-file-filter.test.ts
+++ b/src/fingerprint/__tests__/large-file-filter.test.ts
@@ -1,0 +1,233 @@
+import path from 'path';
+import { describe, it, expect, vi } from 'vitest';
+import { filterIgnoredWarnings } from '../large-file-filter.js';
+import type { LargeFileWarning } from '../large-file-scan.js';
+
+const MiB = 1_048_576;
+
+function makeWarning(dir: string, relPath: string, sizeMB = 5): LargeFileWarning {
+  return {
+    filePath: path.join(dir, relPath),
+    sizeBytes: sizeMB * MiB,
+    sizeMB: sizeMB.toFixed(2),
+  };
+}
+
+describe('filterIgnoredWarnings', () => {
+  const DIR = '/project';
+
+  // ── Empty input ──────────────────────────────────────────────────────────
+
+  it('returns empty array without calling git when warnings are empty', () => {
+    const execFileSync = vi.fn();
+    const readFileSync = vi.fn();
+
+    const result = filterIgnoredWarnings([], DIR, { execFileSync, readFileSync });
+
+    expect(result).toHaveLength(0);
+    expect(execFileSync).not.toHaveBeenCalled();
+    expect(readFileSync).not.toHaveBeenCalled();
+  });
+
+  // ── Git filter ───────────────────────────────────────────────────────────
+
+  it('filters out gitignored files', () => {
+    const warnings = [
+      makeWarning(DIR, 'infra/.terraform/provider.bin'),
+      makeWarning(DIR, 'src/data.csv'),
+    ];
+
+    const execFileSync = vi.fn().mockReturnValue('infra/.terraform/provider.bin\n');
+    const readFileSync = vi.fn().mockImplementation(() => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+
+    const result = filterIgnoredWarnings(warnings, DIR, { execFileSync, readFileSync });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].filePath).toBe(path.join(DIR, 'src/data.csv'));
+  });
+
+  it('keeps all warnings when git check-ignore finds none ignored (exit code 1)', () => {
+    const warnings = [makeWarning(DIR, 'data/dump.sqlite'), makeWarning(DIR, 'assets/video.mp4')];
+
+    const execFileSync = vi.fn().mockImplementation(() => {
+      throw Object.assign(new Error('exit code 1'), { status: 1 });
+    });
+    const readFileSync = vi.fn().mockImplementation(() => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+
+    const result = filterIgnoredWarnings(warnings, DIR, { execFileSync, readFileSync });
+
+    expect(result).toHaveLength(2);
+  });
+
+  it('keeps all warnings when not in a git repo', () => {
+    const warnings = [makeWarning(DIR, 'big-file.bin')];
+
+    const execFileSync = vi.fn().mockImplementation(() => {
+      throw new Error('fatal: not a git repository');
+    });
+    const readFileSync = vi.fn().mockImplementation(() => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+
+    const result = filterIgnoredWarnings(warnings, DIR, { execFileSync, readFileSync });
+
+    expect(result).toHaveLength(1);
+  });
+
+  it('filters multiple gitignored files from a mixed set', () => {
+    const warnings = [
+      makeWarning(DIR, '.terraform/provider-aws'),
+      makeWarning(DIR, 'src/app.ts'),
+      makeWarning(DIR, 'build/output.wasm'),
+      makeWarning(DIR, 'data/seed.sql'),
+    ];
+
+    const execFileSync = vi.fn().mockReturnValue('.terraform/provider-aws\nbuild/output.wasm\n');
+    const readFileSync = vi.fn().mockImplementation(() => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+
+    const result = filterIgnoredWarnings(warnings, DIR, { execFileSync, readFileSync });
+    const paths = result.map((w) => path.basename(w.filePath));
+
+    expect(paths).toEqual(['app.ts', 'seed.sql']);
+  });
+
+  // ── Caliberignore filter ─────────────────────────────────────────────────
+
+  it('filters files matching .caliberignore patterns', () => {
+    const warnings = [makeWarning(DIR, 'data/dump.sqlite'), makeWarning(DIR, 'src/index.ts')];
+
+    const execFileSync = vi.fn().mockImplementation(() => {
+      throw Object.assign(new Error('exit code 1'), { status: 1 });
+    });
+    const readFileSync = vi.fn().mockReturnValue('*.sqlite\n');
+
+    const result = filterIgnoredWarnings(warnings, DIR, { execFileSync, readFileSync });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].filePath).toBe(path.join(DIR, 'src/index.ts'));
+  });
+
+  it('supports glob patterns in .caliberignore', () => {
+    const warnings = [
+      makeWarning(DIR, 'infra/admin/.terraform/provider-aws'),
+      makeWarning(DIR, 'infra/cloud/.terraform/provider-aws'),
+      makeWarning(DIR, 'src/data.csv'),
+    ];
+
+    const execFileSync = vi.fn().mockImplementation(() => {
+      throw Object.assign(new Error('exit code 1'), { status: 1 });
+    });
+    const readFileSync = vi.fn().mockReturnValue('infra/**/.terraform/**\n');
+
+    const result = filterIgnoredWarnings(warnings, DIR, { execFileSync, readFileSync });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].filePath).toBe(path.join(DIR, 'src/data.csv'));
+  });
+
+  it('skips comments and empty lines in .caliberignore', () => {
+    const warnings = [makeWarning(DIR, 'data/dump.sqlite'), makeWarning(DIR, 'assets/video.mp4')];
+
+    const execFileSync = vi.fn().mockImplementation(() => {
+      throw Object.assign(new Error('exit code 1'), { status: 1 });
+    });
+    const readFileSync = vi
+      .fn()
+      .mockReturnValue('# Large data files\n\n*.sqlite\n\n# Videos\n*.mp4\n');
+
+    const result = filterIgnoredWarnings(warnings, DIR, { execFileSync, readFileSync });
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('keeps all warnings when .caliberignore does not exist', () => {
+    const warnings = [makeWarning(DIR, 'data/big.bin')];
+
+    const execFileSync = vi.fn().mockImplementation(() => {
+      throw Object.assign(new Error('exit code 1'), { status: 1 });
+    });
+    const readFileSync = vi.fn().mockImplementation(() => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+
+    const result = filterIgnoredWarnings(warnings, DIR, { execFileSync, readFileSync });
+
+    expect(result).toHaveLength(1);
+  });
+
+  // ── Combined filters ────────────────────────────────────────────────────
+
+  it('filters via both gitignore and caliberignore', () => {
+    const warnings = [
+      makeWarning(DIR, '.terraform/provider'),
+      makeWarning(DIR, 'data/dump.sqlite'),
+      makeWarning(DIR, 'src/app.ts'),
+    ];
+
+    const execFileSync = vi.fn().mockReturnValue('.terraform/provider\n');
+    const readFileSync = vi.fn().mockReturnValue('*.sqlite\n');
+
+    const result = filterIgnoredWarnings(warnings, DIR, { execFileSync, readFileSync });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].filePath).toBe(path.join(DIR, 'src/app.ts'));
+  });
+
+  it('handles file ignored by both filters without double-counting', () => {
+    const warnings = [makeWarning(DIR, 'build/output.wasm')];
+
+    const execFileSync = vi.fn().mockReturnValue('build/output.wasm\n');
+    const readFileSync = vi.fn().mockReturnValue('build/**\n');
+
+    const result = filterIgnoredWarnings(warnings, DIR, { execFileSync, readFileSync });
+
+    expect(result).toHaveLength(0);
+  });
+
+  // ── Path handling ───────────────────────────────────────────────────────
+
+  it('correctly converts absolute paths to relative for filtering', () => {
+    const dir = '/home/user/project';
+    const warnings = [makeWarning(dir, 'deep/nested/dir/big.bin')];
+
+    const execFileSync = vi.fn().mockReturnValue('deep/nested/dir/big.bin\n');
+    const readFileSync = vi.fn().mockImplementation(() => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+
+    const result = filterIgnoredWarnings(warnings, dir, { execFileSync, readFileSync });
+
+    expect(result).toHaveLength(0);
+    expect(execFileSync).toHaveBeenCalledWith(
+      'git',
+      expect.arrayContaining(['check-ignore', 'deep/nested/dir/big.bin']),
+      expect.any(Object),
+    );
+  });
+
+  it('passes correct cwd to git check-ignore', () => {
+    const dir = '/my/project';
+    const warnings = [makeWarning(dir, 'file.bin')];
+
+    const execFileSync = vi.fn().mockImplementation(() => {
+      throw Object.assign(new Error('exit code 1'), { status: 1 });
+    });
+    const readFileSync = vi.fn().mockImplementation(() => {
+      throw Object.assign(new Error('ENOENT'), { code: 'ENOENT' });
+    });
+
+    filterIgnoredWarnings(warnings, dir, { execFileSync, readFileSync });
+
+    expect(execFileSync).toHaveBeenCalledWith(
+      'git',
+      expect.any(Array),
+      expect.objectContaining({ cwd: dir }),
+    );
+  });
+});

--- a/src/fingerprint/__tests__/large-file-filter.test.ts
+++ b/src/fingerprint/__tests__/large-file-filter.test.ts
@@ -206,8 +206,8 @@ describe('filterIgnoredWarnings', () => {
     expect(result).toHaveLength(0);
     expect(execFileSync).toHaveBeenCalledWith(
       'git',
-      expect.arrayContaining(['check-ignore', 'deep/nested/dir/big.bin']),
-      expect.any(Object),
+      ['check-ignore', '--stdin'],
+      expect.objectContaining({ input: 'deep/nested/dir/big.bin' }),
     );
   });
 

--- a/src/fingerprint/large-file-filter.ts
+++ b/src/fingerprint/large-file-filter.ts
@@ -1,0 +1,88 @@
+import fs from 'fs';
+import path from 'path';
+import { execFileSync } from 'child_process';
+import { minimatch } from 'minimatch';
+import type { LargeFileWarning } from './large-file-scan.js';
+
+export interface FilterDeps {
+  execFileSync?: typeof execFileSync;
+  readFileSync?: typeof fs.readFileSync;
+}
+
+function toForwardSlash(p: string): string {
+  return p.replace(/\\/g, '/');
+}
+
+function getGitIgnoredPaths(
+  dir: string,
+  relativePaths: string[],
+  exec: typeof execFileSync,
+): Set<string> | null {
+  if (relativePaths.length === 0) return new Set();
+  try {
+    const result = exec('git', ['check-ignore', ...relativePaths], {
+      cwd: dir,
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    return new Set(
+      (result as string)
+        .split('\n')
+        .map((l) => l.trim())
+        .filter(Boolean),
+    );
+  } catch (err: unknown) {
+    if (
+      err &&
+      typeof err === 'object' &&
+      'status' in err &&
+      (err as { status: number }).status === 1
+    ) {
+      return new Set<string>();
+    }
+    return null;
+  }
+}
+
+function loadCaliberIgnorePatterns(dir: string, read: typeof fs.readFileSync): string[] {
+  try {
+    const content = read(path.join(dir, '.caliberignore'), 'utf-8') as string;
+    return content
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && !line.startsWith('#'));
+  } catch {
+    return [];
+  }
+}
+
+function matchesCaliberIgnore(relativePath: string, patterns: string[]): boolean {
+  const normalized = toForwardSlash(relativePath);
+  return patterns.some((pattern) =>
+    minimatch(normalized, pattern, { dot: true, matchBase: !pattern.includes('/') }),
+  );
+}
+
+export function filterIgnoredWarnings(
+  warnings: LargeFileWarning[],
+  dir: string,
+  deps: FilterDeps = {},
+): LargeFileWarning[] {
+  if (warnings.length === 0) return warnings;
+
+  const exec = deps.execFileSync ?? execFileSync;
+  const read = deps.readFileSync ?? fs.readFileSync;
+
+  const relativePaths = warnings.map((w) => toForwardSlash(path.relative(dir, w.filePath)));
+
+  const gitIgnored = getGitIgnoredPaths(dir, relativePaths, exec);
+
+  const caliberPatterns = loadCaliberIgnorePatterns(dir, read);
+
+  return warnings.filter((_, i) => {
+    const rel = relativePaths[i];
+    if (gitIgnored && gitIgnored.has(rel)) return false;
+    if (caliberPatterns.length > 0 && matchesCaliberIgnore(rel, caliberPatterns)) return false;
+    return true;
+  });
+}

--- a/src/fingerprint/large-file-filter.ts
+++ b/src/fingerprint/large-file-filter.ts
@@ -20,15 +20,16 @@ function getGitIgnoredPaths(
 ): Set<string> | null {
   if (relativePaths.length === 0) return new Set();
   try {
-    const result = exec('git', ['check-ignore', ...relativePaths], {
+    const result = exec('git', ['check-ignore', '--stdin'], {
       cwd: dir,
       encoding: 'utf-8',
+      input: relativePaths.join('\n'),
       stdio: ['pipe', 'pipe', 'pipe'],
     });
     return new Set(
       (result as string)
         .split('\n')
-        .map((l) => l.trim())
+        .map((l) => toForwardSlash(l.trim()))
         .filter(Boolean),
     );
   } catch (err: unknown) {


### PR DESCRIPTION
## Summary

Resolves #214. The large-file scanner walked the filesystem with only a hardcoded `IGNORE_DIRS` set, ignoring `.gitignore` and `.caliberignore` patterns. Files like `.terraform/` binaries (750MB+) appeared in warnings despite being gitignored. The hint "Add them to .gitignore or .caliberignore" was misleading since neither file was read.

- Add `filterIgnoredWarnings()` as a post-filter step (keeps `scanLargeFiles()` pure/testable)
- Use `git check-ignore` to filter gitignored paths
- Parse `.caliberignore` and match with `minimatch` for custom ignore patterns
- Compose filter at both call sites (`init` and `refresh`)

## Test plan

- [x] 13 new unit tests covering git filter, caliberignore patterns, combined filters, edge cases
- [x] Full suite passes (1098/1099, 1 pre-existing failure from #217)
- [x] Type-check clean
- [x] Build succeeds