### PR TITLE
feat: expand MiniMax provider registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Then, in your terminal (not the IDE chat), start a Claude Code or Cursor CLI ses
 
 Your agent detects your stack, generates tailored configs for every platform your team uses, sets up pre-commit hooks, and enables continuous sync — all from inside your normal workflow.
 
-**Don't use Claude Code or Cursor?** Run `caliber init` instead — it's the same setup as a CLI wizard. Works with any LLM provider: bring your own Anthropic, OpenAI, or Vertex AI key.
+**Don't use Claude Code or Cursor?** Run `caliber init` instead — it's the same setup as a CLI wizard. Works with any LLM provider: bring your own Anthropic, OpenAI, MiniMax, or Vertex AI key.
 
 > **Your code stays on your machine.** Bootstrap is 100% local — no LLM calls, no code sent anywhere. Generation uses your own AI subscription or API key. Caliber never sees your code.
 
@@ -284,7 +284,7 @@ No. Caliber shows you a diff of every proposed change. You accept, refine, or de
 
 **Bootstrap & scoring:** No. Both run 100% locally with no LLM.
 
-**Generation** (via `/setup-caliber` or `caliber init`): Uses your existing Claude Code or Cursor subscription (no API key needed), or bring your own key for Anthropic, OpenAI, or Vertex AI.
+**Generation** (via `/setup-caliber` or `caliber init`): Uses your existing Claude Code or Cursor subscription (no API key needed), or bring your own key for Anthropic, OpenAI, MiniMax, or Vertex AI.
 
 </details>
 
@@ -329,6 +329,7 @@ No API key? No problem. Caliber works with your existing AI tool subscription:
 | **Cursor** (your seat) | `caliber config` → Cursor | Inherited from Cursor |
 | **Anthropic** | `export ANTHROPIC_API_KEY=sk-ant-...` | `claude-sonnet-4-6` |
 | **OpenAI** | `export OPENAI_API_KEY=sk-...` | `gpt-5.4-mini` |
+| **MiniMax** | `export MINIMAX_API_KEY=...` | `MiniMax-M3` |
 | **Vertex AI** | `export VERTEX_PROJECT_ID=my-project` | `claude-sonnet-4-6` |
 | **Custom endpoint** | `OPENAI_API_KEY` + `OPENAI_BASE_URL` | `gpt-5.4-mini` |
 
@@ -337,6 +338,13 @@ Override the model for any provider: `export CALIBER_MODEL=<model-name>` or use 
 Caliber uses a **two-tier model system** — lightweight tasks (classification, scoring) auto-use a faster model, while heavy tasks (generation, refinement) use the default. This keeps costs low and speed high.
 
 Configuration is stored in `~/.caliber/config.json` with restricted permissions (`0600`). API keys are never written to project files.
+
+MiniMax supports OpenAI-compatible and Anthropic-compatible requests in both service regions. Set `MINIMAX_BASE_URL` or choose a base URL with `caliber config`:
+
+| Region | OpenAI-compatible base URL | Anthropic-compatible base URL | Documentation |
+|---|---|---|---|
+| Global | `https://api.minimax.io/v1` | `https://api.minimax.io/anthropic` | [MiniMax platform docs](https://platform.minimax.io/docs) |
+| China | `https://api.minimaxi.com/v1` | `https://api.minimaxi.com/anthropic` | [MiniMax platform docs](https://platform.minimaxi.com/docs) |
 
 <details>
 <summary>Vertex AI advanced setup</summary>
@@ -365,6 +373,8 @@ export GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account.json
 | `ANTHROPIC_API_KEY` | Anthropic API key |
 | `OPENAI_API_KEY` | OpenAI API key |
 | `OPENAI_BASE_URL` | Custom OpenAI-compatible endpoint |
+| `MINIMAX_API_KEY` | MiniMax API key |
+| `MINIMAX_BASE_URL` | MiniMax OpenAI-compatible or Anthropic-compatible base URL |
 | `VERTEX_PROJECT_ID` | GCP project ID for Vertex AI |
 | `VERTEX_REGION` | Vertex AI region (default: `us-east5`) |
 | `VERTEX_SA_CREDENTIALS` | Service account JSON (inline) |

--- a/src/commands/__tests__/interactive-provider-setup.test.ts
+++ b/src/commands/__tests__/interactive-provider-setup.test.ts
@@ -23,6 +23,7 @@ vi.mock('../../llm/config.js', () => ({
     anthropic: 'claude-sonnet-4-6',
     vertex: 'claude-sonnet-4-6',
     openai: 'gpt-5.4-mini',
+    minimax: 'MiniMax-M3',
     cursor: 'default',
     'claude-cli': 'default',
   },
@@ -122,6 +123,36 @@ describe('runInteractiveProviderSetup', () => {
     mockInput.mockResolvedValue('');
 
     await expect(runInteractiveProviderSetup()).rejects.toThrow('__exit__');
+  });
+
+  it('configures minimax with the global OpenAI-compatible endpoint by default', async () => {
+    mockSelect.mockResolvedValue('minimax');
+    mockInput
+      .mockResolvedValueOnce('minimax-test-key')
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('');
+
+    const config = await runInteractiveProviderSetup();
+
+    expect(config).toEqual({
+      provider: 'minimax',
+      apiKey: 'minimax-test-key',
+      baseUrl: 'https://api.minimax.io/v1',
+      model: 'MiniMax-M3',
+    });
+  });
+
+  it('accepts the China Anthropic-compatible endpoint for minimax', async () => {
+    mockSelect.mockResolvedValue('minimax');
+    mockInput
+      .mockResolvedValueOnce('minimax-test-key')
+      .mockResolvedValueOnce('https://api.minimaxi.com/anthropic')
+      .mockResolvedValueOnce('MiniMax-M2.7');
+
+    const config = await runInteractiveProviderSetup();
+
+    expect(config.baseUrl).toBe('https://api.minimaxi.com/anthropic');
+    expect(config.model).toBe('MiniMax-M2.7');
   });
 
   it('configures vertex provider with project ID and region', async () => {

--- a/src/commands/interactive-provider-setup.ts
+++ b/src/commands/interactive-provider-setup.ts
@@ -11,6 +11,7 @@ import {
 } from '../llm/cursor-acp.js';
 import { isClaudeCliAvailable, isClaudeCliLoggedIn } from '../llm/claude-cli.js';
 import { isOpenCodeAvailable, isOpenCodeLoggedIn } from '../llm/opencode.js';
+import { MINIMAX_ENDPOINTS } from '../llm/minimax.js';
 import { promptInput } from '../utils/prompt.js';
 
 const IS_WINDOWS = process.platform === 'win32';
@@ -209,6 +210,10 @@ export async function runInteractiveProviderSetup(options?: {
         console.log(chalk.red('API key is required.'));
         throw new Error('__exit__');
       }
+      config.baseUrl =
+        (await promptInput(
+          `Base URL (default: ${MINIMAX_ENDPOINTS.global_en.openai}; use an /anthropic endpoint for Anthropic-compatible requests):`,
+        )) || MINIMAX_ENDPOINTS.global_en.openai;
       config.model =
         (await promptInput(`Model (default: ${DEFAULT_MODELS.minimax}):`)) ||
         DEFAULT_MODELS.minimax;

--- a/src/llm/__tests__/anthropic-base-url.test.ts
+++ b/src/llm/__tests__/anthropic-base-url.test.ts
@@ -1,0 +1,50 @@
+import { once } from 'node:events';
+import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterEach, describe, expect, it } from 'vitest';
+import { AnthropicProvider } from '../anthropic.js';
+
+describe('AnthropicProvider base URL', () => {
+  let server: Server | undefined;
+
+  afterEach(async () => {
+    if (!server) return;
+    await new Promise<void>((resolve, reject) => {
+      server?.close((error) => (error ? reject(error) : resolve()));
+    });
+    server = undefined;
+  });
+
+  it('appends /v1/messages to a configured /anthropic base URL', async () => {
+    let requestPath = '';
+    server = createServer((request, response) => {
+      requestPath = request.url ?? '';
+      response.writeHead(200, { 'Content-Type': 'application/json' });
+      response.end(
+        JSON.stringify({
+          id: 'msg_test',
+          type: 'message',
+          role: 'assistant',
+          model: 'MiniMax-M3',
+          content: [{ type: 'text', text: 'ok' }],
+          stop_reason: 'end_turn',
+          stop_sequence: null,
+          usage: { input_tokens: 1, output_tokens: 1 },
+        }),
+      );
+    });
+    server.listen(0, '127.0.0.1');
+    await once(server, 'listening');
+
+    const address = server.address() as AddressInfo;
+    const provider = new AnthropicProvider({
+      provider: 'minimax',
+      model: 'MiniMax-M3',
+      apiKey: 'test-key',
+      baseUrl: `http://127.0.0.1:${address.port}/anthropic`,
+    });
+
+    await expect(provider.call({ system: 'Respond briefly.', prompt: 'ping' })).resolves.toBe('ok');
+    expect(requestPath).toBe('/anthropic/v1/messages');
+  });
+});

--- a/src/llm/__tests__/config.test.ts
+++ b/src/llm/__tests__/config.test.ts
@@ -27,10 +27,12 @@ describe('config', () => {
     process.env = { ...originalEnv };
     delete process.env.ANTHROPIC_API_KEY;
     delete process.env.OPENAI_API_KEY;
+    delete process.env.MINIMAX_API_KEY;
     delete process.env.VERTEX_PROJECT_ID;
     delete process.env.GCP_PROJECT_ID;
     delete process.env.CALIBER_MODEL;
     delete process.env.OPENAI_BASE_URL;
+    delete process.env.MINIMAX_BASE_URL;
     delete process.env.VERTEX_REGION;
     delete process.env.GCP_REGION;
     delete process.env.VERTEX_SA_CREDENTIALS;
@@ -93,6 +95,18 @@ describe('config', () => {
       process.env.OPENAI_BASE_URL = 'http://localhost:11434/v1';
       const config = resolveFromEnv();
       expect(config?.baseUrl).toBe('http://localhost:11434/v1');
+    });
+
+    it('returns minimax config with its configured endpoint', () => {
+      process.env.MINIMAX_API_KEY = 'minimax-test-key';
+      process.env.MINIMAX_BASE_URL = 'https://api.minimaxi.com/anthropic';
+      const config = resolveFromEnv();
+      expect(config).toEqual({
+        provider: 'minimax',
+        apiKey: 'minimax-test-key',
+        model: 'MiniMax-M3',
+        baseUrl: 'https://api.minimaxi.com/anthropic',
+      });
     });
 
     it('respects CALIBER_MODEL override', () => {
@@ -334,6 +348,7 @@ describe('config', () => {
       expect(DEFAULT_MODELS.anthropic).toBeDefined();
       expect(DEFAULT_MODELS.vertex).toBeDefined();
       expect(DEFAULT_MODELS.openai).toBeDefined();
+      expect(DEFAULT_MODELS.minimax).toBe('MiniMax-M3');
     });
   });
 
@@ -431,6 +446,7 @@ describe('config', () => {
       expect(DEFAULT_FAST_MODELS.anthropic).toBe('claude-haiku-4-5-20251001');
       expect(DEFAULT_FAST_MODELS.vertex).toBe('claude-haiku-4-5-20251001');
       expect(DEFAULT_FAST_MODELS.openai).toBe('gpt-5.4-mini');
+      expect(DEFAULT_FAST_MODELS.minimax).toBe('MiniMax-M2.7-highspeed');
       expect(DEFAULT_FAST_MODELS.cursor).toBe('gpt-5.3-codex-fast');
       expect(DEFAULT_FAST_MODELS['claude-cli']).toBeUndefined();
     });
@@ -483,6 +499,11 @@ describe('config', () => {
         if (model === 'default') continue;
         expect(MODEL_CONTEXT_WINDOWS[model]).toBeDefined();
       }
+    });
+
+    it('uses the current MiniMax model context windows', () => {
+      expect(MODEL_CONTEXT_WINDOWS['MiniMax-M3']).toBe(1_000_000);
+      expect(MODEL_CONTEXT_WINDOWS['MiniMax-M2.7']).toBe(204_800);
     });
   });
 });

--- a/src/llm/__tests__/config.test.ts
+++ b/src/llm/__tests__/config.test.ts
@@ -504,6 +504,7 @@ describe('config', () => {
     it('uses the current MiniMax model context windows', () => {
       expect(MODEL_CONTEXT_WINDOWS['MiniMax-M3']).toBe(1_000_000);
       expect(MODEL_CONTEXT_WINDOWS['MiniMax-M2.7']).toBe(204_800);
+      expect(MODEL_CONTEXT_WINDOWS['MiniMax-M2.7-highspeed']).toBe(204_800);
     });
   });
 });

--- a/src/llm/__tests__/minimax.test.ts
+++ b/src/llm/__tests__/minimax.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { MiniMaxProvider } from '../minimax.js';
+import { createMiniMaxProvider, MiniMaxAnthropicProvider, MiniMaxProvider } from '../minimax.js';
 import type { LLMConfig } from '../types.js';
 
 const createMock = vi.fn();
@@ -18,7 +18,7 @@ vi.mock('../usage.js', () => ({ trackUsage: vi.fn() }));
 
 import OpenAI from 'openai';
 
-const BASE_CONFIG: LLMConfig = { provider: 'minimax', model: 'MiniMax-M2.7', apiKey: 'test-key' };
+const BASE_CONFIG: LLMConfig = { provider: 'minimax', model: 'MiniMax-M3', apiKey: 'test-key' };
 
 describe('MiniMaxProvider', () => {
   beforeEach(() => {
@@ -97,6 +97,24 @@ describe('MiniMaxProvider', () => {
   it('listModels() returns hardcoded MiniMax models', async () => {
     const provider = new MiniMaxProvider(BASE_CONFIG);
     const models = await provider.listModels();
-    expect(models).toEqual(['MiniMax-M2.7', 'MiniMax-M2.7-highspeed']);
+    expect(models).toEqual(['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed']);
+  });
+
+  it('uses the Anthropic adapter for an Anthropic-compatible base URL', () => {
+    const provider = createMiniMaxProvider({
+      ...BASE_CONFIG,
+      baseUrl: 'https://api.minimax.io/anthropic',
+    });
+
+    expect(provider).toBeInstanceOf(MiniMaxAnthropicProvider);
+  });
+
+  it('keeps the OpenAI adapter for an OpenAI-compatible base URL', () => {
+    const provider = createMiniMaxProvider({
+      ...BASE_CONFIG,
+      baseUrl: 'https://api.minimaxi.com/v1',
+    });
+
+    expect(provider).toBeInstanceOf(MiniMaxProvider);
   });
 });

--- a/src/llm/anthropic.ts
+++ b/src/llm/anthropic.ts
@@ -7,7 +7,10 @@ export class AnthropicProvider implements LLMProvider {
   private defaultModel: string;
 
   constructor(config: LLMConfig) {
-    this.client = new Anthropic({ apiKey: config.apiKey });
+    this.client = new Anthropic({
+      apiKey: config.apiKey,
+      ...(config.baseUrl && { baseURL: config.baseUrl }),
+    });
     this.defaultModel = config.model;
   }
 

--- a/src/llm/config.ts
+++ b/src/llm/config.ts
@@ -27,7 +27,7 @@ export const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   auto: 200_000,
   'MiniMax-M3': 1_000_000,
   'MiniMax-M2.7': 204_800,
-  'MiniMax-M2.7-highspeed': 1_000_000,
+  'MiniMax-M2.7-highspeed': 204_800,
 };
 
 const DEFAULT_CONTEXT_WINDOW = 200_000;

--- a/src/llm/config.ts
+++ b/src/llm/config.ts
@@ -10,7 +10,7 @@ export const DEFAULT_MODELS: Record<ProviderType, string> = {
   anthropic: 'claude-sonnet-4-6',
   vertex: 'claude-sonnet-4-6',
   openai: 'gpt-5.4-mini',
-  minimax: 'MiniMax-M2.7',
+  minimax: 'MiniMax-M3',
   cursor: 'auto',
   'claude-cli': 'default',
   opencode: 'default',
@@ -25,7 +25,8 @@ export const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   'gpt-4o': 128_000,
   'gpt-4o-mini': 128_000,
   auto: 200_000,
-  'MiniMax-M2.7': 1_000_000,
+  'MiniMax-M3': 1_000_000,
+  'MiniMax-M2.7': 204_800,
   'MiniMax-M2.7-highspeed': 1_000_000,
 };
 

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -3,7 +3,7 @@ import { loadConfig } from './config.js';
 import { AnthropicProvider } from './anthropic.js';
 import { VertexProvider } from './vertex.js';
 import { OpenAICompatProvider } from './openai-compat.js';
-import { MiniMaxProvider } from './minimax.js';
+import { createMiniMaxProvider } from './minimax.js';
 import { CursorAcpProvider, isCursorAgentAvailable, isCursorLoggedIn } from './cursor-acp.js';
 import { ClaudeCliProvider, isClaudeCliAvailable, isClaudeCliLoggedIn } from './claude-cli.js';
 import { OpenCodeProvider, isOpenCodeAvailable, isOpenCodeLoggedIn } from './opencode.js';
@@ -33,7 +33,7 @@ function createProvider(config: LLMConfig): LLMProvider {
     case 'openai':
       return new OpenAICompatProvider(config);
     case 'minimax':
-      return new MiniMaxProvider(config);
+      return createMiniMaxProvider(config);
     case 'cursor': {
       if (!isCursorAgentAvailable()) {
         throw new Error(

--- a/src/llm/minimax.ts
+++ b/src/llm/minimax.ts
@@ -1,16 +1,36 @@
-import type { LLMConfig } from './types.js';
+import type { LLMConfig, LLMProvider } from './types.js';
+import { AnthropicProvider } from './anthropic.js';
 import { OpenAICompatProvider } from './openai-compat.js';
 
-const MINIMAX_DEFAULT_BASE_URL = 'https://api.minimax.io/v1';
+export const MINIMAX_ENDPOINTS = {
+  global_en: {
+    openai: 'https://api.minimax.io/v1',
+    anthropic: 'https://api.minimax.io/anthropic',
+  },
+  cn_zh: {
+    openai: 'https://api.minimaxi.com/v1',
+    anthropic: 'https://api.minimaxi.com/anthropic',
+  },
+} as const;
+
+const MINIMAX_MODELS = ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'];
+
+function resolveMiniMaxConfig(config: LLMConfig): LLMConfig {
+  return {
+    ...config,
+    apiKey: config.apiKey ?? process.env.MINIMAX_API_KEY,
+    baseUrl: config.baseUrl ?? process.env.MINIMAX_BASE_URL ?? MINIMAX_ENDPOINTS.global_en.openai,
+  };
+}
+
+function isAnthropicCompatibleBaseUrl(baseUrl: string | undefined): boolean {
+  return /\/anthropic\/?$/.test(baseUrl ?? '');
+}
 
 export class MiniMaxProvider extends OpenAICompatProvider {
   constructor(config: LLMConfig) {
     super(
-      {
-        ...config,
-        apiKey: config.apiKey ?? process.env.MINIMAX_API_KEY,
-        baseUrl: config.baseUrl ?? process.env.MINIMAX_BASE_URL ?? MINIMAX_DEFAULT_BASE_URL,
-      },
+      resolveMiniMaxConfig(config),
       // MiniMax requires temperature in (0.0, 1.0] — 1.0 is the only safe default.
       { temperature: 1.0 },
     );
@@ -18,6 +38,23 @@ export class MiniMaxProvider extends OpenAICompatProvider {
 
   // MiniMax API doesn't support model listing; return known models statically.
   override async listModels(): Promise<string[]> {
-    return ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed'];
+    return [...MINIMAX_MODELS];
   }
+}
+
+export class MiniMaxAnthropicProvider extends AnthropicProvider {
+  constructor(config: LLMConfig) {
+    super(resolveMiniMaxConfig(config));
+  }
+
+  override async listModels(): Promise<string[]> {
+    return [...MINIMAX_MODELS];
+  }
+}
+
+export function createMiniMaxProvider(config: LLMConfig): LLMProvider {
+  const resolvedConfig = resolveMiniMaxConfig(config);
+  return isAnthropicCompatibleBaseUrl(resolvedConfig.baseUrl)
+    ? new MiniMaxAnthropicProvider(resolvedConfig)
+    : new MiniMaxProvider(resolvedConfig);
 }

--- a/src/llm/minimax.ts
+++ b/src/llm/minimax.ts
@@ -2,6 +2,7 @@ import type { LLMConfig, LLMProvider } from './types.js';
 import { AnthropicProvider } from './anthropic.js';
 import { OpenAICompatProvider } from './openai-compat.js';
 
+/** Documented MiniMax regional endpoints (OpenAI- and Anthropic-compatible). */
 export const MINIMAX_ENDPOINTS = {
   global_en: {
     openai: 'https://api.minimax.io/v1',
@@ -13,7 +14,7 @@ export const MINIMAX_ENDPOINTS = {
   },
 } as const;
 
-const MINIMAX_MODELS = ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'];
+export const MINIMAX_MODELS = ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'] as const;
 
 function resolveMiniMaxConfig(config: LLMConfig): LLMConfig {
   return {
@@ -21,10 +22,6 @@ function resolveMiniMaxConfig(config: LLMConfig): LLMConfig {
     apiKey: config.apiKey ?? process.env.MINIMAX_API_KEY,
     baseUrl: config.baseUrl ?? process.env.MINIMAX_BASE_URL ?? MINIMAX_ENDPOINTS.global_en.openai,
   };
-}
-
-function isAnthropicCompatibleBaseUrl(baseUrl: string | undefined): boolean {
-  return /\/anthropic\/?$/.test(baseUrl ?? '');
 }
 
 export class MiniMaxProvider extends OpenAICompatProvider {
@@ -53,8 +50,9 @@ export class MiniMaxAnthropicProvider extends AnthropicProvider {
 }
 
 export function createMiniMaxProvider(config: LLMConfig): LLMProvider {
-  const resolvedConfig = resolveMiniMaxConfig(config);
-  return isAnthropicCompatibleBaseUrl(resolvedConfig.baseUrl)
-    ? new MiniMaxAnthropicProvider(resolvedConfig)
-    : new MiniMaxProvider(resolvedConfig);
+  const baseUrl =
+    config.baseUrl ?? process.env.MINIMAX_BASE_URL ?? MINIMAX_ENDPOINTS.global_en.openai;
+  return /\/anthropic\/?$/.test(baseUrl)
+    ? new MiniMaxAnthropicProvider(config)
+    : new MiniMaxProvider(config);
 }

--- a/src/llm/model-recovery.ts
+++ b/src/llm/model-recovery.ts
@@ -1,6 +1,7 @@
 import chalk from 'chalk';
 import select from '@inquirer/select';
 import { writeConfigFile } from './config.js';
+import { MINIMAX_MODELS } from './minimax.js';
 import type { LLMConfig, LLMProvider, ProviderType } from './types.js';
 import { displayCaliberName } from '../lib/resolve-caliber.js';
 
@@ -25,7 +26,7 @@ const KNOWN_MODELS: Record<ProviderType, string[]> = {
     'claude-opus-4-1-20250620',
   ],
   openai: ['gpt-5.4-mini', 'gpt-4o', 'gpt-4o-mini', 'o3-mini'],
-  minimax: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
+  minimax: [...MINIMAX_MODELS],
   cursor: ['auto', 'composer-2', 'composer-2-fast', 'claude-4.6-sonnet-medium'],
   'claude-cli': [],
   opencode: [],

--- a/src/llm/model-recovery.ts
+++ b/src/llm/model-recovery.ts
@@ -25,7 +25,7 @@ const KNOWN_MODELS: Record<ProviderType, string[]> = {
     'claude-opus-4-1-20250620',
   ],
   openai: ['gpt-5.4-mini', 'gpt-4o', 'gpt-4o-mini', 'o3-mini'],
-  minimax: ['MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
+  minimax: ['MiniMax-M3', 'MiniMax-M2.7', 'MiniMax-M2.7-highspeed'],
   cursor: ['auto', 'composer-2', 'composer-2-fast', 'claude-4.6-sonnet-medium'],
   'claude-cli': [],
   opencode: [],


### PR DESCRIPTION
Reason: add target provider/model to existing provider registry

Update the MiniMax provider registry to use MiniMax-M3 by default while retaining MiniMax-M2.7 and the existing fast model fallback. Add current context windows and static model recovery entries.

Support both configured service regions and both compatible request formats through the existing adapters. Document the four base URLs and make them available through `caliber config` and `MINIMAX_BASE_URL`.

Checks:
- `npm ci`
- `npm run lint`
- `npm run build:skills:check`
- `npx tsc --noEmit`
- `npm test`
- `npm run build`
- `node dist/bin.js --version`