### PR TITLE
feat: upgrade MiniMax default to M3

### DIFF
--- a/src/llm/__tests__/minimax.test.ts
+++ b/src/llm/__tests__/minimax.test.ts
@@ -97,6 +97,6 @@ describe('MiniMaxProvider', () => {
   it('listModels() returns hardcoded MiniMax models', async () => {
     const provider = new MiniMaxProvider(BASE_CONFIG);
     const models = await provider.listModels();
-    expect(models).toEqual(['MiniMax-M2.7', 'MiniMax-M2.7-highspeed']);
+    expect(models).toEqual(['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed']);
   });
 });

--- a/src/llm/config.ts
+++ b/src/llm/config.ts
@@ -10,7 +10,7 @@ export const DEFAULT_MODELS: Record<ProviderType, string> = {
   anthropic: 'claude-sonnet-4-6',
   vertex: 'claude-sonnet-4-6',
   openai: 'gpt-5.4-mini',
-  minimax: 'MiniMax-M2.7',
+  minimax: 'MiniMax-M3',
   cursor: 'auto',
   'claude-cli': 'default',
   opencode: 'default',
@@ -25,6 +25,7 @@ export const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   'gpt-4o': 128_000,
   'gpt-4o-mini': 128_000,
   auto: 200_000,
+  'MiniMax-M3': 524_288,
   'MiniMax-M2.7': 1_000_000,
   'MiniMax-M2.7-highspeed': 1_000_000,
 };

--- a/src/llm/minimax.ts
+++ b/src/llm/minimax.ts
@@ -18,6 +18,6 @@ export class MiniMaxProvider extends OpenAICompatProvider {
 
   // MiniMax API doesn't support model listing; return known models statically.
   override async listModels(): Promise<string[]> {
-    return ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed'];
+    return ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'];
   }
 }

--- a/src/llm/model-recovery.ts
+++ b/src/llm/model-recovery.ts
@@ -25,7 +25,7 @@ const KNOWN_MODELS: Record<ProviderType, string[]> = {
     'claude-opus-4-1-20250620',
   ],
   openai: ['gpt-5.4-mini', 'gpt-4o', 'gpt-4o-mini', 'o3-mini'],
-  minimax: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
+  minimax: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
   cursor: ['auto', 'composer-2', 'composer-2-fast', 'claude-4.6-sonnet-medium'],
   'claude-cli': [],
   opencode: [],


### PR DESCRIPTION
## Summary

Add `MiniMax-M3` to the `minimax` provider's curated model list and make it the new default. `MiniMax-M2.7` and `MiniMax-M2.7-highspeed` are kept as legacy and fast-tier fallbacks (the highspeed variant is still wired up as `DEFAULT_FAST_MODELS.minimax`).

## Changes

- `src/llm/config.ts`
  - `DEFAULT_MODELS.minimax`: `MiniMax-M2.7` -> `MiniMax-M3`
  - `MODEL_CONTEXT_WINDOWS`: add `MiniMax-M3: 524_288`
- `src/llm/minimax.ts` — `listModels()` returns `[M3, M2.7, M2.7-highspeed]` (M3 first)
- `src/llm/model-recovery.ts` — `KNOWN_MODELS.minimax` updated likewise
- `src/llm/__tests__/minimax.test.ts` — pin the new `listModels()` return value

## Notes

- M3 has a 512K context window per the MiniMax docs.
- No API URL or env-var changes; existing `MINIMAX_API_KEY` / `MINIMAX_BASE_URL` flow is unchanged.
- Anyone with `~/.caliber/config.json` already pinning `MiniMax-M2.7` keeps that pin; only the auto-detected default for `MINIMAX_API_KEY` changes.

## Test plan

- [x] `npx vitest run src/llm/__tests__/minimax.test.ts` (7/7)
- [x] `npx vitest run src/llm/` (210 passed, 1 pre-existing skip)
- [x] `npx tsc --noEmit`
- [x] `npm run build`