### PR TITLE
fix(test): pass CLAUDE_PROJECT_DIR in hook shell tests

### DIFF
--- a/src/lib/__tests__/caliber-hooks-shell.test.ts
+++ b/src/lib/__tests__/caliber-hooks-shell.test.ts
@@ -88,20 +88,20 @@ describe('caliber-check-sync.sh', () => {
       path.join(tmpDir, '.git', 'hooks', 'pre-commit'),
       '#!/bin/sh\ncaliber refresh\n',
     );
-    const { status } = runScript(tmpDir);
+    const { status } = runScript(tmpDir, { CLAUDE_PROJECT_DIR: tmpDir });
     expect(status).toBe(0);
   });
 
   it('outputs block decision when caliber is not set up and flag is not set', () => {
-    const { stdout } = runScript(tmpDir);
+    const { stdout } = runScript(tmpDir, { CLAUDE_PROJECT_DIR: tmpDir });
     expect(stdout).toContain('"decision":"block"');
   });
 
   it('exits 0 on second run (flag file prevents repeat prompt)', () => {
     // First run sets the flag
-    runScript(tmpDir);
+    runScript(tmpDir, { CLAUDE_PROJECT_DIR: tmpDir });
     // Second run should exit 0 silently
-    const { status, stdout } = runScript(tmpDir);
+    const { status, stdout } = runScript(tmpDir, { CLAUDE_PROJECT_DIR: tmpDir });
     expect(status).toBe(0);
     expect(stdout).not.toContain('"decision":"block"');
   });


### PR DESCRIPTION
## Summary

Three hook shell tests didn't set `CLAUDE_PROJECT_DIR`, relying on a script-relative fallback that resolved to the repo root. Since the repo already has caliber in its pre-commit hook, the block-decision test never fired the nudge — passing in CI (no caliber installed) but failing locally.

Fix: explicitly pass `CLAUDE_PROJECT_DIR: tmpDir` so tests exercise the intended code paths.

## Test plan

- [x] All 8 hook shell tests pass locally
- [x] No other tests affected