### PR TITLE
fix(windows): eliminate console-window flashes across all three sources (spawn audit + cmd-shim bypass + wscript wrapper)

### DIFF
--- a/assets/hook-runner.vbs
+++ b/assets/hook-runner.vbs
@@ -1,0 +1,38 @@
+' Caliber hook runner — invokes a child command hidden + waits for exit.
+'
+' The Windows flash this avoids: Claude Code spawns hook commands via
+' child_process.spawn without windowsHide:true. When the hook command
+' is a console-subsystem binary (node.exe, python.exe, cmd.exe …),
+' Windows allocates a new console window for it that flashes onto the
+' user's desktop for the lifetime of the call. Anthropic closed
+' anthropics/claude-code#19012 as "not planned"; this VBS is the
+' supported workaround they recommend.
+'
+' wscript.exe is windows-subsystem (no console allocated), so the
+' OUTER spawn is silent. WScript.Shell.Run with intWindowStyle=0
+' and bWaitOnReturn=True hides the INNER node child's window AND
+' waits for it to exit so the parent (Claude Code) sees the real
+' exit code. Stdout is NOT forwarded — this wrapper is only suitable
+' for fire-and-forget hooks (learn observe, learn finalize, etc.)
+' that don't return systemMessage / decision JSON to Claude Code.
+'
+' Usage:
+'   wscript //nologo hook-runner.vbs <node.exe> <bin.js> [args ...]
+'
+' All arguments are quoted before being joined into a single command
+' line for WScript.Shell.Run, so paths with spaces (e.g. "C:\Program
+' Files\nodejs\node.exe") survive unchanged.
+
+If WScript.Arguments.Count < 1 Then
+  WScript.Quit(1)
+End If
+
+Dim cmd, i
+cmd = ""
+For i = 0 To WScript.Arguments.Count - 1
+  If i > 0 Then cmd = cmd & " "
+  cmd = cmd & """" & WScript.Arguments(i) & """"
+Next
+
+Set sh = CreateObject("WScript.Shell")
+WScript.Quit(sh.Run(cmd, 0, True))

--- a/index.cjs
+++ b/index.cjs
@@ -300,7 +300,12 @@ async function run() {
             if (!/^[\w\.\-\/]+$/.test(baseBranch)) throw new Error('Invalid base branch name');
             const baseOutput = execFileSync(
               'npx', ['--yes', CALIBER_PKG, 'score', '--json', '--quiet', '--agent', agent, '--compare', `origin/${baseBranch}`],
-              { encoding: 'utf-8', timeout: 120000, env: { ...process.env, CALIBER_SKIP_UPDATE_CHECK: '1' } }, { windowsHide: true }
+              {
+                encoding: 'utf-8',
+                timeout: 120000,
+                env: { ...process.env, CALIBER_SKIP_UPDATE_CHECK: '1' },
+                windowsHide: true,
+              },
             );
             const parsed = JSON.parse(baseOutput.trim());
             baseResult = parsed.base || null;

--- a/index.cjs
+++ b/index.cjs
@@ -143,24 +143,25 @@ async function runSync(token) {
 
   // Ensure we're on the default branch for sync mode
   try {
-    execFileSync('git', ['checkout', defaultBranch], { stdio: 'pipe' });
+    execFileSync('git', ['checkout', defaultBranch],{ stdio: 'pipe', windowsHide: true });
   } catch {
     console.log(`Warning: Could not checkout ${defaultBranch}`);
   }
 
   // Run caliber refresh
   try {
-    execFileSync('npx', ['--yes', CALIBER_PKG, 'refresh', '--quiet'], {
+    execFileSync('npx', ['--yes', CALIBER_PKG, 'refresh', '--quiet'],{
       encoding: 'utf-8',
       timeout: 300000,
       env: { ...process.env, CALIBER_SKIP_UPDATE_CHECK: '1' },
+      windowsHide: true,
     });
   } catch (err) {
     console.log(`Refresh failed: ${err.message}`);
     return;
   }
 
-  const changes = execFileSync('git', ['diff', '--name-only'], { encoding: 'utf-8' }).trim();
+  const changes = execFileSync('git', ['diff', '--name-only'],{ encoding: 'utf-8', windowsHide: true }).trim();
   if (!changes) {
     console.log('No config changes detected — all agent formats are up to date.');
     return;
@@ -172,31 +173,31 @@ async function runSync(token) {
   const syncBranch = `${branchPrefix}-${date}`;
 
   // Configure git
-  execFileSync('git', ['config', 'user.name', 'caliber[bot]']);
-  execFileSync('git', ['config', 'user.email', 'caliber-bot@users.noreply.github.com']);
+  execFileSync('git', ['config', 'user.name', 'caliber[bot]'], { windowsHide: true });
+  execFileSync('git', ['config', 'user.email', 'caliber-bot@users.noreply.github.com'], { windowsHide: true });
 
   // Create sync branch from current state (carries uncommitted refresh changes)
   try {
-    execFileSync('git', ['branch', '-D', syncBranch], { stdio: 'pipe' });
+    execFileSync('git', ['branch', '-D', syncBranch],{ stdio: 'pipe', windowsHide: true });
   } catch { /* branch may not exist locally */ }
-  execFileSync('git', ['checkout', '-b', syncBranch]);
+  execFileSync('git', ['checkout', '-b', syncBranch], { windowsHide: true });
 
   try {
-    execFileSync('git', ['add', ...MANAGED_FILES], { stdio: 'pipe' });
+    execFileSync('git', ['add', ...MANAGED_FILES],{ stdio: 'pipe', windowsHide: true });
   } catch { /* some files may not exist */ }
 
   // Check if there's anything staged to commit
-  const staged = execFileSync('git', ['diff', '--cached', '--name-only'], { encoding: 'utf-8' }).trim();
+  const staged = execFileSync('git', ['diff', '--cached', '--name-only'],{ encoding: 'utf-8', windowsHide: true }).trim();
   if (!staged) {
     console.log('No config files to commit after staging.');
     return;
   }
 
   const formatNames = formats.map(f => f.name).join(', ') || 'agent configs';
-  execFileSync('git', ['commit', '-m', `[caliber] sync ${formatNames}`]);
+  execFileSync('git', ['commit', '-m', `[caliber] sync ${formatNames}`], { windowsHide: true });
 
   try {
-    execFileSync('git', ['push', '--force', 'origin', syncBranch]);
+    execFileSync('git', ['push', '--force', 'origin', syncBranch], { windowsHide: true });
   } catch (err) {
     console.log(`Failed to push sync branch: ${err.message}`);
     return;
@@ -261,10 +262,11 @@ async function run() {
   // Run caliber score
   let resultJson;
   try {
-    const output = execFileSync('npx', ['--yes', CALIBER_PKG, 'score', '--json', '--quiet', '--agent', agent], {
+    const output = execFileSync('npx', ['--yes', CALIBER_PKG, 'score', '--json', '--quiet', '--agent', agent],{
       encoding: 'utf-8',
       timeout: 120000,
       env: { ...process.env, CALIBER_SKIP_UPDATE_CHECK: '1' },
+      windowsHide: true,
     });
     resultJson = JSON.parse(output.trim());
   } catch (err) {
@@ -298,7 +300,7 @@ async function run() {
             if (!/^[\w\.\-\/]+$/.test(baseBranch)) throw new Error('Invalid base branch name');
             const baseOutput = execFileSync(
               'npx', ['--yes', CALIBER_PKG, 'score', '--json', '--quiet', '--agent', agent, '--compare', `origin/${baseBranch}`],
-              { encoding: 'utf-8', timeout: 120000, env: { ...process.env, CALIBER_SKIP_UPDATE_CHECK: '1' } },
+              { encoding: 'utf-8', timeout: 120000, env: { ...process.env, CALIBER_SKIP_UPDATE_CHECK: '1' } }, { windowsHide: true }
             );
             const parsed = JSON.parse(baseOutput.trim());
             baseResult = parsed.base || null;
@@ -344,25 +346,26 @@ async function run() {
   // Auto-refresh
   if (autoRefresh) {
     try {
-      execFileSync('npx', ['--yes', CALIBER_PKG, 'refresh', '--quiet'], {
+      execFileSync('npx', ['--yes', CALIBER_PKG, 'refresh', '--quiet'],{
         encoding: 'utf-8',
         timeout: 300000,
         env: { ...process.env, CALIBER_SKIP_UPDATE_CHECK: '1' },
+        windowsHide: true,
       });
 
-      const changes = execFileSync('git', ['diff', '--name-only'], { encoding: 'utf-8' }).trim();
+      const changes = execFileSync('git', ['diff', '--name-only'],{ encoding: 'utf-8', windowsHide: true }).trim();
       if (changes) {
         const changedFiles = changes.split('\n').filter(Boolean);
         const formats = detectAgentFormats(changedFiles);
         const formatNames = formats.map(f => f.name).join(', ') || 'agent configs';
 
-        execFileSync('git', ['config', 'user.name', 'caliber[bot]']);
-        execFileSync('git', ['config', 'user.email', 'caliber-bot@users.noreply.github.com']);
+        execFileSync('git', ['config', 'user.name', 'caliber[bot]'], { windowsHide: true });
+        execFileSync('git', ['config', 'user.email', 'caliber-bot@users.noreply.github.com'], { windowsHide: true });
         try {
-          execFileSync('git', ['add', ...MANAGED_FILES], { stdio: 'pipe' });
+          execFileSync('git', ['add', ...MANAGED_FILES],{ stdio: 'pipe', windowsHide: true });
         } catch { /* some files may not exist */ }
-        execFileSync('git', ['commit', '-m', `[caliber] sync ${formatNames}`]);
-        execFileSync('git', ['push']);
+        execFileSync('git', ['commit', '-m', `[caliber] sync ${formatNames}`], { windowsHide: true });
+        execFileSync('git', ['push'], { windowsHide: true });
         console.log(`Synced ${formats.length} agent format${formats.length === 1 ? '' : 's'}: ${formatNames}`);
       } else {
         console.log('No config changes to commit.');

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "prebuild": "npm run build:skills:check",
-    "build": "tsup",
+    "build": "tsup && node scripts/copy-hook-runner.mjs",
     "build:skills": "node scripts/generate-skills.mjs",
     "build:skills:check": "node scripts/generate-skills.mjs --check",
     "dev": "tsup --watch",
@@ -41,6 +41,7 @@
   },
   "files": [
     "dist/**/*.js",
+    "dist/**/*.vbs",
     "README.md",
     "LICENSE"
   ],

--- a/scripts/copy-hook-runner.mjs
+++ b/scripts/copy-hook-runner.mjs
@@ -1,0 +1,20 @@
+#!/usr/bin/env node
+// Copy assets/hook-runner.vbs → dist/hook-runner.vbs as part of the
+// build. The VBS lives next to the bundled bin.js so the path
+// resolution in src/lib/resolve-caliber.ts can find it via the same
+// npm-global layout assumption it uses for bin.js.
+//
+// Keep this script tiny and ESM so it runs under the same Node we use
+// for the rest of the build pipeline without a transpile step.
+
+import { copyFileSync, mkdirSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = resolve(here, '..', 'assets', 'hook-runner.vbs');
+const dst = resolve(here, '..', 'dist', 'hook-runner.vbs');
+
+mkdirSync(dirname(dst), { recursive: true });
+copyFileSync(src, dst);
+console.log(`copied: ${src} → ${dst}`);

--- a/src/__tests__/windows-hide-regression.test.ts
+++ b/src/__tests__/windows-hide-regression.test.ts
@@ -114,6 +114,10 @@ describe('windowsHide regression — every spawn-family call must set the flag',
       // because every call in these files passes an options object
       // literal — no helper indirection.
       expect(hideCount).toBeGreaterThanOrEqual(spawnCount);
+      // Catch the class of bug where windowsHide is passed as a 4th
+      // positional arg to execFileSync (ignored by Node) instead of
+      // inside the options object.
+      expect(code).not.toMatch(/\)\s*,\s*\{\s*windowsHide\s*:\s*true\s*\}\s*\)/);
     });
   }
 });

--- a/src/__tests__/windows-hide-regression.test.ts
+++ b/src/__tests__/windows-hide-regression.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Source-level regression: every spawn-family call in Caliber must
+ * pass ``windowsHide: true`` in its options object.
+ *
+ * Without the flag, Node's ``child_process`` asks ``CreateProcess`` to
+ * use ``STARTF_USESHOWWINDOW`` with ``SW_SHOWDEFAULT`` and a black
+ * console window flashes onto the user's desktop for the duration of
+ * each call. Under active Claude Code / Cursor / Codex / scoring use
+ * that's a near-continuous stream of pop-ups on Windows — unusable in
+ * practice.
+ *
+ * ``windowsHide`` is a no-op on macOS/Linux ([Node docs][1]: "Hide
+ * the subprocess console window that would normally be created on
+ * Windows systems"). The flag is platform-neutral and zero-risk on
+ * POSIX — silently dropped by the POSIX spawn path.
+ *
+ * [1]: https://nodejs.org/api/child_process.html#optionswindowshide
+ *
+ * The check is source-level rather than behavioural because:
+ *   - the flag's effect is observable only on Windows;
+ *   - CI runs vitest on Linux for these tests;
+ *   - regressing this is easy (every new spawn site has to remember
+ *     the flag), and a runtime check on a Windows-only CI leg would
+ *     still let a PR land on ``master`` first.
+ *
+ * Adding a new file is one entry in the SOURCE_FILES tuple. Every
+ * file in ``src/`` that imports a spawn-family function from
+ * ``child_process`` MUST be added to this list.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const ROOT = resolve(__dirname, '..', '..');
+
+const SOURCE_FILES: ReadonlyArray<readonly [string, string]> = [
+  ['index.cjs', 'index.cjs'],
+  ['src/constants.ts', 'src/constants.ts'],
+  ['src/llm/claude-cli.ts', 'src/llm/claude-cli.ts'],
+  ['src/llm/cursor-acp.ts', 'src/llm/cursor-acp.ts'],
+  ['src/llm/opencode.ts', 'src/llm/opencode.ts'],
+  ['src/scoring/utils.ts', 'src/scoring/utils.ts'],
+  ['src/utils/editor.ts', 'src/utils/editor.ts'],
+  ['src/utils/version-check.ts', 'src/utils/version-check.ts'],
+  // src/fingerprint/large-file-filter.ts uses dependency-injected
+  // ``exec()`` rather than calling ``execFileSync`` directly, so the
+  // regex below — which deliberately ignores the bare ``exec``
+  // identifier to avoid colliding with ``RegExp.exec()`` — undercounts.
+  // The call inside it does carry ``windowsHide: true`` (verifiable
+  // by grep); skipping the regex check here is the right call.
+  ['src/fingerprint/file-tree.ts', 'src/fingerprint/file-tree.ts'],
+  ['src/fingerprint/code-analysis.ts', 'src/fingerprint/code-analysis.ts'],
+  ['src/fingerprint/cache.ts', 'src/fingerprint/cache.ts'],
+  ['src/fingerprint/git.ts', 'src/fingerprint/git.ts'],
+  ['src/commands/score.ts', 'src/commands/score.ts'],
+  ['src/commands/learn.ts', 'src/commands/learn.ts'],
+  ['src/lib/hooks.ts', 'src/lib/hooks.ts'],
+  ['src/lib/state.ts', 'src/lib/state.ts'],
+  ['src/lib/git-diff.ts', 'src/lib/git-diff.ts'],
+  ['src/lib/resolve-caliber.ts', 'src/lib/resolve-caliber.ts'],
+  ['src/telemetry/config.ts', 'src/telemetry/config.ts'],
+  ['src/scoring/checks/accuracy.ts', 'src/scoring/checks/accuracy.ts'],
+  ['src/scoring/checks/freshness.ts', 'src/scoring/checks/freshness.ts'],
+  ['src/scoring/checks/bonus.ts', 'src/scoring/checks/bonus.ts'],
+];
+
+/**
+ * Strip pure-comment lines so prose mentions of ``spawn`` / ``exec``
+ * don't inflate the call count.
+ */
+function stripComments(source: string): string {
+  return source
+    .split('\n')
+    .filter((l) => {
+      const t = l.trim();
+      return !t.startsWith('//') && !t.startsWith('*') && !t.startsWith('/*');
+    })
+    .join('\n');
+}
+
+/**
+ * Count spawn-family invocations. The regex matches ``spawn(``,
+ * ``spawnSync(``, ``execFile(``, ``execFileSync(``, ``execFileAsync(``,
+ * ``execSync(`` as function calls — not destructures (``const { spawn
+ * } = ...``), not method calls (``.exec(``), not type-import lines.
+ */
+function countSpawnCalls(codeSource: string): number {
+  const re =
+    /(^|[^a-zA-Z0-9_$.])(spawn|spawnSync|execFile|execFileSync|execFileAsync|execSync)\s*\(/gm;
+  let count = 0;
+  // Use a fresh RegExp per call to avoid stateful lastIndex issues
+  // across multiple invocations of this helper.
+  while (re.exec(codeSource) !== null) {
+    count++;
+  }
+  return count;
+}
+
+describe('windowsHide regression — every spawn-family call must set the flag', () => {
+  for (const [label, file] of SOURCE_FILES) {
+    it(`${label}: every spawn-family options object contains windowsHide: true`, () => {
+      const abs = resolve(ROOT, file);
+      const source = readFileSync(abs, 'utf-8');
+      const code = stripComments(source);
+
+      const spawnCount = countSpawnCalls(code);
+      const hideCount = (code.match(/windowsHide\s*:\s*true/g) ?? []).length;
+
+      // Sanity: catch a refactor that accidentally deletes every
+      // spawn call (which would otherwise make the equality below
+      // trivially true at 0 == 0).
+      expect(spawnCount).toBeGreaterThan(0);
+      // One windowsHide per spawn-family call. Equality is sufficient
+      // because every call in these files passes an options object
+      // literal — no helper indirection.
+      expect(hideCount).toBeGreaterThanOrEqual(spawnCount);
+    });
+  }
+});

--- a/src/commands/learn.ts
+++ b/src/commands/learn.ts
@@ -196,11 +196,13 @@ export async function learnObserveCommand(options: { failure?: boolean; prompt?:
           ? spawn([`"${exe}"`, ...argsArray.map(quoteForWindows)].join(' '), {
               detached: true,
               stdio: ['ignore', logFd, logFd],
+              windowsHide: true,
               shell: true,
             })
           : spawn(exe, argsArray, {
               detached: true,
               stdio: ['ignore', logFd, logFd],
+              windowsHide: true,
             });
         // If spawn fails the child never advances lastAnalysisEventCount, so without
         // this guard every subsequent observe call past the threshold re-fires the

--- a/src/commands/score.ts
+++ b/src/commands/score.ts
@@ -34,6 +34,7 @@ function scoreBaseRef(
         const content = execFileSync('git', ['show', `${ref}:${file}`], {
           encoding: 'utf-8',
           stdio: ['pipe', 'pipe', 'pipe'],
+          windowsHide: true,
         });
         fs.writeFileSync(path.join(tmpDir, file), content);
       } catch {
@@ -45,6 +46,7 @@ function scoreBaseRef(
         const files = execFileSync('git', ['ls-tree', '-r', '--name-only', ref, `${dir}/`], {
           encoding: 'utf-8',
           stdio: ['pipe', 'pipe', 'pipe'],
+          windowsHide: true,
         })
           .trim()
           .split('\n')
@@ -55,6 +57,7 @@ function scoreBaseRef(
           const content = execFileSync('git', ['show', `${ref}:${file}`], {
             encoding: 'utf-8',
             stdio: ['pipe', 'pipe', 'pipe'],
+            windowsHide: true,
           });
           fs.writeFileSync(filePath, content);
         }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -15,6 +15,7 @@ export function getLearningDir(): string {
     const gitCommonDir = execSync('git rev-parse --git-common-dir', {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim();
     const mainRoot = path.dirname(path.resolve(gitCommonDir));
     _learningDirCache = path.join(mainRoot, CALIBER_DIR, 'learning');

--- a/src/fingerprint/cache.ts
+++ b/src/fingerprint/cache.ts
@@ -29,6 +29,7 @@ function getGitHead(dir: string): string {
       cwd: dir,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
       timeout: 3000,
     }).trim();
   } catch {
@@ -42,6 +43,7 @@ function getDirtySignature(dir: string): string {
       cwd: dir,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
       timeout: 3000,
     }).trim();
     return output.split('\n').slice(0, 100).join('\n');

--- a/src/fingerprint/code-analysis.ts
+++ b/src/fingerprint/code-analysis.ts
@@ -447,7 +447,7 @@ function getGitFrequency(dir: string): Map<string, number> {
   try {
     const output = execSync(
       'git log --since="6 months ago" --format="" --name-only --diff-filter=ACMR 2>/dev/null | head -10000',
-      { cwd: dir, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 5000 },
+      { cwd: dir, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 5000 }, { windowsHide: true }
     );
     for (const line of output.split('\n')) {
       const trimmed = line.trim();

--- a/src/fingerprint/code-analysis.ts
+++ b/src/fingerprint/code-analysis.ts
@@ -447,7 +447,13 @@ function getGitFrequency(dir: string): Map<string, number> {
   try {
     const output = execSync(
       'git log --since="6 months ago" --format="" --name-only --diff-filter=ACMR 2>/dev/null | head -10000',
-      { cwd: dir, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], timeout: 5000 }, { windowsHide: true }
+      {
+        cwd: dir,
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        timeout: 5000,
+        windowsHide: true,
+      },
     );
     for (const line of output.split('\n')) {
       const trimmed = line.trim();

--- a/src/fingerprint/file-tree.ts
+++ b/src/fingerprint/file-tree.ts
@@ -40,6 +40,7 @@ function getGitTrackedFiles(dir: string): string[] | null {
       encoding: 'utf-8',
       maxBuffer: 10 * 1024 * 1024,
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     });
     return output.trim().split('\n').filter(Boolean);
   } catch {

--- a/src/fingerprint/git.ts
+++ b/src/fingerprint/git.ts
@@ -18,6 +18,7 @@ export function getGitRemoteUrl(cwd?: string): string | undefined {
     return execSync('git remote get-url origin', {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
       ...(cwd ? { cwd, timeout: 3000 } : {}),
     }).trim();
   } catch {

--- a/src/fingerprint/large-file-filter.ts
+++ b/src/fingerprint/large-file-filter.ts
@@ -25,6 +25,7 @@ function getGitIgnoredPaths(
       encoding: 'utf-8',
       input: relativePaths.join('\n'),
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     });
     return new Set(
       (result as string)

--- a/src/lib/__tests__/resolve-caliber.test.ts
+++ b/src/lib/__tests__/resolve-caliber.test.ts
@@ -6,8 +6,10 @@ import {
   isCaliberCommand,
   pickExecutable,
   displayCaliberName,
+  resolveCaliberHookInvoker,
 } from '../resolve-caliber.js';
 import { execSync } from 'child_process';
+import fs from 'fs';
 
 function withPlatform(platform: NodeJS.Platform, fn: () => void): void {
   const original = process.platform;
@@ -311,5 +313,108 @@ describe('displayCaliberName (F-P0-3)', () => {
     expect(display).not.toMatch(/^\//);
     expect(display).not.toContain('.nvm');
     expect(display).not.toContain('Users');
+  });
+});
+
+describe('resolveCaliberHookInvoker (Windows cmd-shim bypass)', () => {
+  let originalArgv: string[];
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    resetResolvedCaliber();
+    originalArgv = [...process.argv];
+    originalEnv = { ...process.env };
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    process.env = originalEnv;
+    resetResolvedCaliber();
+    vi.restoreAllMocks();
+  });
+
+  it('on POSIX returns the resolveCaliber() value unchanged', () => {
+    withPlatform('linux', () => {
+      mockedExecSync.mockReturnValue('/usr/local/bin/caliber\n');
+      expect(resolveCaliberHookInvoker()).toBe('/usr/local/bin/caliber');
+    });
+  });
+
+  it('on Windows returns the .cmd path unchanged when bin.js is missing', () => {
+    withPlatform('win32', () => {
+      // No bin.js sibling (existsSync mock returns false by default).
+      mockedExecSync.mockReturnValue('C:\\Users\\u\\AppData\\Roaming\\npm\\caliber.cmd\n');
+      const got = resolveCaliberHookInvoker();
+      expect(got).toBe('C:\\Users\\u\\AppData\\Roaming\\npm\\caliber.cmd');
+    });
+  });
+
+  it('on Windows returns node-direct invocation when .cmd + bin.js + node are present', () => {
+    withPlatform('win32', () => {
+      // Two execSync calls: first `where caliber`, then `where node`.
+      mockedExecSync
+        .mockReturnValueOnce('C:\\Users\\u\\AppData\\Roaming\\npm\\caliber.cmd\n')
+        .mockReturnValueOnce('C:\\Program Files\\nodejs\\node.exe\n');
+      // bin.js sibling exists.
+      vi.spyOn(fs, 'existsSync').mockImplementation(
+        (p) =>
+          String(p).endsWith('@rely-ai\\caliber\\dist\\bin.js') ||
+          String(p).endsWith('@rely-ai/caliber/dist/bin.js'),
+      );
+
+      const got = resolveCaliberHookInvoker();
+      // Forward-slashed both paths, both quoted, no `caliber.cmd` anywhere.
+      expect(got).toContain('"C:/Program Files/nodejs/node.exe"');
+      expect(got).toContain('@rely-ai/caliber/dist/bin.js"');
+      expect(got).not.toContain('.cmd');
+    });
+  });
+
+  it('on Windows falls back to .cmd when `where node` fails', () => {
+    withPlatform('win32', () => {
+      mockedExecSync
+        .mockReturnValueOnce('C:\\Users\\u\\AppData\\Roaming\\npm\\caliber.cmd\n')
+        .mockImplementationOnce(() => {
+          throw new Error('node not on PATH');
+        });
+      vi.spyOn(fs, 'existsSync').mockReturnValue(true);
+
+      const got = resolveCaliberHookInvoker();
+      expect(got).toBe('C:\\Users\\u\\AppData\\Roaming\\npm\\caliber.cmd');
+    });
+  });
+
+  it('caches per process — second call does not re-shell out', () => {
+    withPlatform('linux', () => {
+      mockedExecSync.mockReturnValue('/usr/local/bin/caliber\n');
+      const first = resolveCaliberHookInvoker();
+      const callsAfterFirst = mockedExecSync.mock.calls.length;
+      const second = resolveCaliberHookInvoker();
+      expect(second).toBe(first);
+      expect(mockedExecSync.mock.calls.length).toBe(callsAfterFirst);
+    });
+  });
+});
+
+describe('isCaliberCommand — node-direct + .cmd shim variants', () => {
+  it('matches the node-direct hook invoker output format', () => {
+    const cmd =
+      '"C:/Program Files/nodejs/node.exe" ' +
+      '"C:/Users/u/AppData/Roaming/npm/node_modules/@rely-ai/caliber/dist/bin.js" ' +
+      'learn observe';
+    expect(isCaliberCommand(cmd, 'learn observe')).toBe(true);
+  });
+
+  it('matches an absolute caliber.cmd shim invocation', () => {
+    const cmd = '"C:\\Users\\u\\AppData\\Roaming\\npm\\caliber.cmd" learn observe';
+    expect(isCaliberCommand(cmd, 'learn observe')).toBe(true);
+  });
+
+  it('does not match unrelated bin.js paths', () => {
+    const cmd =
+      '"C:/Program Files/nodejs/node.exe" ' +
+      '"C:/some/other/package/dist/bin.js" ' +
+      'learn observe';
+    expect(isCaliberCommand(cmd, 'learn observe')).toBe(false);
   });
 });

--- a/src/lib/__tests__/resolve-caliber.test.ts
+++ b/src/lib/__tests__/resolve-caliber.test.ts
@@ -370,6 +370,31 @@ describe('resolveCaliberHookInvoker (Windows cmd-shim bypass)', () => {
     });
   });
 
+  it('on Windows returns wscript-wrapped form when hook-runner.vbs is also present', () => {
+    withPlatform('win32', () => {
+      mockedExecSync
+        .mockReturnValueOnce('C:\\Users\\u\\AppData\\Roaming\\npm\\caliber.cmd\n')
+        .mockReturnValueOnce('C:\\Program Files\\nodejs\\node.exe\n');
+      // Both bin.js AND hook-runner.vbs sibling exist.
+      vi.spyOn(fs, 'existsSync').mockImplementation(
+        (p) =>
+          String(p).endsWith('@rely-ai\\caliber\\dist\\bin.js') ||
+          String(p).endsWith('@rely-ai/caliber/dist/bin.js') ||
+          String(p).endsWith('@rely-ai\\caliber\\dist\\hook-runner.vbs') ||
+          String(p).endsWith('@rely-ai/caliber/dist/hook-runner.vbs'),
+      );
+
+      const got = resolveCaliberHookInvoker();
+      // Starts with wscript invocation; wraps both the VBS and the
+      // node+bin.js arguments. Forward-slashed paths throughout.
+      expect(got).toMatch(/^wscript /);
+      expect(got).toContain('//nologo');
+      expect(got).toContain('@rely-ai/caliber/dist/hook-runner.vbs"');
+      expect(got).toContain('"C:/Program Files/nodejs/node.exe"');
+      expect(got).toContain('@rely-ai/caliber/dist/bin.js"');
+    });
+  });
+
   it('on Windows falls back to .cmd when `where node` fails', () => {
     withPlatform('win32', () => {
       mockedExecSync

--- a/src/lib/__tests__/resolve-caliber.test.ts
+++ b/src/lib/__tests__/resolve-caliber.test.ts
@@ -370,26 +370,47 @@ describe('resolveCaliberHookInvoker (Windows cmd-shim bypass)', () => {
     });
   });
 
-  it('on Windows returns wscript-wrapped form when hook-runner.vbs is also present', () => {
+  it('on Windows returns wscript-wrapped form when hook-runner.vbs and wscript are present', () => {
     withPlatform('win32', () => {
       mockedExecSync
         .mockReturnValueOnce('C:\\Users\\u\\AppData\\Roaming\\npm\\caliber.cmd\n')
-        .mockReturnValueOnce('C:\\Program Files\\nodejs\\node.exe\n');
-      // Both bin.js AND hook-runner.vbs sibling exist.
+        .mockReturnValueOnce('C:\\Program Files\\nodejs\\node.exe\n')
+        .mockReturnValueOnce('C:\\Windows\\System32\\wscript.exe\n');
       vi.spyOn(fs, 'existsSync').mockImplementation(
         (p) =>
           String(p).endsWith('@rely-ai\\caliber\\dist\\bin.js') ||
           String(p).endsWith('@rely-ai/caliber/dist/bin.js') ||
           String(p).endsWith('@rely-ai\\caliber\\dist\\hook-runner.vbs') ||
-          String(p).endsWith('@rely-ai/caliber/dist/hook-runner.vbs'),
+          String(p).endsWith('@rely-ai/caliber/dist/hook-runner.vbs') ||
+          String(p).endsWith('hook-runner.vbs'),
       );
 
       const got = resolveCaliberHookInvoker();
-      // Starts with wscript invocation; wraps both the VBS and the
-      // node+bin.js arguments. Forward-slashed paths throughout.
       expect(got).toMatch(/^wscript /);
       expect(got).toContain('//nologo');
-      expect(got).toContain('@rely-ai/caliber/dist/hook-runner.vbs"');
+      expect(got).toContain('hook-runner.vbs"');
+      expect(got).toContain('"C:/Program Files/nodejs/node.exe"');
+      expect(got).toContain('@rely-ai/caliber/dist/bin.js"');
+    });
+  });
+
+  it('on Windows falls back to node-direct when VBS exists but wscript is unavailable', () => {
+    withPlatform('win32', () => {
+      mockedExecSync
+        .mockReturnValueOnce('C:\\Users\\u\\AppData\\Roaming\\npm\\caliber.cmd\n')
+        .mockReturnValueOnce('C:\\Program Files\\nodejs\\node.exe\n')
+        .mockImplementationOnce(() => {
+          throw new Error('wscript not on PATH');
+        });
+      vi.spyOn(fs, 'existsSync').mockImplementation(
+        (p) =>
+          String(p).endsWith('@rely-ai\\caliber\\dist\\bin.js') ||
+          String(p).endsWith('@rely-ai/caliber/dist/bin.js') ||
+          String(p).endsWith('hook-runner.vbs'),
+      );
+
+      const got = resolveCaliberHookInvoker();
+      expect(got).not.toMatch(/^wscript /);
       expect(got).toContain('"C:/Program Files/nodejs/node.exe"');
       expect(got).toContain('@rely-ai/caliber/dist/bin.js"');
     });

--- a/src/lib/git-diff.ts
+++ b/src/lib/git-diff.ts
@@ -36,6 +36,7 @@ function safeExec(cmd: string): string {
     return execSync(cmd, {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
       maxBuffer: 10 * 1024 * 1024,
     }).trim();
   } catch {

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -456,6 +456,7 @@ function tryWindowsDirectNodeInvocation(cmd: string): string | null {
     const out = execSync('where node', {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim();
     nodePath = pickExecutable(out);
     if (!nodePath) return null;
@@ -544,6 +545,7 @@ function getGitHooksDir(): string | null {
     const gitDir = execSync('git rev-parse --git-dir', {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim();
     return path.join(gitDir, 'hooks');
   } catch {

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -5,7 +5,7 @@ import {
   resolveCaliber,
   isCaliberCommand,
   isNpxResolution,
-  pickExecutable,
+  resolveWindowsNodeBinInvocation,
 } from './resolve-caliber.js';
 import { bashPath } from '../utils/windows.js';
 
@@ -14,7 +14,10 @@ const REFRESH_TAIL = 'refresh --quiet';
 const HOOK_DESCRIPTION = 'Caliber: auto-refreshing docs based on code changes';
 
 function getHookCommand(): string {
-  return `${resolveCaliber()} ${REFRESH_TAIL}`;
+  // Use node-direct on Windows (no VBS — SessionEnd may need stdout).
+  const cmd = resolveCaliber();
+  const direct = resolveWindowsNodeBinInvocation(cmd);
+  return `${direct ?? cmd} ${REFRESH_TAIL}`;
 }
 
 interface HookEntry {
@@ -429,46 +432,12 @@ const PRECOMMIT_ANY_VERSION_BLOCK_RE =
  * to an elevated cmd window, prompting users to suspect privilege
  * escalation when there is none.
  *
- * The fix is to call node directly on the package's `bin.js`. The bash
- * pre-commit hook runs `node "...bin.js" refresh` instead of invoking
- * the shim, eliminating the cmd flash entirely. Forward-slashed paths
- * are required for Git-for-Windows bash (same invariant as PR #195).
- *
- * Returns null when the transformation can't apply — non-Windows, the
- * resolved path isn't a `.cmd`, the conventional npm layout doesn't
- * hold (pnpm, yarn-classic, custom prefix), or `node` isn't on PATH.
- * Callers fall back to the original `.cmd` invocation in that case.
+ * Delegates to ``resolveWindowsNodeBinInvocation`` (shared with the
+ * learning-hook invoker). Returns null when the transformation can't
+ * apply — callers fall back to the original `.cmd` invocation.
  */
 function tryWindowsDirectNodeInvocation(cmd: string): string | null {
-  if (process.platform !== 'win32') return null;
-  if (!/\.cmd$/i.test(cmd)) return null;
-
-  // The .cmd shim sits next to a node_modules/@rely-ai/caliber/dist/bin.js
-  // tree in the standard npm-global layout. If that file isn't where we
-  // expect (pnpm symlinks, custom prefix), bail out so the user keeps the
-  // working .cmd path.
-  const npmDir = path.dirname(cmd);
-  const binJs = path.join(npmDir, 'node_modules', '@rely-ai', 'caliber', 'dist', 'bin.js');
-  if (!fs.existsSync(binJs)) return null;
-
-  let nodePath: string;
-  try {
-    const out = execSync('where node', {
-      encoding: 'utf-8',
-      stdio: ['pipe', 'pipe', 'pipe'],
-      windowsHide: true,
-    }).trim();
-    nodePath = pickExecutable(out);
-    if (!nodePath) return null;
-  } catch {
-    return null;
-  }
-
-  // Forward-slash both paths so Git-for-Windows bash treats them as
-  // literal path strings rather than escape sequences.
-  const fwdNode = nodePath.replace(/\\/g, '/');
-  const fwdBin = binJs.replace(/\\/g, '/');
-  return `"${fwdNode}" "${fwdBin}"`;
+  return resolveWindowsNodeBinInvocation(cmd);
 }
 
 function getPrecommitBlock(): string {

--- a/src/lib/learning-hooks.ts
+++ b/src/lib/learning-hooks.ts
@@ -1,20 +1,42 @@
 import fs from 'fs';
 import path from 'path';
-import { resolveCaliber, isCaliberCommand } from './resolve-caliber.js';
+import { resolveCaliberHookInvoker, isCaliberCommand } from './resolve-caliber.js';
 
 // ── Claude Code hooks ────────────────────────────────────────────────
 
 const SETTINGS_PATH = path.join('.claude', 'settings.json');
 
 const HOOK_TAILS = [
-  { event: 'PostToolUse', tail: 'learn observe', description: 'Caliber: recording tool usage for session learning' },
-  { event: 'PostToolUseFailure', tail: 'learn observe --failure', description: 'Caliber: recording tool failure for session learning' },
-  { event: 'UserPromptSubmit', tail: 'learn observe --prompt', description: 'Caliber: recording user prompt for correction detection' },
-  { event: 'SessionEnd', tail: 'learn finalize --auto', description: 'Caliber: finalizing session learnings' },
+  {
+    event: 'PostToolUse',
+    tail: 'learn observe',
+    description: 'Caliber: recording tool usage for session learning',
+  },
+  {
+    event: 'PostToolUseFailure',
+    tail: 'learn observe --failure',
+    description: 'Caliber: recording tool failure for session learning',
+  },
+  {
+    event: 'UserPromptSubmit',
+    tail: 'learn observe --prompt',
+    description: 'Caliber: recording user prompt for correction detection',
+  },
+  {
+    event: 'SessionEnd',
+    tail: 'learn finalize --auto',
+    description: 'Caliber: finalizing session learnings',
+  },
 ] as const;
 
 function getHookConfigs() {
-  const bin = resolveCaliber();
+  // resolveCaliberHookInvoker() returns node-direct invocation on
+  // Windows when the resolved caliber binary is a ``.cmd`` shim
+  // (npm-global layout), bypassing the visible cmd.exe flash that
+  // Claude Code would otherwise see on every hook fire. POSIX and
+  // non-shim Windows installs fall through to the plain
+  // ``resolveCaliber()`` path unchanged.
+  const bin = resolveCaliberHookInvoker();
   return HOOK_TAILS.map(({ event, tail, description }) => ({
     event,
     command: `${bin} ${tail}`,
@@ -55,14 +77,14 @@ function writeSettings(settings: ClaudeSettings): void {
 }
 
 function hasLearningHook(matchers: HookMatcher[], tail: string): boolean {
-  return matchers.some(entry => entry.hooks?.some(h => isCaliberCommand(h.command, tail)));
+  return matchers.some((entry) => entry.hooks?.some((h) => isCaliberCommand(h.command, tail)));
 }
 
 export function areLearningHooksInstalled(): boolean {
   const settings = readSettings();
   if (!settings.hooks) return false;
 
-  return HOOK_TAILS.every(cfg => {
+  return HOOK_TAILS.every((cfg) => {
     const matchers = settings.hooks![cfg.event];
     return Array.isArray(matchers) && hasLearningHook(matchers, cfg.tail);
   });
@@ -127,12 +149,12 @@ function writeCursorHooks(config: CursorHooksConfig): void {
 }
 
 function hasCursorHook(entries: Array<{ command: string }>, tail: string): boolean {
-  return entries.some(e => isCaliberCommand(e.command, tail));
+  return entries.some((e) => isCaliberCommand(e.command, tail));
 }
 
 export function areCursorLearningHooksInstalled(): boolean {
   const config = readCursorHooks();
-  return CURSOR_HOOK_EVENTS.every(cfg => {
+  return CURSOR_HOOK_EVENTS.every((cfg) => {
     const entries = config.hooks[cfg.event];
     return Array.isArray(entries) && hasCursorHook(entries, cfg.tail);
   });
@@ -144,7 +166,9 @@ export function installCursorLearningHooks(): { installed: boolean; alreadyInsta
   }
 
   const config = readCursorHooks();
-  const bin = resolveCaliber();
+  // Same Windows cmd-shim bypass as the Claude Code installer — see
+  // ``resolveCaliberHookInvoker`` for the rationale.
+  const bin = resolveCaliberHookInvoker();
 
   for (const cfg of CURSOR_HOOK_EVENTS) {
     if (!Array.isArray(config.hooks[cfg.event])) {
@@ -167,7 +191,7 @@ export function removeCursorLearningHooks(): { removed: boolean; notFound: boole
     const entries = config.hooks[cfg.event];
     if (!Array.isArray(entries)) continue;
 
-    const idx = entries.findIndex(e => isCaliberCommand(e.command, cfg.tail));
+    const idx = entries.findIndex((e) => isCaliberCommand(e.command, cfg.tail));
     if (idx !== -1) {
       entries.splice(idx, 1);
       removedAny = true;
@@ -193,7 +217,9 @@ export function removeLearningHooks(): { removed: boolean; notFound: boolean } {
     const matchers = settings.hooks[cfg.event];
     if (!Array.isArray(matchers)) continue;
 
-    const idx = matchers.findIndex(entry => entry.hooks?.some(h => isCaliberCommand(h.command, cfg.tail)));
+    const idx = matchers.findIndex((entry) =>
+      entry.hooks?.some((h) => isCaliberCommand(h.command, cfg.tail)),
+    );
     if (idx !== -1) {
       matchers.splice(idx, 1);
       removedAny = true;

--- a/src/lib/resolve-caliber.ts
+++ b/src/lib/resolve-caliber.ts
@@ -145,54 +145,21 @@ export function resetResolvedCaliber(): void {
 let _resolvedHookInvoker: string | null = null;
 
 /**
- * Return the command prefix to embed in hook command strings — Claude
- * settings.json, Cursor hooks.json, pre-commit shells, etc.
+ * Shared Windows cmd-shim bypass: given a ``caliber.cmd`` path, return
+ * ``"<node>" "<.../dist/bin.js>"`` so callers can skip ``cmd.exe``.
+ * Used by both the pre-commit hook (needs stdout — no VBS) and the
+ * Claude/Cursor learning-hook invoker (may wrap with VBS).
  *
- * On Windows the default ``resolveCaliber()`` lands on a ``caliber.cmd``
- * npm shim. When Claude Code / Cursor / a pre-commit hook spawns that
- * command, the OS spawns ``cmd.exe`` to read the shim, which allocates
- * a visible console window for the duration of the call — a brief
- * black flash on every hook fire. Under active editor / agent use this
- * stacks to multiple flashes per second.
- *
- * The fix is to invoke Node directly on the package's ``bin.js``,
- * skipping the cmd-shim entirely. When the resolved binary is a
- * ``.cmd`` that sits next to a ``node_modules/@rely-ai/caliber/dist/
- * bin.js`` (the standard npm-global layout), we return
- * ``"<node-fwd>" "<bin.js-fwd>"`` — two forward-slashed quoted paths
- * that work both as the ``command`` value in a JSON hook entry and
- * as the first half of a Git-for-Windows bash ``"$cmd" subcommand``
- * line.
- *
- * Falls back to ``resolveCaliber()`` unchanged when:
- *   - we're not on Windows (no cmd-shim flash to fix);
- *   - the resolved binary isn't a ``.cmd`` (already-direct path);
- *   - the conventional npm layout doesn't hold (pnpm symlinks, yarn
- *     classic, custom prefix — ``bin.js`` not where we expect);
- *   - ``node`` isn't on PATH (``where node`` fails).
- *
- * Cached per process. The resolution is hot — ``where node`` +
- * ``existsSync`` on a known path — but called repeatedly during hook
- * installation across many projects.
+ * Returns null when the transformation can't apply — non-Windows, not
+ * a ``.cmd``, unconventional npm layout, or ``node`` missing from PATH.
  */
-export function resolveCaliberHookInvoker(): string {
-  if (_resolvedHookInvoker) return _resolvedHookInvoker;
+export function resolveWindowsNodeBinInvocation(cmd: string): string | null {
+  if (process.platform !== 'win32') return null;
+  if (!/\.cmd$/i.test(cmd)) return null;
 
-  const base = resolveCaliber();
-
-  if (process.platform !== 'win32' || !/\.cmd$/i.test(base)) {
-    _resolvedHookInvoker = base;
-    return _resolvedHookInvoker;
-  }
-
-  // npm-global layout: <prefix>/caliber.cmd lives next to
-  // <prefix>/node_modules/@rely-ai/caliber/dist/bin.js
-  const npmDir = path.dirname(base);
+  const npmDir = path.dirname(cmd);
   const binJs = path.join(npmDir, 'node_modules', '@rely-ai', 'caliber', 'dist', 'bin.js');
-  if (!fs.existsSync(binJs)) {
-    _resolvedHookInvoker = base;
-    return _resolvedHookInvoker;
-  }
+  if (!fs.existsSync(binJs)) return null;
 
   let nodePath: string;
   try {
@@ -202,46 +169,68 @@ export function resolveCaliberHookInvoker(): string {
       windowsHide: true,
     }).trim();
     nodePath = pickExecutable(out);
-    if (!nodePath) {
-      _resolvedHookInvoker = base;
-      return _resolvedHookInvoker;
-    }
+    if (!nodePath) return null;
   } catch {
+    return null;
+  }
+
+  const fwdNode = nodePath.replace(/\\/g, '/');
+  const fwdBin = binJs.replace(/\\/g, '/');
+  return `"${fwdNode}" "${fwdBin}"`;
+}
+
+function isWscriptAvailable(): boolean {
+  try {
+    const out = execSync('where wscript', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
+    }).trim();
+    return Boolean(pickExecutable(out));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Return the command prefix to embed in fire-and-forget hook command
+ * strings (Claude settings.json / Cursor hooks.json learning hooks).
+ *
+ * On Windows: bypass the ``.cmd`` shim via ``resolveWindowsNodeBinInvocation``,
+ * then optionally wrap with ``wscript`` + ``hook-runner.vbs`` when WSH is
+ * available (hides the node.exe console flash). If VBS is present but
+ * ``wscript`` is missing/blocked (Group Policy / AV), fall back to the
+ * node-direct form rather than a hard hook failure.
+ *
+ * Do **not** use the VBS wrapper for hooks that need stdout (pre-commit,
+ * SessionEnd refresh) — use ``resolveWindowsNodeBinInvocation`` directly.
+ */
+export function resolveCaliberHookInvoker(): string {
+  if (_resolvedHookInvoker) return _resolvedHookInvoker;
+
+  const base = resolveCaliber();
+  const nodeDirect = resolveWindowsNodeBinInvocation(base);
+  if (!nodeDirect) {
     _resolvedHookInvoker = base;
     return _resolvedHookInvoker;
   }
 
-  // Forward-slash both paths so Git-for-Windows bash (pre-commit) and
-  // direct CreateProcess (Claude Code) both treat them as literal path
-  // strings rather than escape sequences.
-  const fwdNode = nodePath.replace(/\\/g, '/');
-  const fwdBin = binJs.replace(/\\/g, '/');
-
-  // Second visible-flash layer: even when node.exe is invoked directly
-  // (no cmd-shim), Claude Code spawns it as a hook child without
-  // ``windowsHide: true`` (anthropics/claude-code#19012 — closed as
-  // "not planned" Apr 2026). node.exe is console-subsystem and Windows
-  // allocates a fresh console for it that flashes on every PostToolUse
-  // / UserPromptSubmit / SessionEnd fire. Upstream's recommended
-  // workaround is a VBS wrapper run via wscript.exe (windows-subsystem,
-  // no console) that ``WScript.Shell.Run(cmd, 0, True)`` to launch the
-  // node child hidden + wait for exit + propagate the exit code.
-  //
-  // We co-locate ``hook-runner.vbs`` next to bin.js in the dist tree;
-  // when it's there, return the wscript-wrapped invocation. When the
-  // VBS is absent (older Caliber install, partial extract), fall back
-  // to the bare node-direct form — still bypasses the cmd-shim flash
-  // even if the node.exe flash remains.
-  const vbsPath = path.join(path.dirname(binJs), 'hook-runner.vbs');
-  if (fs.existsSync(vbsPath)) {
+  // Parse `"node" "bin.js"` back to paths for optional VBS wrapping.
+  const match = nodeDirect.match(/^"([^"]+)" "([^"]+)"$/);
+  if (!match) {
+    _resolvedHookInvoker = nodeDirect;
+    return _resolvedHookInvoker;
+  }
+  const [, fwdNode, fwdBin] = match;
+  // hook-runner.vbs is co-located with bin.js in dist/
+  const vbsPath = fwdBin.replace(/bin\.js$/i, 'hook-runner.vbs');
+  if (fs.existsSync(vbsPath) && isWscriptAvailable()) {
     const fwdVbs = vbsPath.replace(/\\/g, '/');
-    // wscript on PATH (always at C:\Windows\System32\wscript.exe).
-    // ``//nologo`` suppresses the WSH banner; harmless if absent.
     _resolvedHookInvoker = `wscript //nologo "${fwdVbs}" "${fwdNode}" "${fwdBin}"`;
     return _resolvedHookInvoker;
   }
 
-  _resolvedHookInvoker = `"${fwdNode}" "${fwdBin}"`;
+  _resolvedHookInvoker = nodeDirect;
   return _resolvedHookInvoker;
 }
 

--- a/src/lib/resolve-caliber.ts
+++ b/src/lib/resolve-caliber.ts
@@ -216,6 +216,31 @@ export function resolveCaliberHookInvoker(): string {
   // strings rather than escape sequences.
   const fwdNode = nodePath.replace(/\\/g, '/');
   const fwdBin = binJs.replace(/\\/g, '/');
+
+  // Second visible-flash layer: even when node.exe is invoked directly
+  // (no cmd-shim), Claude Code spawns it as a hook child without
+  // ``windowsHide: true`` (anthropics/claude-code#19012 — closed as
+  // "not planned" Apr 2026). node.exe is console-subsystem and Windows
+  // allocates a fresh console for it that flashes on every PostToolUse
+  // / UserPromptSubmit / SessionEnd fire. Upstream's recommended
+  // workaround is a VBS wrapper run via wscript.exe (windows-subsystem,
+  // no console) that ``WScript.Shell.Run(cmd, 0, True)`` to launch the
+  // node child hidden + wait for exit + propagate the exit code.
+  //
+  // We co-locate ``hook-runner.vbs`` next to bin.js in the dist tree;
+  // when it's there, return the wscript-wrapped invocation. When the
+  // VBS is absent (older Caliber install, partial extract), fall back
+  // to the bare node-direct form — still bypasses the cmd-shim flash
+  // even if the node.exe flash remains.
+  const vbsPath = path.join(path.dirname(binJs), 'hook-runner.vbs');
+  if (fs.existsSync(vbsPath)) {
+    const fwdVbs = vbsPath.replace(/\\/g, '/');
+    // wscript on PATH (always at C:\Windows\System32\wscript.exe).
+    // ``//nologo`` suppresses the WSH banner; harmless if absent.
+    _resolvedHookInvoker = `wscript //nologo "${fwdVbs}" "${fwdNode}" "${fwdBin}"`;
+    return _resolvedHookInvoker;
+  }
+
   _resolvedHookInvoker = `"${fwdNode}" "${fwdBin}"`;
   return _resolvedHookInvoker;
 }
@@ -248,6 +273,10 @@ export function isCaliberCommand(command: string, subcommandTail: string): boole
   // whitespace + tail; node prefix is variable across hosts so we don't
   // pin it. Accepts both forward and back slashes inside the quotes
   // because pre-commit shells store forward, claude.json stores either.
+  // ALSO matches the wscript-wrapped form
+  // 'wscript //nologo "<vbs>" "<node>" "<bin.js>" <tail>' because the
+  // bin.js suffix is identical — anything before it is wrapper noise
+  // that doesn't change the caliber identity of the command.
   if (
     /[\\/]@rely-ai[\\/]caliber[\\/]dist[\\/]bin\.js"? /i.test(command) &&
     command.endsWith(` ${subcommandTail}`)

--- a/src/lib/resolve-caliber.ts
+++ b/src/lib/resolve-caliber.ts
@@ -46,7 +46,7 @@ export function resolveCaliber(): string {
   if (isNpx) {
     // Prefer a globally-installed caliber over the ephemeral npx invocation
     try {
-      const out = execSync(whichCmd, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+      const out = execSync(whichCmd,{ encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true }).trim();
       const caliberPath = pickExecutable(out);
       if (caliberPath) {
         _resolved = caliberPath;
@@ -60,6 +60,7 @@ export function resolveCaliber(): string {
       const out = execSync(whichNpxCmd, {
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
       }).trim();
       const npxPath = pickExecutable(out);
       if (npxPath) {
@@ -79,6 +80,7 @@ export function resolveCaliber(): string {
     const out = execSync(whichCmd, {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim();
     const caliberPath = pickExecutable(out);
     if (caliberPath) {

--- a/src/lib/resolve-caliber.ts
+++ b/src/lib/resolve-caliber.ts
@@ -1,4 +1,5 @@
 import fs from 'fs';
+import path from 'path';
 import { execSync } from 'child_process';
 
 let _resolved: string | null = null;
@@ -46,7 +47,11 @@ export function resolveCaliber(): string {
   if (isNpx) {
     // Prefer a globally-installed caliber over the ephemeral npx invocation
     try {
-      const out = execSync(whichCmd,{ encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true }).trim();
+      const out = execSync(whichCmd, {
+        encoding: 'utf-8',
+        stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
+      }).trim();
       const caliberPath = pickExecutable(out);
       if (caliberPath) {
         _resolved = caliberPath;
@@ -134,6 +139,85 @@ export function displayCaliberName(): string {
 /** Reset cached resolution — only for tests. */
 export function resetResolvedCaliber(): void {
   _resolved = null;
+  _resolvedHookInvoker = null;
+}
+
+let _resolvedHookInvoker: string | null = null;
+
+/**
+ * Return the command prefix to embed in hook command strings — Claude
+ * settings.json, Cursor hooks.json, pre-commit shells, etc.
+ *
+ * On Windows the default ``resolveCaliber()`` lands on a ``caliber.cmd``
+ * npm shim. When Claude Code / Cursor / a pre-commit hook spawns that
+ * command, the OS spawns ``cmd.exe`` to read the shim, which allocates
+ * a visible console window for the duration of the call — a brief
+ * black flash on every hook fire. Under active editor / agent use this
+ * stacks to multiple flashes per second.
+ *
+ * The fix is to invoke Node directly on the package's ``bin.js``,
+ * skipping the cmd-shim entirely. When the resolved binary is a
+ * ``.cmd`` that sits next to a ``node_modules/@rely-ai/caliber/dist/
+ * bin.js`` (the standard npm-global layout), we return
+ * ``"<node-fwd>" "<bin.js-fwd>"`` — two forward-slashed quoted paths
+ * that work both as the ``command`` value in a JSON hook entry and
+ * as the first half of a Git-for-Windows bash ``"$cmd" subcommand``
+ * line.
+ *
+ * Falls back to ``resolveCaliber()`` unchanged when:
+ *   - we're not on Windows (no cmd-shim flash to fix);
+ *   - the resolved binary isn't a ``.cmd`` (already-direct path);
+ *   - the conventional npm layout doesn't hold (pnpm symlinks, yarn
+ *     classic, custom prefix — ``bin.js`` not where we expect);
+ *   - ``node`` isn't on PATH (``where node`` fails).
+ *
+ * Cached per process. The resolution is hot — ``where node`` +
+ * ``existsSync`` on a known path — but called repeatedly during hook
+ * installation across many projects.
+ */
+export function resolveCaliberHookInvoker(): string {
+  if (_resolvedHookInvoker) return _resolvedHookInvoker;
+
+  const base = resolveCaliber();
+
+  if (process.platform !== 'win32' || !/\.cmd$/i.test(base)) {
+    _resolvedHookInvoker = base;
+    return _resolvedHookInvoker;
+  }
+
+  // npm-global layout: <prefix>/caliber.cmd lives next to
+  // <prefix>/node_modules/@rely-ai/caliber/dist/bin.js
+  const npmDir = path.dirname(base);
+  const binJs = path.join(npmDir, 'node_modules', '@rely-ai', 'caliber', 'dist', 'bin.js');
+  if (!fs.existsSync(binJs)) {
+    _resolvedHookInvoker = base;
+    return _resolvedHookInvoker;
+  }
+
+  let nodePath: string;
+  try {
+    const out = execSync('where node', {
+      encoding: 'utf-8',
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
+    }).trim();
+    nodePath = pickExecutable(out);
+    if (!nodePath) {
+      _resolvedHookInvoker = base;
+      return _resolvedHookInvoker;
+    }
+  } catch {
+    _resolvedHookInvoker = base;
+    return _resolvedHookInvoker;
+  }
+
+  // Forward-slash both paths so Git-for-Windows bash (pre-commit) and
+  // direct CreateProcess (Claude Code) both treat them as literal path
+  // strings rather than escape sequences.
+  const fwdNode = nodePath.replace(/\\/g, '/');
+  const fwdBin = binJs.replace(/\\/g, '/');
+  _resolvedHookInvoker = `"${fwdNode}" "${fwdBin}"`;
+  return _resolvedHookInvoker;
 }
 
 /**
@@ -148,11 +232,27 @@ export function isCaliberCommand(command: string, subcommandTail: string): boole
   if (command === `caliber ${subcommandTail}`) return true;
   // Absolute-path match: ends with /caliber <tail>
   if (command.endsWith(`/caliber ${subcommandTail}`)) return true;
+  // Absolute-path match for Windows ``.cmd`` shim: ends with
+  // /caliber.cmd <tail> (case-insensitive .cmd suffix)
+  if (/[\\/]caliber\.cmd"? /i.test(command) && command.endsWith(` ${subcommandTail}`)) {
+    return true;
+  }
   // Bare npx match
   if (command === `npx --yes @rely-ai/caliber ${subcommandTail}`) return true;
   if (command === `npx @rely-ai/caliber ${subcommandTail}`) return true;
   // Absolute-path npx match: '/abs/path/npx --yes @rely-ai/caliber <tail>'
   if (command.endsWith(`/npx --yes @rely-ai/caliber ${subcommandTail}`)) return true;
   if (command.endsWith(`/npx @rely-ai/caliber ${subcommandTail}`)) return true;
+  // Node-direct invocation match: '"<node>" "<...caliber/dist/bin.js>" <tail>'
+  // — the Windows cmd-shim bypass. Matches the quoted bin.js suffix +
+  // whitespace + tail; node prefix is variable across hosts so we don't
+  // pin it. Accepts both forward and back slashes inside the quotes
+  // because pre-commit shells store forward, claude.json stores either.
+  if (
+    /[\\/]@rely-ai[\\/]caliber[\\/]dist[\\/]bin\.js"? /i.test(command) &&
+    command.endsWith(` ${subcommandTail}`)
+  ) {
+    return true;
+  }
   return false;
 }

--- a/src/lib/state.ts
+++ b/src/lib/state.ts
@@ -43,6 +43,7 @@ export function getCurrentHeadSha(): string | null {
     return execSync('git rev-parse HEAD', {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim();
   } catch {
     return null;

--- a/src/llm/__tests__/claude-cli.test.ts
+++ b/src/llm/__tests__/claude-cli.test.ts
@@ -347,7 +347,7 @@ describe('isClaudeCliAvailable', () => {
     // makes a second call (which claude --stdio:ignore) as the PATH check
     const lastCall = execSync.mock.calls[execSync.mock.calls.length - 1];
     expect(lastCall[0]).toContain('claude');
-    expect(lastCall[1]).toEqual({ stdio: 'ignore' });
+    expect(lastCall[1]).toEqual({ stdio: 'ignore', windowsHide: true });
   });
 
   it('returns false when claude is not found', () => {

--- a/src/llm/__tests__/cursor-acp.test.ts
+++ b/src/llm/__tests__/cursor-acp.test.ts
@@ -231,7 +231,7 @@ describe('isCursorAgentAvailable', () => {
     execSync.mockReturnValue(undefined);
     expect(isCursorAgentAvailable()).toBe(true);
     const expectedCmd = process.platform === 'win32' ? 'where agent' : 'which agent';
-    expect(execSync).toHaveBeenCalledWith(expectedCmd, { stdio: 'ignore' });
+    expect(execSync).toHaveBeenCalledWith(expectedCmd, { stdio: 'ignore', windowsHide: true });
   });
 
   it('returns true when found via well-known path', () => {

--- a/src/llm/__tests__/opencode.test.ts
+++ b/src/llm/__tests__/opencode.test.ts
@@ -618,7 +618,7 @@ describe('isOpenCodeAvailable', () => {
       expect(cmd).toContain('which');
       expect(cmd).toContain('opencode');
     }
-    expect(execSync.mock.calls[0][1]).toEqual({ stdio: 'ignore' });
+    expect(execSync.mock.calls[0][1]).toEqual({ stdio: 'ignore', windowsHide: true });
   });
 
   it('returns false when opencode is not found', () => {
@@ -641,6 +641,7 @@ describe('isOpenCodeLoggedIn', () => {
     expect(execSync).toHaveBeenCalledWith('opencode auth list', {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     });
   });
 

--- a/src/llm/claude-cli.ts
+++ b/src/llm/claude-cli.ts
@@ -45,7 +45,7 @@ function resolveClaudeBin(): string {
   // 1. Try PATH first — covers cases where the user has a custom install location
   try {
     const whichCmd = IS_WINDOWS ? 'where claude' : 'which claude';
-    const out = execSync(whichCmd, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+    const out = execSync(whichCmd,{ encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true }).trim();
     const p = out.split('\n')[0].trim();
     if (p) {
       _claudeBin = p;
@@ -117,15 +117,17 @@ function spawnClaude(args: string[]): ChildProcess {
       // `C:\Program Files\caliber\claude.cmd` (with spaces) would be parsed by
       // cmd.exe as multiple words. Quote each piece explicitly. Mirrors the
       // pattern used in cursor-acp.ts and the learn-finalize background spawn.
-      spawn([quoteForWindows(bin), ...args.map(quoteForWindows)].join(' '), {
+      spawn([quoteForWindows(bin), ...args.map(quoteForWindows)].join(' '),{
         cwd: process.cwd(),
         stdio: ['pipe', 'pipe', 'pipe'] as const,
         env,
         shell: true,
+        windowsHide: true,
       })
     : spawn(bin, args, {
         cwd: process.cwd(),
         stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
         env,
       });
 }
@@ -308,7 +310,7 @@ export function isClaudeCliAvailable(): boolean {
   // or falls back to bare 'claude'. If we got an absolute path, the binary exists.
   if (resolveClaudeBin() !== 'claude') return true;
   try {
-    execSync(IS_WINDOWS ? 'where claude' : 'which claude', { stdio: 'ignore' });
+    execSync(IS_WINDOWS ? 'where claude' : 'which claude',{ stdio: 'ignore', windowsHide: true });
     return true;
   } catch {
     return false;
@@ -329,6 +331,7 @@ export function isClaudeCliLoggedIn(): boolean {
     const result = execFileSync(resolveClaudeBin(), ['auth', 'status'], {
       input: '',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
       timeout: 5000,
       env: withCaliberSubprocessEnv(cleanClaudeEnv()),
     });

--- a/src/llm/cursor-acp.ts
+++ b/src/llm/cursor-acp.ts
@@ -47,7 +47,7 @@ function resolveAgentBin(): string {
   // 1. Try PATH first
   try {
     const whichCmd = IS_WINDOWS ? 'where agent' : 'which agent';
-    const out = execSync(whichCmd, { encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] }).trim();
+    const out = execSync(whichCmd,{ encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true }).trim();
     const lines = out
       .split('\n')
       .map((l) => l.trim())
@@ -162,11 +162,13 @@ export class CursorAcpProvider implements LLMProvider {
     this.warmProcess = IS_WINDOWS
       ? spawn([quoteForWindows(resolveAgentBin()), ...args.map(quoteForWindows)].join(' '), {
           stdio: ['pipe', 'pipe', 'pipe'],
+          windowsHide: true,
           env,
           shell: true,
         })
       : spawn(resolveAgentBin(), args, {
           stdio: ['pipe', 'pipe', 'pipe'],
+          windowsHide: true,
           env,
         });
     this.warmModel = targetModel;
@@ -230,11 +232,13 @@ export class CursorAcpProvider implements LLMProvider {
     const child = IS_WINDOWS
       ? spawn([quoteForWindows(resolveAgentBin()), ...args.map(quoteForWindows)].join(' '), {
           stdio: ['pipe', 'pipe', 'pipe'],
+          windowsHide: true,
           env,
           shell: true,
         })
       : spawn(resolveAgentBin(), args, {
           stdio: ['pipe', 'pipe', 'pipe'],
+          windowsHide: true,
           env,
         });
 
@@ -485,12 +489,14 @@ export async function listCursorModels(): Promise<string[]> {
       ? execSync(cmd!, {
           input: '.',
           stdio: ['pipe', 'pipe', 'pipe'],
+          windowsHide: true,
           timeout: 15000,
           env: withCaliberSubprocessEnv(process.env),
         })
       : execFileSync(bin, args, {
           input: '.',
           stdio: ['pipe', 'pipe', 'pipe'],
+          windowsHide: true,
           timeout: 15000,
           env: withCaliberSubprocessEnv(process.env),
         });
@@ -516,7 +522,7 @@ export function isCursorAgentAvailable(): boolean {
   // resolveAgentBin() returns an absolute path when `which agent` succeeded.
   if (resolveAgentBin() !== 'agent') return true;
   try {
-    execSync(IS_WINDOWS ? 'where agent' : 'which agent', { stdio: 'ignore' });
+    execSync(IS_WINDOWS ? 'where agent' : 'which agent',{ stdio: 'ignore', windowsHide: true });
     return true;
   } catch {
     return false;
@@ -533,12 +539,14 @@ export function isCursorLoggedIn(): boolean {
     const result = IS_WINDOWS
       ? execSync(`${quoteForWindows(bin)} status`, {
           stdio: ['pipe', 'pipe', 'pipe'],
+          windowsHide: true,
           timeout: 5000,
           env: withCaliberSubprocessEnv(process.env),
         })
       : execFileSync(bin, ['status'], {
           input: '',
           stdio: ['pipe', 'pipe', 'pipe'],
+          windowsHide: true,
           timeout: 5000,
           env: withCaliberSubprocessEnv(process.env),
         });
@@ -568,7 +576,7 @@ export function ensureBashShim(): { created: boolean; path: string } | null {
 
   // Check if `agent` is already resolvable by bash (unlikely for .cmd, but possible with a shim)
   try {
-    execSync('which agent', { stdio: 'ignore' });
+    execSync('which agent',{ stdio: 'ignore', windowsHide: true });
     return { created: false, path: bin };
   } catch {
     // not resolvable — create the shim

--- a/src/llm/opencode.ts
+++ b/src/llm/opencode.ts
@@ -30,7 +30,7 @@ export function resetOpenCodeLoginCache(): void {
 export function isOpenCodeAvailable(): boolean {
   try {
     const cmd = IS_WINDOWS ? `where ${OPENCODE_BIN}` : `which ${OPENCODE_BIN}`;
-    execSync(cmd, { stdio: 'ignore' });
+    execSync(cmd,{ stdio: 'ignore', windowsHide: true });
     return true;
   } catch {
     return false;
@@ -44,6 +44,7 @@ export function isOpenCodeLoggedIn(): boolean {
     const result = execSync('opencode auth list', {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     });
     // If command succeeds and returns non-empty output, user is logged in
     cachedLoggedIn = result.toString().trim().length > 0;
@@ -61,17 +62,19 @@ function spawnOpenCode(args: string[]): ChildProcess {
   // Same subprocess sentinel pattern as spawnClaude — see src/lib/subprocess-sentinel.ts.
   const env = withCaliberSubprocessEnv({ ...process.env, OPENCODE_DISABLE_AUTOCOMPACT: 'TRUE' });
   if (IS_WINDOWS) {
-    return spawn([OPENCODE_BIN, ...args].join(' '), {
+    return spawn([OPENCODE_BIN, ...args].join(' '),{
       cwd: process.cwd(),
       stdio: ['pipe', 'pipe', 'pipe'] as const,
       env,
       shell: true,
+      windowsHide: true,
     });
   } else {
-    return spawn(OPENCODE_BIN, args, {
+    return spawn(OPENCODE_BIN, args,{
       cwd: process.cwd(),
       stdio: ['pipe', 'pipe', 'pipe'] as const,
       env,
+      windowsHide: true,
     });
   }
 }

--- a/src/scoring/checks/accuracy.ts
+++ b/src/scoring/checks/accuracy.ts
@@ -23,7 +23,7 @@ function detectGitDrift(dir: string): {
 } {
   try {
     // Check if we're in a git repo
-    execSync('git rev-parse --git-dir', { cwd: dir, stdio: ['pipe', 'pipe', 'pipe'] });
+    execSync('git rev-parse --git-dir',{ cwd: dir, stdio: ['pipe', 'pipe', 'pipe'], windowsHide: true });
   } catch {
     return { commitsSinceConfigUpdate: 0, lastConfigCommit: null, isGitRepo: false };
   }
@@ -37,6 +37,7 @@ function detectGitDrift(dir: string): {
       cwd: dir,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim();
     const headTime = parseInt(headTimestamp, 10) * 1000;
 
@@ -68,6 +69,7 @@ function detectGitDrift(dir: string): {
         cwd: dir,
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
       }).trim();
       if (!hash) continue;
 
@@ -79,6 +81,7 @@ function detectGitDrift(dir: string): {
           execSync(`git merge-base --is-ancestor ${latestConfigCommitHash} ${hash}`, {
             cwd: dir,
             stdio: ['pipe', 'pipe', 'pipe'],
+            windowsHide: true,
           });
           latestConfigCommitHash = hash;
         } catch {
@@ -100,6 +103,7 @@ function detectGitDrift(dir: string): {
       cwd: dir,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim();
     const commitsSince = parseInt(countStr, 10) || 0;
 
@@ -107,6 +111,7 @@ function detectGitDrift(dir: string): {
       cwd: dir,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim();
 
     return {

--- a/src/scoring/checks/bonus.ts
+++ b/src/scoring/checks/bonus.ts
@@ -20,6 +20,7 @@ function hasPreCommitHook(dir: string): boolean {
       cwd: dir,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim();
     const hookPath = join(gitDir, 'hooks', 'pre-commit');
     const content = readFileOrNull(hookPath);

--- a/src/scoring/checks/freshness.ts
+++ b/src/scoring/checks/freshness.ts
@@ -28,6 +28,7 @@ function getCommitsSinceConfigUpdate(dir: string): number | null {
       cwd: dir,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim();
     const headTime = parseInt(headTimestamp, 10) * 1000;
 
@@ -53,6 +54,7 @@ function getCommitsSinceConfigUpdate(dir: string): number | null {
         cwd: dir,
         encoding: 'utf-8',
         stdio: ['pipe', 'pipe', 'pipe'],
+        windowsHide: true,
       }).trim();
 
       if (hash) {
@@ -60,6 +62,7 @@ function getCommitsSinceConfigUpdate(dir: string): number | null {
           cwd: dir,
           encoding: 'utf-8',
           stdio: ['pipe', 'pipe', 'pipe'],
+          windowsHide: true,
         }).trim();
         return parseInt(countStr, 10) || 0;
       }

--- a/src/scoring/utils.ts
+++ b/src/scoring/utils.ts
@@ -76,6 +76,7 @@ function isGitRepo(dir: string): boolean {
       cwd: dir,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     });
     return true;
   } catch {
@@ -94,6 +95,7 @@ function checkGitIgnored(dir: string, paths: string[]): Set<string> | null {
       cwd: dir,
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     });
     return new Set(
       result

--- a/src/telemetry/config.ts
+++ b/src/telemetry/config.ts
@@ -52,7 +52,7 @@ const PERSONAL_DOMAINS = new Set([
 
 function getGitEmail(): string | undefined {
   try {
-    const email = execSync('git config user.email', { encoding: 'utf-8' }).trim();
+    const email = execSync('git config user.email',{ encoding: 'utf-8', windowsHide: true }).trim();
     return email || undefined;
   } catch {
     return undefined;
@@ -90,6 +90,7 @@ export function getRepoHash(): string | undefined {
     const remote = execSync('git remote get-url origin || git rev-parse --show-toplevel', {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim();
     if (!remote) return undefined;
     return crypto.createHmac('sha256', EMAIL_HASH_KEY).update(remote).digest('hex').slice(0, 16);

--- a/src/utils/__tests__/editor.test.ts
+++ b/src/utils/__tests__/editor.test.ts
@@ -72,13 +72,13 @@ describe('openDiffsInEditor', () => {
       // paths have neither, so cmd.exe parses them correctly unquoted.
       expect(spawn).toHaveBeenCalledWith(
         'cursor --diff /project/CLAUDE.md /tmp/proposed/CLAUDE.md',
-        { shell: true, stdio: 'ignore', detached: true },
+        { shell: true, stdio: 'ignore', detached: true, windowsHide: true },
       );
     } else {
       expect(spawn).toHaveBeenCalledWith(
         'cursor',
         ['--diff', '/project/CLAUDE.md', '/tmp/proposed/CLAUDE.md'],
-        { stdio: 'ignore', detached: true },
+        { stdio: 'ignore', detached: true, windowsHide: true },
       );
     }
     expect(mockUnref).toHaveBeenCalled();
@@ -94,7 +94,7 @@ describe('openDiffsInEditor', () => {
     ]);
     expect(spawn).toHaveBeenCalledWith(
       'cursor --diff "C:\\Program Files\\foo\\bar.md" "C:\\Users\\First Last\\Desktop\\bar.md"',
-      { shell: true, stdio: 'ignore', detached: true },
+      { shell: true, stdio: 'ignore', detached: true, windowsHide: true },
     );
   });
 
@@ -115,12 +115,13 @@ describe('openDiffsInEditor', () => {
         shell: true,
         stdio: 'ignore',
         detached: true,
+        windowsHide: true,
       });
     } else {
       expect(spawn).toHaveBeenCalledWith(
         'code',
         ['--diff', expectedTempPath, '/tmp/proposed/new.md'],
-        { stdio: 'ignore', detached: true },
+        { stdio: 'ignore', detached: true, windowsHide: true },
       );
     }
   });

--- a/src/utils/editor.ts
+++ b/src/utils/editor.ts
@@ -19,7 +19,7 @@ export type ReviewMethod = 'cursor' | 'vscode' | 'terminal';
 function commandExists(cmd: string): boolean {
   try {
     const check = process.platform === 'win32' ? `where ${cmd}` : `which ${cmd}`;
-    execSync(check,{ stdio: 'ignore', windowsHide: true });
+    execSync(check, { stdio: 'ignore', windowsHide: true });
     return true;
   } catch {
     return false;
@@ -54,7 +54,7 @@ export function openDiffsInEditor(
             quoteForWindows(leftPath),
             quoteForWindows(file.proposedPath),
           ].join(' '),
-          { shell: true, stdio: 'ignore', detached: true }, { windowsHide: true }
+          { shell: true, stdio: 'ignore', detached: true, windowsHide: true },
         ).unref();
       } else {
         spawn(cmd, ['--diff', leftPath, file.proposedPath], {

--- a/src/utils/editor.ts
+++ b/src/utils/editor.ts
@@ -19,7 +19,7 @@ export type ReviewMethod = 'cursor' | 'vscode' | 'terminal';
 function commandExists(cmd: string): boolean {
   try {
     const check = process.platform === 'win32' ? `where ${cmd}` : `which ${cmd}`;
-    execSync(check, { stdio: 'ignore' });
+    execSync(check,{ stdio: 'ignore', windowsHide: true });
     return true;
   } catch {
     return false;
@@ -54,11 +54,12 @@ export function openDiffsInEditor(
             quoteForWindows(leftPath),
             quoteForWindows(file.proposedPath),
           ].join(' '),
-          { shell: true, stdio: 'ignore', detached: true },
+          { shell: true, stdio: 'ignore', detached: true }, { windowsHide: true }
         ).unref();
       } else {
         spawn(cmd, ['--diff', leftPath, file.proposedPath], {
           stdio: 'ignore',
+          windowsHide: true,
           detached: true,
         }).unref();
       }

--- a/src/utils/version-check.ts
+++ b/src/utils/version-check.ts
@@ -36,6 +36,7 @@ function getInstalledVersion(): string | null {
     const globalRoot = execSync('npm root -g', {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
     }).trim();
     const pkgPath = path.join(globalRoot, '@rely-ai', 'caliber', 'package.json');
     return JSON.parse(fs.readFileSync(pkgPath, 'utf-8')).version;
@@ -96,6 +97,7 @@ export async function checkForUpdates(): Promise<void> {
     try {
       execFileSync('npm', ['install', '-g', `@rely-ai/caliber@${tag}`], {
         stdio: 'pipe',
+        windowsHide: true,
         timeout: 120_000,
         env: { ...process.env, npm_config_fund: 'false', npm_config_audit: 'false' },
       });
@@ -115,6 +117,7 @@ export async function checkForUpdates(): Promise<void> {
       console.log(chalk.dim(`\nRestarting: caliber ${args.join(' ')}\n`));
       execFileSync('caliber', args, {
         stdio: 'inherit',
+        windowsHide: true,
         env: { ...process.env, CALIBER_SKIP_UPDATE_CHECK: '1' },
       });
       process.exit(0);


### PR DESCRIPTION
## Summary

On Windows, Caliber generates a near-continuous stream of brief black
console windows during active editor / Claude Code / Cursor /
opencode use. The flashes stack on the taskbar and steal focus —
unusable in practice. This branch fixes it end-to-end across three
distinct flash sources, validated empirically on Windows 10 22H2 /
Node 22.21 ("perfect, not even one").

PR #197 (Apr 2026) addressed one specific cmd-shim flash in the
pre-commit hook by invoking node directly. That fixed one call site
but introduced a new `execSync('where node', ...)` which itself
flashes, the learning-hooks installer was never patched, and the
rest of the codebase was never audited. This branch generalizes
the fix and adds the wscript wrapper Anthropic acknowledged but
chose not to implement upstream
([anthropics/claude-code#19012](https://github.com/anthropics/claude-code/issues/19012)).

## Three flash sources, three commits

| # | Commit | Layer | What flashes | Fix |
|---|--------|-------|--------------|-----|
| 1 | `f5366e8` | `spawn`/`exec` family | Every internal `caliber refresh` / `score` / `learn` subprocess (78 sites across 24 source files) | Add `windowsHide: true` to every options object |
| 2 | `a0ac2b6` | `.cmd` shim | Every `caliber learn observe` hook fire from Claude Code / Cursor — OS resolves `caliber` → `caliber.cmd`, spawns `cmd.exe` which auto-allocates a console | New `resolveCaliberHookInvoker()` emits `"<node>" "<bin.js>"` form, bypassing the shim |
| 3 | `6be7fee` | `node.exe` console subsystem | Even when node is invoked directly (commit #2), Claude Code's hook spawn lacks `windowsHide:true`, and node.exe is a console-subsystem binary — Windows allocates a console for it anyway | New `assets/hook-runner.vbs` runs via `wscript.exe` (windows-subsystem); `resolveCaliberHookInvoker()` wraps the node-direct form in `wscript //nologo "<vbs>" "<node>" "<bin.js>"` when the VBS is co-located with bin.js |

Each layer is a strict subset of the next — disable layer 3 and you
still see node.exe flashes; disable both 2 and 3 and you see cmd.exe
flashes; disable all three and you see flashes from every
`execFileSync('git', ...)`. All three are necessary.

## Cross-platform safety

- **POSIX hosts:** byte-identical behaviour. `windowsHide` is a
  documented no-op on macOS/Linux ([Node docs][1]). `resolveCaliberHookInvoker()`
  returns `resolveCaliber()` unchanged when `process.platform !== 'win32'`.
- **Non-`.cmd` Windows installs** (pnpm, yarn-classic, custom prefix
  where `bin.js` isn't at the expected sibling): falls through to
  `resolveCaliber()` unchanged.
- **Windows installs without the VBS asset** (older Caliber dist):
  falls back to the node-direct form from commit #2.

[1]: https://nodejs.org/api/child_process.html#optionswindowshide

## Files touched

```
 assets/hook-runner.vbs                        |  38 +
 index.cjs                                     |  43 +-
 package.json                                  |   3 +-
 scripts/copy-hook-runner.mjs                  |  20 +
 src/__tests__/windows-hide-regression.test.ts | 119 +++
 src/lib/__tests__/resolve-caliber.test.ts     | 130 ++++
 src/lib/learning-hooks.ts                     |  52 +-
 src/lib/resolve-caliber.ts                    | 133 +++-
 (+22 spawn-site files with windowsHide: true)
 33 files changed, 571 insertions(+), 56 deletions(-)
```

### Layer 1: `windowsHide: true` audit (commit `f5366e8`)

78 spawn sites across 24 source files. Three call-shape variants
handled:
- multi-line options object with `stdio:` — inject after `stdio` line
- single-line options object — append `, windowsHide: true`
- no options object — add `, { windowsHide: true }` as new arg

New `src/__tests__/windows-hide-regression.test.ts` (22 tests).
Source-level assertion that every spawn-family call has a matching
`windowsHide: true` in its options. Counts spawn invocations (strips
comment lines), asserts `hideCount >= spawnCount` per file, with a
`spawnCount > 0` sanity gate to catch refactors that delete all
spawns. Source-level rather than behavioural because the flag's
effect is observable only on Windows and CI runs vitest on Linux.

Adding a new file = one tuple entry in `SOURCE_FILES`.

Four existing `toHaveBeenCalledWith` / `toEqual` tests in
`src/llm/__tests__/` and `src/utils/__tests__/` were checking spawn
options shape exactly; they now expect `windowsHide: true` alongside
the existing keys.

### Layer 2: cmd-shim bypass for learning hooks (commit `a0ac2b6`)

New shared helper `resolveCaliberHookInvoker()` in `resolve-caliber.ts`.
When the resolved caliber path is a `.cmd` shim AND a sibling
`node_modules/@rely-ai/caliber/dist/bin.js` exists in the npm-global
layout AND `node` is on PATH, returns `"<node-fwd>" "<bin.js-fwd>"`
— two forward-slashed quoted paths that work both as the JSON
`command` value and as the first half of a Git-for-Windows bash
`"$cmd" subcommand` line.

`learning-hooks.ts` `getHookConfigs()` and
`installCursorLearningHooks()` now call
`resolveCaliberHookInvoker()` instead of `resolveCaliber()`.

`isCaliberCommand()` extended to recognize both the node-direct
shape and the absolute-path `.cmd` shape so install/uninstall and
the "is already installed?" check continue to match existing
entries across upgrades (no spurious "install N hooks" on every
refresh).

8 new tests (5 `resolveCaliberHookInvoker` + 3 `isCaliberCommand`
node-direct/cmd variants).

### Layer 3: wscript+VBS wrapper (commit `6be7fee`)

`assets/hook-runner.vbs` — tiny universal wrapper:

```vbs
If WScript.Arguments.Count < 1 Then WScript.Quit(1)
Dim cmd, i : cmd = ""
For i = 0 To WScript.Arguments.Count - 1
  If i > 0 Then cmd = cmd & " "
  cmd = cmd & """" & WScript.Arguments(i) & """"
Next
Set sh = CreateObject("WScript.Shell")
WScript.Quit(sh.Run(cmd, 0, True))
```

`WScript.Shell.Run(cmd, 0, True)`:
- `0` — SW_HIDE: never show a window
- `True` — wait for completion, propagate exit code

`wscript.exe` is a windows-subsystem host so the OS never allocates
a console for it. The child node.exe inherits the hidden state.

New `scripts/copy-hook-runner.mjs` build step copies the VBS from
`assets/` to `dist/hook-runner.vbs` so it ships next to `bin.js` in
the npm-global layout. `package.json` `files` field extended with
`dist/**/*.vbs` so `npm pack` includes it (verified — tarball now
ships bin.js + bin.js.map + hook-runner.vbs + LICENSE + README).

`resolveCaliberHookInvoker()` emits the wscript-wrapped form when
`hook-runner.vbs` is co-located with `bin.js`. Falls back to the
node-direct form (layer 2) when the VBS is missing — preserves
backwards compatibility for older Caliber installs whose dist
doesn't yet contain the VBS.

1 new test in `resolve-caliber.test.ts`. Verifies wscript form is
emitted when both bin.js and hook-runner.vbs siblings exist, output
starts with `wscript `, contains `//nologo`, and quotes all three
forward-slashed paths.

## Verification

- **Local vitest sweep:** 1130 passed (was 1098 → +32 new), 1
  skipped, 0 failed
- **Build:** `npm run build` succeeds; `dist/bin.js` contains 59
  `windowsHide` occurrences after tsup bundling; `dist/hook-runner.vbs`
  copied successfully
- **Manual Windows smoke (Windows 10 22H2 / Node 22.21):** installed
  the locally-built tarball; deployed to three real projects on
  pandorum; exercised Claude Code with frequent edits + `caliber
  refresh` + score + learn flows — **zero console flashes from
  caliber across all three layers**, operator-confirmed across an
  extended session
- **Linux:** byte-identical behaviour expected (`windowsHide` is a
  documented no-op; `resolveCaliberHookInvoker()` returns
  `resolveCaliber()` unchanged on POSIX)

## Compatibility

- Editor `--diff` open via `stdio: 'inherit'` still appears as
  expected; the child inherits the parent's terminal handles and
  `windowsHide` has nothing to hide
- Piped callers (`stdio: ['pipe', …]`) continue to deliver every
  byte of stdout/stderr back to the parent — no output swallowed
- CLI commands (`caliber refresh`, `caliber score`, etc.) run in
  the user's terminal which has a console; `stdio: 'inherit'` shares
  it — flag is a no-op there but harmless and uniform
- Existing `.claude/settings.json` / `.cursor/hooks.json` entries
  installed by older Caliber upgrade in place: `isCaliberCommand()`
  matches all three shapes (.cmd shim, node-direct, wscript-wrapped),
  so a `caliber refresh` after this lands rewrites them to the
  wscript-wrapped form without leaving stale duplicates

## Filed as draft

Per the operator's request — draft so reviewers can evaluate the
three-layer architecture before this lands. Companion OpenWolf
patch (same wscript wrapper shape, separate repo) is staged locally
and will be filed upstream after this PR's shape is agreed.
