### PR TITLE
fix(hooks): anchor settings.json hook command on $CLAUDE_PROJECT_DIR + auto-migrate legacy entries

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -64,7 +64,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/caliber-check-sync.sh",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-check-sync.sh",
             "description": "Caliber: offer setup if not configured"
           }
         ]
@@ -76,7 +76,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/caliber-session-freshness.sh",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-session-freshness.sh",
             "description": "Caliber: check config freshness on session start"
           }
         ]
@@ -88,7 +88,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/caliber-freshness-notify.sh",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-freshness-notify.sh",
             "description": "Caliber: warn when agent configs are stale"
           }
         ]

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -64,7 +64,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-check-sync.sh",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-check-sync.sh\"",
             "description": "Caliber: offer setup if not configured"
           }
         ]
@@ -76,7 +76,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-session-freshness.sh",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-session-freshness.sh\"",
             "description": "Caliber: check config freshness on session start"
           }
         ]
@@ -88,7 +88,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-freshness-notify.sh",
+            "command": "\"$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-freshness-notify.sh\"",
             "description": "Caliber: warn when agent configs are stale"
           }
         ]

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -269,6 +269,25 @@ export async function initCommand(options: InitOptions) {
   installSessionStartHook();
   console.log(`  ${chalk.green('✓')} Freshness hook — warns when configs are stale`);
 
+  // Migrate any pre-existing legacy hook entries (bare relative `command:`)
+  // to the $CLAUDE_PROJECT_DIR-anchored form. The two install*() calls
+  // above are no-ops when the hooks are already registered, so without
+  // this step an `init` against a partially-Caliber-equipped project
+  // would leave the broken bare-path commands in settings.json. The
+  // pass is idempotent — fresh installs have nothing to migrate and
+  // this returns 0.
+  try {
+    const { migrateAllScriptHooks } = await import('../lib/hooks.js');
+    const { migratedHookCount } = migrateAllScriptHooks();
+    if (migratedHookCount > 0) {
+      console.log(
+        `  ${chalk.green('✓')} Migrated ${migratedHookCount} legacy hook command${migratedHookCount === 1 ? '' : 's'} to $CLAUDE_PROJECT_DIR`,
+      );
+    }
+  } catch {
+    /* best effort */
+  }
+
   if (IS_WINDOWS) {
     console.log(
       chalk.yellow(

--- a/src/commands/refresh.ts
+++ b/src/commands/refresh.ts
@@ -459,6 +459,25 @@ export async function refreshCommand(options: RefreshOptions) {
     if (isCaliberRunning()) return;
   }
 
+  // Migrate legacy bare-command hook entries to the $CLAUDE_PROJECT_DIR-anchored
+  // form. Idempotent — runs in microseconds on already-migrated projects (one
+  // settings.json read, no write). Done early so the rest of refresh runs
+  // against a settings.json with consistent hook commands; surfaces a brief
+  // note in interactive mode so users see the migration happen.
+  try {
+    const { migrateAllScriptHooks } = await import('../lib/hooks.js');
+    const { migratedHookCount } = migrateAllScriptHooks();
+    if (migratedHookCount > 0 && !quiet) {
+      console.log(
+        chalk.green(
+          `  ✓ Migrated ${migratedHookCount} legacy hook command${migratedHookCount === 1 ? '' : 's'} to $CLAUDE_PROJECT_DIR`,
+        ),
+      );
+    }
+  } catch {
+    /* best effort — never let a migration failure block refresh */
+  }
+
   // Show last refresh error if running interactively
   if (!quiet) {
     const lastError = readRefreshError();

--- a/src/lib/__tests__/hooks.test.ts
+++ b/src/lib/__tests__/hooks.test.ts
@@ -464,7 +464,7 @@ describe('script hook paths use forward slashes', () => {
     );
     const command = settings.hooks.Stop[0].hooks[0].command;
     expect(command).not.toContain('\\');
-    expect(command).toBe('.claude/hooks/caliber-check-sync.sh');
+    expect(command).toBe('$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-check-sync.sh');
   });
 
   it('SessionStart hook script path contains only forward slashes', async () => {
@@ -476,7 +476,7 @@ describe('script hook paths use forward slashes', () => {
     );
     const command = settings.hooks.SessionStart[0].hooks[0].command;
     expect(command).not.toContain('\\');
-    expect(command).toBe('.claude/hooks/caliber-session-freshness.sh');
+    expect(command).toBe('$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-session-freshness.sh');
   });
 
   it('Notification hook script path contains only forward slashes', async () => {
@@ -488,7 +488,232 @@ describe('script hook paths use forward slashes', () => {
     );
     const command = settings.hooks.Notification[0].hooks[0].command;
     expect(command).not.toContain('\\');
-    expect(command).toBe('.claude/hooks/caliber-freshness-notify.sh');
+    expect(command).toBe('$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-freshness-notify.sh');
+  });
+});
+
+// ── Hook command migration ──────────────────────────────────────────
+//
+// Regression coverage for the recurring SessionStart:compact bug:
+// `sh: 1: .claude/hooks/caliber-session-freshness.sh: not found`. The
+// fix lives in two places: (a) `install*Hook` now writes the
+// `$CLAUDE_PROJECT_DIR/...` form on first install (covered above),
+// and (b) `migrateAllScriptHooks` rewrites pre-existing bare entries
+// in place so projects initialized on older Caliber versions are
+// fixed by `caliber refresh` — without manual settings.json edits.
+
+describe('migrateAllScriptHooks — legacy bare-command rewrite', () => {
+  let originalCwd: string;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = makeTmpDir();
+    originalCwd = process.cwd();
+    process.chdir(tmpDir);
+    fs.mkdirSync(path.join(tmpDir, '.claude'), { recursive: true });
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  function writeSettingsFile(matchers: Record<string, unknown>) {
+    fs.writeFileSync(
+      path.join(tmpDir, '.claude', 'settings.json'),
+      JSON.stringify({ hooks: matchers }, null, 2),
+    );
+  }
+
+  function readCommand(eventName: string): string {
+    const settings = JSON.parse(
+      fs.readFileSync(path.join(tmpDir, '.claude', 'settings.json'), 'utf-8'),
+    );
+    return settings.hooks[eventName][0].hooks[0].command;
+  }
+
+  it('rewrites bare relative path to $CLAUDE_PROJECT_DIR-anchored form', async () => {
+    writeSettingsFile({
+      SessionStart: [
+        {
+          matcher: '',
+          hooks: [
+            {
+              type: 'command',
+              command: '.claude/hooks/caliber-session-freshness.sh',
+              description: 'Caliber: check config freshness on session start',
+            },
+          ],
+        },
+      ],
+    });
+
+    const { migrateAllScriptHooks } = await import('../hooks.js');
+    const { migratedHookCount } = migrateAllScriptHooks();
+    expect(migratedHookCount).toBe(1);
+    expect(readCommand('SessionStart')).toBe(
+      '$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-session-freshness.sh',
+    );
+  });
+
+  it('rewrites bare path with ./prefix', async () => {
+    writeSettingsFile({
+      Stop: [
+        {
+          matcher: '',
+          hooks: [
+            {
+              type: 'command',
+              command: './.claude/hooks/caliber-check-sync.sh',
+              description: 'Caliber: offer setup if not configured',
+            },
+          ],
+        },
+      ],
+    });
+
+    const { migrateAllScriptHooks } = await import('../hooks.js');
+    const { migratedHookCount } = migrateAllScriptHooks();
+    expect(migratedHookCount).toBe(1);
+    expect(readCommand('Stop')).toBe('$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-check-sync.sh');
+  });
+
+  it('rewrites bare path with backslashes (from older win32 install)', async () => {
+    writeSettingsFile({
+      SessionStart: [
+        {
+          matcher: '',
+          hooks: [
+            {
+              type: 'command',
+              command: '.claude\\hooks\\caliber-session-freshness.sh',
+              description: 'Caliber: check config freshness on session start',
+            },
+          ],
+        },
+      ],
+    });
+
+    const { migrateAllScriptHooks } = await import('../hooks.js');
+    const { migratedHookCount } = migrateAllScriptHooks();
+    expect(migratedHookCount).toBe(1);
+    expect(readCommand('SessionStart')).toBe(
+      '$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-session-freshness.sh',
+    );
+  });
+
+  it('leaves already-migrated entries alone (idempotent)', async () => {
+    writeSettingsFile({
+      SessionStart: [
+        {
+          matcher: '',
+          hooks: [
+            {
+              type: 'command',
+              command: '$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-session-freshness.sh',
+              description: 'Caliber: check config freshness on session start',
+            },
+          ],
+        },
+      ],
+    });
+
+    const { migrateAllScriptHooks } = await import('../hooks.js');
+    const { migratedHookCount } = migrateAllScriptHooks();
+    expect(migratedHookCount).toBe(0);
+    expect(readCommand('SessionStart')).toBe(
+      '$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-session-freshness.sh',
+    );
+  });
+
+  it('migrates Stop + SessionStart + Notification in a single pass', async () => {
+    writeSettingsFile({
+      Stop: [
+        {
+          matcher: '',
+          hooks: [
+            {
+              type: 'command',
+              command: '.claude/hooks/caliber-check-sync.sh',
+              description: 'Caliber: offer setup if not configured',
+            },
+          ],
+        },
+      ],
+      SessionStart: [
+        {
+          matcher: '',
+          hooks: [
+            {
+              type: 'command',
+              command: '.claude/hooks/caliber-session-freshness.sh',
+              description: 'Caliber: check config freshness on session start',
+            },
+          ],
+        },
+      ],
+      Notification: [
+        {
+          matcher: '',
+          hooks: [
+            {
+              type: 'command',
+              command: '.claude/hooks/caliber-freshness-notify.sh',
+              description: 'Caliber: warn when agent configs are stale',
+            },
+          ],
+        },
+      ],
+    });
+
+    const { migrateAllScriptHooks } = await import('../hooks.js');
+    const { migratedHookCount } = migrateAllScriptHooks();
+    expect(migratedHookCount).toBe(3);
+    expect(readCommand('Stop')).toContain('$CLAUDE_PROJECT_DIR/');
+    expect(readCommand('SessionStart')).toContain('$CLAUDE_PROJECT_DIR/');
+    expect(readCommand('Notification')).toContain('$CLAUDE_PROJECT_DIR/');
+  });
+
+  it('does NOT touch user-authored hook entries with unrelated descriptions', async () => {
+    // Imagine a user-added hook that happens to point at the same dir but
+    // is not Caliber-owned (description doesn't match). The migrator must
+    // not rewrite paths it doesn't own.
+    writeSettingsFile({
+      SessionStart: [
+        {
+          matcher: '',
+          hooks: [
+            {
+              type: 'command',
+              command: '.claude/hooks/my-own-hook.sh',
+              description: 'Not a Caliber hook',
+            },
+          ],
+        },
+      ],
+    });
+
+    const { migrateAllScriptHooks } = await import('../hooks.js');
+    const { migratedHookCount } = migrateAllScriptHooks();
+    expect(migratedHookCount).toBe(0);
+    expect(readCommand('SessionStart')).toBe('.claude/hooks/my-own-hook.sh');
+  });
+
+  it('no-op when settings.json has no hooks section', async () => {
+    fs.writeFileSync(path.join(tmpDir, '.claude', 'settings.json'), '{}');
+
+    const { migrateAllScriptHooks } = await import('../hooks.js');
+    const { migratedHookCount } = migrateAllScriptHooks();
+    expect(migratedHookCount).toBe(0);
+  });
+
+  it('no-op when settings.json does not exist', async () => {
+    // readSettings() returns {} for missing files, so this should not throw.
+    const { migrateAllScriptHooks } = await import('../hooks.js');
+    const { migratedHookCount } = migrateAllScriptHooks();
+    expect(migratedHookCount).toBe(0);
   });
 });
 

--- a/src/lib/__tests__/hooks.test.ts
+++ b/src/lib/__tests__/hooks.test.ts
@@ -464,7 +464,7 @@ describe('script hook paths use forward slashes', () => {
     );
     const command = settings.hooks.Stop[0].hooks[0].command;
     expect(command).not.toContain('\\');
-    expect(command).toBe('$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-check-sync.sh');
+    expect(command).toBe('"$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-check-sync.sh"');
   });
 
   it('SessionStart hook script path contains only forward slashes', async () => {
@@ -476,7 +476,7 @@ describe('script hook paths use forward slashes', () => {
     );
     const command = settings.hooks.SessionStart[0].hooks[0].command;
     expect(command).not.toContain('\\');
-    expect(command).toBe('$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-session-freshness.sh');
+    expect(command).toBe('"$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-session-freshness.sh"');
   });
 
   it('Notification hook script path contains only forward slashes', async () => {
@@ -488,7 +488,7 @@ describe('script hook paths use forward slashes', () => {
     );
     const command = settings.hooks.Notification[0].hooks[0].command;
     expect(command).not.toContain('\\');
-    expect(command).toBe('$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-freshness-notify.sh');
+    expect(command).toBe('"$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-freshness-notify.sh"');
   });
 });
 
@@ -497,7 +497,7 @@ describe('script hook paths use forward slashes', () => {
 // Regression coverage for the recurring SessionStart:compact bug:
 // `sh: 1: .claude/hooks/caliber-session-freshness.sh: not found`. The
 // fix lives in two places: (a) `install*Hook` now writes the
-// `$CLAUDE_PROJECT_DIR/...` form on first install (covered above),
+// `"$CLAUDE_PROJECT_DIR/..."` quoted form on first install (covered above),
 // and (b) `migrateAllScriptHooks` rewrites pre-existing bare entries
 // in place so projects initialized on older Caliber versions are
 // fixed by `caliber refresh` — without manual settings.json edits.
@@ -554,7 +554,7 @@ describe('migrateAllScriptHooks — legacy bare-command rewrite', () => {
     const { migratedHookCount } = migrateAllScriptHooks();
     expect(migratedHookCount).toBe(1);
     expect(readCommand('SessionStart')).toBe(
-      '$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-session-freshness.sh',
+      '"$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-session-freshness.sh"',
     );
   });
 
@@ -577,7 +577,7 @@ describe('migrateAllScriptHooks — legacy bare-command rewrite', () => {
     const { migrateAllScriptHooks } = await import('../hooks.js');
     const { migratedHookCount } = migrateAllScriptHooks();
     expect(migratedHookCount).toBe(1);
-    expect(readCommand('Stop')).toBe('$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-check-sync.sh');
+    expect(readCommand('Stop')).toBe('"$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-check-sync.sh"');
   });
 
   it('rewrites bare path with backslashes (from older win32 install)', async () => {
@@ -600,11 +600,11 @@ describe('migrateAllScriptHooks — legacy bare-command rewrite', () => {
     const { migratedHookCount } = migrateAllScriptHooks();
     expect(migratedHookCount).toBe(1);
     expect(readCommand('SessionStart')).toBe(
-      '$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-session-freshness.sh',
+      '"$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-session-freshness.sh"',
     );
   });
 
-  it('leaves already-migrated entries alone (idempotent)', async () => {
+  it('rewrites unquoted $CLAUDE_PROJECT_DIR form to quoted form', async () => {
     writeSettingsFile({
       SessionStart: [
         {
@@ -622,9 +622,33 @@ describe('migrateAllScriptHooks — legacy bare-command rewrite', () => {
 
     const { migrateAllScriptHooks } = await import('../hooks.js');
     const { migratedHookCount } = migrateAllScriptHooks();
+    expect(migratedHookCount).toBe(1);
+    expect(readCommand('SessionStart')).toBe(
+      '"$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-session-freshness.sh"',
+    );
+  });
+
+  it('leaves already-migrated entries alone (idempotent)', async () => {
+    writeSettingsFile({
+      SessionStart: [
+        {
+          matcher: '',
+          hooks: [
+            {
+              type: 'command',
+              command: '"$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-session-freshness.sh"',
+              description: 'Caliber: check config freshness on session start',
+            },
+          ],
+        },
+      ],
+    });
+
+    const { migrateAllScriptHooks } = await import('../hooks.js');
+    const { migratedHookCount } = migrateAllScriptHooks();
     expect(migratedHookCount).toBe(0);
     expect(readCommand('SessionStart')).toBe(
-      '$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-session-freshness.sh',
+      '"$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-session-freshness.sh"',
     );
   });
 

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -138,17 +138,21 @@ interface ScriptHookConfig {
 // `path.join` would inject them on win32 — `path.posix.join`
 // keeps the form portable.
 function commandFor(scriptPath: string): string {
-  return `$CLAUDE_PROJECT_DIR/${scriptPath}`;
+  // Quote so project dirs with spaces survive `sh -c`.
+  return `"$CLAUDE_PROJECT_DIR/${scriptPath}"`;
 }
 
-// True if a hook entry's `command` is the legacy bare scriptPath
-// (or a normalized variant — `./scriptPath`, backslashes from a
-// pre-win32-fix install) rather than the $CLAUDE_PROJECT_DIR-
-// anchored form. Used by the migration pass on `caliber refresh`
-// to rewrite settings.json in place without forcing a re-init.
+// True if a hook entry's `command` is not yet the current
+// `$CLAUDE_PROJECT_DIR`-anchored form. Covers bare paths,
+// `./`-prefixed / backslash variants, and the unquoted
+// `$CLAUDE_PROJECT_DIR/...` form from the first ship of this fix.
 function isLegacyBareCommand(command: string, scriptPath: string): boolean {
   if (!command) return false;
-  if (command.includes('$CLAUDE_PROJECT_DIR')) return false;
+  if (command === commandFor(scriptPath)) return false;
+  if (command.includes('$CLAUDE_PROJECT_DIR')) {
+    const unquoted = `$CLAUDE_PROJECT_DIR/${scriptPath}`;
+    return command === unquoted || command === `'${unquoted}'`;
+  }
   const normalized = command.replace(/\\/g, '/').replace(/^\.\//, '');
   return normalized === scriptPath;
 }

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -117,6 +117,42 @@ interface ScriptHookConfig {
   description: string;
 }
 
+// The hook command Claude Code writes into settings.json must be
+// anchored on $CLAUDE_PROJECT_DIR. Claude Code launches hooks via
+// `sh -c "<command>"` with cwd = the session's working directory,
+// which can be a subdirectory of the project (the assistant cd'd
+// during the session). A bare relative path like
+// `.claude/hooks/caliber-session-freshness.sh` then resolves
+// against that subdirectory and `sh` returns
+// `not found` (exit 127) before the script ever executes.
+//
+// $CLAUDE_PROJECT_DIR is exported by Claude Code and always points
+// at the directory containing the .claude/ that registered the
+// hook, so prefixing the script path with it makes the launch
+// CWD-independent. The shell expands $CLAUDE_PROJECT_DIR inside
+// the command string at hook-invocation time.
+//
+// Always use forward slashes: Claude Code runs hooks through `sh`
+// even on Windows (via Git for Windows' bundled bash). Backslashes
+// in `command` would be eaten by `sh` as escape characters and
+// `path.join` would inject them on win32 — `path.posix.join`
+// keeps the form portable.
+function commandFor(scriptPath: string): string {
+  return `$CLAUDE_PROJECT_DIR/${scriptPath}`;
+}
+
+// True if a hook entry's `command` is the legacy bare scriptPath
+// (or a normalized variant — `./scriptPath`, backslashes from a
+// pre-win32-fix install) rather than the $CLAUDE_PROJECT_DIR-
+// anchored form. Used by the migration pass on `caliber refresh`
+// to rewrite settings.json in place without forcing a re-init.
+function isLegacyBareCommand(command: string, scriptPath: string): boolean {
+  if (!command) return false;
+  if (command.includes('$CLAUDE_PROJECT_DIR')) return false;
+  const normalized = command.replace(/\\/g, '/').replace(/^\.\//, '');
+  return normalized === scriptPath;
+}
+
 function createScriptHook(config: ScriptHookConfig) {
   const { eventName, scriptPath, description } = config;
   const getContent = () =>
@@ -150,7 +186,7 @@ function createScriptHook(config: ScriptHookConfig) {
     }
     (settings.hooks[eventName] as HookMatcher[]).push({
       matcher: '',
-      hooks: [{ type: 'command', command: scriptPath, description }],
+      hooks: [{ type: 'command', command: commandFor(scriptPath), description }],
     });
 
     writeSettings(settings);
@@ -183,7 +219,39 @@ function createScriptHook(config: ScriptHookConfig) {
     return { removed: true, notFound: false };
   }
 
-  return { isInstalled, install, remove };
+  // Rewrite a legacy bare-command entry to the $CLAUDE_PROJECT_DIR-
+  // anchored form. Idempotent: returns `{ migrated: false }` when
+  // every matching entry is already prefixed (or no entry exists at
+  // all). Called by `migrateAllScriptHooks` from `caliber refresh`
+  // so existing projects pick up the fix without a re-init. Unlike
+  // `install`, this only touches entries Caliber owns (matched by
+  // `description`) and never re-writes the on-disk script file —
+  // the shell-script content migration is handled separately by
+  // re-installing the upstream PR #217 freshness check via the
+  // normal install/upgrade path.
+  function migrate(): { migrated: boolean } {
+    const settings = readSettings();
+    const matchers = settings.hooks?.[eventName] as HookMatcher[] | undefined;
+    if (!Array.isArray(matchers)) return { migrated: false };
+
+    let changed = false;
+    for (const entry of matchers) {
+      if (!entry.hooks) continue;
+      for (const h of entry.hooks) {
+        if (h.description !== description) continue;
+        if (isLegacyBareCommand(h.command, scriptPath)) {
+          h.command = commandFor(scriptPath);
+          changed = true;
+        }
+      }
+    }
+
+    if (!changed) return { migrated: false };
+    writeSettings(settings);
+    return { migrated: true };
+  }
+
+  return { isInstalled, install, remove, migrate };
 }
 
 // ── Stop hook (onboarding nudge) ────────────────────────────────────
@@ -252,6 +320,7 @@ const stopHook = createScriptHook({
 
 export const installStopHook = stopHook.install;
 export const removeStopHook = stopHook.remove;
+export const migrateStopHook = stopHook.migrate;
 
 // ── Freshness check script ───────────────────────────────────────────
 
@@ -288,6 +357,7 @@ const sessionStartHook = createScriptHook({
 export const isSessionStartHookInstalled = sessionStartHook.isInstalled;
 export const installSessionStartHook = sessionStartHook.install;
 export const removeSessionStartHook = sessionStartHook.remove;
+export const migrateSessionStartHook = sessionStartHook.migrate;
 
 // ── Notification hook (kept for backwards compat, not auto-installed) ─
 
@@ -301,6 +371,31 @@ const notificationHook = createScriptHook({
 export const isNotificationHookInstalled = notificationHook.isInstalled;
 export const installNotificationHook = notificationHook.install;
 export const removeNotificationHook = notificationHook.remove;
+export const migrateNotificationHook = notificationHook.migrate;
+
+// ── Settings.json hook migration aggregator ─────────────────────────
+//
+// Runs the per-hook `migrate()` step for every Caliber-owned script
+// hook. Returns the count of entries actually rewritten (so callers
+// can report "migrated N legacy hook commands" without recomputing).
+// Idempotent — safe to call on every `caliber refresh`.
+//
+// Why this exists: when Caliber was first shipped, the script hook
+// installer wrote a bare relative `command` like
+// `.claude/hooks/caliber-session-freshness.sh`. Claude Code launches
+// hooks with `cwd = session cwd`, which can be a subdirectory of
+// the project, so the bare path resolves to nowhere and `sh`
+// reports `not found` (exit 127) before the script runs. The fix is
+// to anchor the command on `$CLAUDE_PROJECT_DIR`; this migration
+// rewrites existing settings.json files in place so users don't
+// have to manually re-init.
+export function migrateAllScriptHooks(): { migratedHookCount: number } {
+  let migratedHookCount = 0;
+  if (stopHook.migrate().migrated) migratedHookCount++;
+  if (sessionStartHook.migrate().migrated) migratedHookCount++;
+  if (notificationHook.migrate().migrated) migratedHookCount++;
+  return { migratedHookCount };
+}
 
 // ── Pre-commit hook ──────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem

Claude Code launches hooks via `sh -c "<command>"` with `cwd = the session's working directory`, which can be a subdirectory of the project when the assistant `cd`'d during the session.

Today, `src/lib/hooks.ts:153` writes a bare relative path into `settings.json`:

```ts
hooks: [{ type: 'command', command: scriptPath, description }],
```

…producing commands like `.claude/hooks/caliber-session-freshness.sh`. From any cwd that isn't the project root, `sh` exits 127 with:

```
/bin/sh: 1: .claude/hooks/caliber-session-freshness.sh: not found
```

**before** the script ever executes. Reproduces cleanly:

```sh
$ cd /path/to/some/project           # project root — works
$ /bin/sh -c '.claude/hooks/caliber-session-freshness.sh'
$ echo $?
0

$ cd ..                              # one directory up
$ /bin/sh -c '.claude/hooks/caliber-session-freshness.sh'
/bin/sh: 1: .claude/hooks/caliber-session-freshness.sh: not found
$ echo $?
127
```

`SessionStart:compact` is the most visible victim because Claude Code's compact event often fires from a non-root cwd, but Stop and Notification hooks see the same failure mode whenever the session has navigated away from the project root.

PR #217 fixed this from the **inside** (the freshness script now anchors its `git rev-parse` on `$CLAUDE_PROJECT_DIR` instead of `$PWD`), but that fix is unreachable when `sh` can't find the script to begin with. This PR closes the **outside** layer.

## Fix

### 1. New installs use `$CLAUDE_PROJECT_DIR/`-anchored commands

A `commandFor(scriptPath: string)` helper prefixes with `$CLAUDE_PROJECT_DIR/`. The shell expands the variable at hook-launch time — Claude Code exports it pointing at the directory that registered the hook. Forward-slash-only for portability: Claude Code runs hooks through `sh` even on Windows (via Git for Windows' bundled bash).

### 2. Auto-migration on `caliber refresh` and `caliber init`

Each script hook gets a `migrate()` method that rewrites any pre-existing bare-command entries in place. The new exported `migrateAllScriptHooks()` aggregator runs all three (Stop / SessionStart / Notification) in one pass. Wired into:

- `refreshCommand()` (after the cascade guards, before LLM work) — surfaces a one-line green tick when entries are migrated; silent in `--quiet` mode and on already-migrated projects.
- `initCommand()` (after `installStopHook` / `installSessionStartHook`) — catches partially-Caliber-equipped projects where the install calls would otherwise be no-ops.

The migrator recognizes three legacy forms:

- bare: `.claude/hooks/caliber-session-freshness.sh`
- dot-prefixed: `./.claude/hooks/caliber-session-freshness.sh`
- backslashes (from older win32 installs): `.claude\hooks\caliber-session-freshness.sh`

It only rewrites entries it owns (matched by `description`), never touching user-authored hooks. Idempotent — `migratedHookCount: 0` when nothing needs changing.

## Tests

- Updates the three existing `'forward slashes only'` assertions in `hooks.test.ts` to expect the new `$CLAUDE_PROJECT_DIR/`-anchored form.
- Adds 8 new tests covering: bare-path rewrite, `./prefix` rewrite, backslash rewrite, idempotent re-run, multi-hook single-pass, user-authored entries untouched, no-`hooks` section no-op, missing-`settings.json` no-op.

Full suite: **1106 pass, 1 skipped** on both Node 20 and 22 (CI matrix).

## End-to-end verification

Against a real broken `.claude/settings.json` (from a project initialized on an older Caliber version):

```
===PRE===
"command": ".claude/hooks/caliber-session-freshness.sh"
"command": ".claude/hooks/caliber-freshness-notify.sh"
---
migrated: {"migratedHookCount":2}
===POST===
"command": "$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-session-freshness.sh"
"command": "$CLAUDE_PROJECT_DIR/.claude/hooks/caliber-freshness-notify.sh"
```

## Relationship to PR #217

This PR is the second half of the fix #217 started. #217 made the freshness script's internal path-walking robust to a "wrong `$PWD`" by switching to `$CLAUDE_PROJECT_DIR`. This PR makes the launch path itself robust the same way — so the script can actually start running and the #217 fix becomes reachable. Together they close the SessionStart:compact "not found" bug for both new installs and existing projects.

## Backwards compatibility

- New installs: prefixed form from day one.
- Existing projects: migrated automatically on next `caliber refresh` or `caliber init` (single file write, idempotent).
- User-authored hooks: never touched.
- Settings without Caliber hooks: silent no-op.