### PR TITLE
Add Atlas Cloud LLM provider

### DIFF
--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -7,9 +7,17 @@ console.log(bold(purple('  Caliber installed successfully!')));
 console.log('');
 console.log(`  Get started:`);
 console.log('');
-console.log(`    ${bold('caliber config')}   ${dim('Set up LLM: Claude Code or Cursor (your seat), Anthropic, OpenAI, or Vertex')}`);
-console.log(`    ${bold('caliber init')}   ${dim('Initialize your project for AI-assisted development')}`);
+console.log(
+  `    ${bold('caliber config')}   ${dim('Set up LLM: Claude Code or Cursor (your seat), Anthropic, OpenAI, Atlas Cloud, or Vertex')}`,
+);
+console.log(
+  `    ${bold('caliber init')}   ${dim('Initialize your project for AI-assisted development')}`,
+);
 console.log('');
-console.log(`  ${dim('Use your current seat: choose "Claude Code" or "Cursor" in caliber config (or set CALIBER_USE_CLAUDE_CLI=1 / CALIBER_USE_CURSOR_SEAT=1).')}`);
-console.log(`  ${dim('Or set ANTHROPIC_API_KEY / OPENAI_API_KEY and run caliber init.')}`);
+console.log(
+  `  ${dim('Use your current seat: choose "Claude Code" or "Cursor" in caliber config (or set CALIBER_USE_CLAUDE_CLI=1 / CALIBER_USE_CURSOR_SEAT=1).')}`,
+);
+console.log(
+  `  ${dim('Or set ANTHROPIC_API_KEY / OPENAI_API_KEY / ATLASCLOUD_API_KEY and run caliber init.')}`,
+);
 console.log('');

--- a/src/commands/__tests__/interactive-provider-setup.test.ts
+++ b/src/commands/__tests__/interactive-provider-setup.test.ts
@@ -24,8 +24,10 @@ vi.mock('../../llm/config.js', () => ({
     vertex: 'claude-sonnet-4-6',
     openai: 'gpt-5.4-mini',
     minimax: 'MiniMax-M3',
+    atlascloud: 'deepseek-ai/deepseek-v4-pro',
     cursor: 'default',
     'claude-cli': 'default',
+    opencode: 'default',
   },
 }));
 
@@ -116,6 +118,21 @@ describe('runInteractiveProviderSetup', () => {
     expect(config.apiKey).toBe('sk-openai-test');
     expect(config.baseUrl).toBe('http://localhost:11434/v1');
     expect(config.model).toBe('gpt-5.4-mini');
+  });
+
+  it('configures atlascloud provider with API key, base URL, and default model', async () => {
+    mockSelect.mockResolvedValue('atlascloud');
+    mockInput
+      .mockResolvedValueOnce('atlas-key')
+      .mockResolvedValueOnce('')
+      .mockResolvedValueOnce('');
+
+    const config = await runInteractiveProviderSetup();
+
+    expect(config.provider).toBe('atlascloud');
+    expect(config.apiKey).toBe('atlas-key');
+    expect(config.baseUrl).toBe('https://api.atlascloud.ai/v1');
+    expect(config.model).toBe('deepseek-ai/deepseek-v4-pro');
   });
 
   it('throws __exit__ when openai API key is empty', async () => {

--- a/src/commands/config.ts
+++ b/src/commands/config.ts
@@ -33,7 +33,9 @@ export async function configCommand() {
       console.log(`  Vertex Project: ${chalk.dim(existing.vertexProjectId)}`);
       console.log(`  Vertex Region:  ${chalk.dim(existing.vertexRegion || 'us-east5')}`);
     }
-    console.log(`  Source:   ${chalk.dim(process.env.ANTHROPIC_API_KEY || process.env.OPENAI_API_KEY || process.env.VERTEX_PROJECT_ID || process.env.CALIBER_USE_CURSOR_SEAT || process.env.CALIBER_USE_CLAUDE_CLI ? 'environment variables' : getConfigFilePath())}`);
+    console.log(
+      `  Source:   ${chalk.dim(process.env.ANTHROPIC_API_KEY || process.env.OPENAI_API_KEY || process.env.MINIMAX_API_KEY || process.env.ATLASCLOUD_API_KEY || process.env.ATLAS_CLOUD_API_KEY || process.env.VERTEX_PROJECT_ID || process.env.CALIBER_USE_CURSOR_SEAT || process.env.CALIBER_USE_CLAUDE_CLI || process.env.CALIBER_USE_OPENCODE ? 'environment variables' : getConfigFilePath())}`,
+    );
     console.log('');
   }
 
@@ -45,5 +47,9 @@ export async function configCommand() {
   console.log(chalk.green('\n✓ Configuration saved'));
   console.log(chalk.dim(`  ${getConfigFilePath()}\n`));
   console.log(chalk.dim('  You can also set environment variables instead:'));
-  console.log(chalk.dim('  ANTHROPIC_API_KEY, OPENAI_API_KEY, VERTEX_PROJECT_ID, CALIBER_USE_CURSOR_SEAT=1, or CALIBER_USE_CLAUDE_CLI=1\n'));
+  console.log(
+    chalk.dim(
+      '  ANTHROPIC_API_KEY, OPENAI_API_KEY, MINIMAX_API_KEY, ATLASCLOUD_API_KEY, VERTEX_PROJECT_ID, CALIBER_USE_CURSOR_SEAT=1, CALIBER_USE_CLAUDE_CLI=1, or CALIBER_USE_OPENCODE=1\n',
+    ),
+  );
 }

--- a/src/commands/interactive-provider-setup.ts
+++ b/src/commands/interactive-provider-setup.ts
@@ -24,6 +24,7 @@ const PROVIDER_CHOICES: Array<{ name: string; value: ProviderType }> = [
   { name: 'Google Vertex AI — Claude models via GCP', value: 'vertex' },
   { name: 'OpenAI — or any OpenAI-compatible endpoint', value: 'openai' },
   { name: 'MiniMax — API key from platform.minimax.io', value: 'minimax' },
+  { name: 'Atlas Cloud — OpenAI-compatible endpoint', value: 'atlascloud' },
 ];
 
 /**
@@ -217,6 +218,20 @@ export async function runInteractiveProviderSetup(options?: {
       config.model =
         (await promptInput(`Model (default: ${DEFAULT_MODELS.minimax}):`)) ||
         DEFAULT_MODELS.minimax;
+      break;
+    }
+    case 'atlascloud': {
+      config.apiKey = await promptInput('Atlas Cloud API key:');
+      if (!config.apiKey) {
+        console.log(chalk.red('API key is required.'));
+        throw new Error('__exit__');
+      }
+      config.baseUrl =
+        (await promptInput('Base URL (default: https://api.atlascloud.ai/v1):')) ||
+        'https://api.atlascloud.ai/v1';
+      config.model =
+        (await promptInput(`Model (default: ${DEFAULT_MODELS.atlascloud}):`)) ||
+        DEFAULT_MODELS.atlascloud;
       break;
     }
   }

--- a/src/llm/__tests__/atlascloud.test.ts
+++ b/src/llm/__tests__/atlascloud.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { AtlasCloudProvider, ATLASCLOUD_DEFAULT_BASE_URL } from '../atlascloud.js';
+import type { LLMConfig } from '../types.js';
+
+const createMock = vi.fn();
+const listMock = vi.fn();
+
+vi.mock('openai', () => {
+  return {
+    default: class MockOpenAI {
+      chat = { completions: { create: createMock } };
+      models = { list: listMock };
+      constructor(public opts: Record<string, unknown>) {}
+    },
+  };
+});
+
+vi.mock('../usage.js', () => ({ trackUsage: vi.fn() }));
+
+import OpenAI from 'openai';
+
+const BASE_CONFIG: LLMConfig = {
+  provider: 'atlascloud',
+  model: 'deepseek-ai/deepseek-v4-pro',
+  apiKey: 'atlas-key',
+};
+
+describe('AtlasCloudProvider', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    process.env = { ...originalEnv };
+    delete process.env.ATLASCLOUD_API_KEY;
+    delete process.env.ATLAS_CLOUD_API_KEY;
+    delete process.env.ATLASCLOUD_BASE_URL;
+    delete process.env.ATLAS_CLOUD_BASE_URL;
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('constructor passes apiKey and Atlas Cloud base URL to OpenAI client', () => {
+    const provider = new AtlasCloudProvider(BASE_CONFIG);
+    const instance = (provider as unknown as { client: InstanceType<typeof OpenAI> }).client;
+    const opts = (instance as unknown as { opts: Record<string, unknown> }).opts;
+    expect(opts.apiKey).toBe('atlas-key');
+    expect(opts.baseURL).toBe(ATLASCLOUD_DEFAULT_BASE_URL);
+  });
+
+  it('constructor supports ATLAS_CLOUD_API_KEY env alias when config has no apiKey', () => {
+    process.env.ATLAS_CLOUD_API_KEY = 'alias-key';
+    const provider = new AtlasCloudProvider({
+      provider: 'atlascloud',
+      model: 'deepseek-ai/deepseek-v4-pro',
+    });
+    const instance = (provider as unknown as { client: InstanceType<typeof OpenAI> }).client;
+    const opts = (instance as unknown as { opts: Record<string, unknown> }).opts;
+    expect(opts.apiKey).toBe('alias-key');
+  });
+
+  it('constructor supports ATLASCLOUD_BASE_URL env var when config has no baseUrl', () => {
+    process.env.ATLASCLOUD_BASE_URL = 'https://gateway.example.com/v1';
+    const provider = new AtlasCloudProvider(BASE_CONFIG);
+    const instance = (provider as unknown as { client: InstanceType<typeof OpenAI> }).client;
+    const opts = (instance as unknown as { opts: Record<string, unknown> }).opts;
+    expect(opts.baseURL).toBe('https://gateway.example.com/v1');
+  });
+
+  it('listModels() falls back to known Atlas Cloud chat models when listing fails', async () => {
+    listMock.mockRejectedValue(new Error('listing unavailable'));
+    const provider = new AtlasCloudProvider(BASE_CONFIG);
+    await expect(provider.listModels()).resolves.toEqual([
+      'deepseek-ai/deepseek-v4-pro',
+      'deepseek-ai/deepseek-v4-flash',
+      'qwen/qwen3.5-27b',
+    ]);
+  });
+});

--- a/src/llm/__tests__/config.test.ts
+++ b/src/llm/__tests__/config.test.ts
@@ -28,11 +28,19 @@ describe('config', () => {
     delete process.env.ANTHROPIC_API_KEY;
     delete process.env.OPENAI_API_KEY;
     delete process.env.MINIMAX_API_KEY;
+    delete process.env.ATLASCLOUD_API_KEY;
+    delete process.env.ATLAS_CLOUD_API_KEY;
     delete process.env.VERTEX_PROJECT_ID;
     delete process.env.GCP_PROJECT_ID;
     delete process.env.CALIBER_MODEL;
     delete process.env.OPENAI_BASE_URL;
     delete process.env.MINIMAX_BASE_URL;
+    delete process.env.ATLASCLOUD_BASE_URL;
+    delete process.env.ATLAS_CLOUD_BASE_URL;
+    delete process.env.ATLASCLOUD_MODEL;
+    delete process.env.ATLAS_CLOUD_MODEL;
+    delete process.env.ATLASCLOUD_FAST_MODEL;
+    delete process.env.ATLAS_CLOUD_FAST_MODEL;
     delete process.env.VERTEX_REGION;
     delete process.env.GCP_REGION;
     delete process.env.VERTEX_SA_CREDENTIALS;
@@ -106,6 +114,33 @@ describe('config', () => {
         apiKey: 'minimax-test-key',
         model: 'MiniMax-M3',
         baseUrl: 'https://api.minimaxi.com/anthropic',
+      });
+    });
+
+    it('returns atlascloud config when ATLASCLOUD_API_KEY is set', () => {
+      process.env.ATLASCLOUD_API_KEY = 'atlas-key';
+      const config = resolveFromEnv();
+      expect(config).toEqual({
+        provider: 'atlascloud',
+        apiKey: 'atlas-key',
+        model: DEFAULT_MODELS.atlascloud,
+        fastModel: undefined,
+        baseUrl: 'https://api.atlascloud.ai/v1',
+      });
+    });
+
+    it('supports ATLAS_CLOUD aliases for Atlas Cloud env vars', () => {
+      process.env.ATLAS_CLOUD_API_KEY = 'atlas-alias-key';
+      process.env.ATLAS_CLOUD_BASE_URL = 'https://gateway.example.com/v1';
+      process.env.ATLAS_CLOUD_MODEL = 'qwen/qwen3.5-27b';
+      process.env.ATLAS_CLOUD_FAST_MODEL = 'deepseek-ai/deepseek-v4-flash';
+      const config = resolveFromEnv();
+      expect(config).toEqual({
+        provider: 'atlascloud',
+        apiKey: 'atlas-alias-key',
+        model: 'qwen/qwen3.5-27b',
+        fastModel: 'deepseek-ai/deepseek-v4-flash',
+        baseUrl: 'https://gateway.example.com/v1',
       });
     });
 
@@ -261,6 +296,22 @@ describe('config', () => {
       expect(config?.provider).toBe('claude-cli');
       expect(config?.model).toBe('default');
     });
+
+    it('parses config file with atlascloud provider', () => {
+      vi.mocked(fs.existsSync).mockReturnValue(true);
+
+      vi.mocked(fs.readFileSync).mockReturnValue(
+        JSON.stringify({
+          provider: 'atlascloud',
+          model: 'deepseek-ai/deepseek-v4-pro',
+          apiKey: 'atlas-key',
+          baseUrl: 'https://api.atlascloud.ai/v1',
+        }) as any,
+      );
+      const config = readConfigFile();
+      expect(config?.provider).toBe('atlascloud');
+      expect(config?.model).toBe('deepseek-ai/deepseek-v4-pro');
+    });
   });
 
   describe('loadConfig', () => {
@@ -386,6 +437,11 @@ describe('config', () => {
     it('returns provider default for openai', () => {
       process.env.OPENAI_API_KEY = 'sk-openai-test';
       expect(getFastModel()).toBe('gpt-5.4-mini');
+    });
+
+    it('returns provider default for atlascloud', () => {
+      process.env.ATLASCLOUD_API_KEY = 'atlas-key';
+      expect(getFastModel()).toBe('deepseek-ai/deepseek-v4-flash');
     });
 
     it('returns cursor fast model default', () => {

--- a/src/llm/__tests__/index.test.ts
+++ b/src/llm/__tests__/index.test.ts
@@ -12,6 +12,7 @@ const {
   MockAnthropicProvider,
   MockVertexProvider,
   MockOpenAIProvider,
+  MockAtlasCloudProvider,
   MockCursorAcpProvider,
   MockClaudeCliProvider,
 } = vi.hoisted(() => {
@@ -32,6 +33,14 @@ const {
     }
   }
   class MockOpenAIProvider {
+    config: unknown;
+    call = vi.fn();
+    stream = vi.fn();
+    constructor(c: unknown) {
+      this.config = c;
+    }
+  }
+  class MockAtlasCloudProvider {
     config: unknown;
     call = vi.fn();
     stream = vi.fn();
@@ -65,6 +74,7 @@ const {
     MockAnthropicProvider,
     MockVertexProvider,
     MockOpenAIProvider,
+    MockAtlasCloudProvider,
     MockCursorAcpProvider,
     MockClaudeCliProvider,
   };
@@ -86,6 +96,10 @@ vi.mock('../vertex.js', () => ({
 
 vi.mock('../openai-compat.js', () => ({
   OpenAICompatProvider: MockOpenAIProvider,
+}));
+
+vi.mock('../atlascloud.js', () => ({
+  AtlasCloudProvider: MockAtlasCloudProvider,
 }));
 
 vi.mock('../cursor-acp.js', () => ({
@@ -133,6 +147,25 @@ describe('getProvider', () => {
     const provider = getProvider();
 
     expect(provider).toBeInstanceOf(MockCursorAcpProvider);
+  });
+
+  it('creates AtlasCloudProvider for atlascloud config', () => {
+    mockLoadConfig.mockReturnValue({
+      provider: 'atlascloud',
+      model: 'deepseek-ai/deepseek-v4-pro',
+      apiKey: 'atlas-key',
+      baseUrl: 'https://api.atlascloud.ai/v1',
+    });
+
+    const provider = getProvider();
+
+    expect(provider).toBeInstanceOf(MockAtlasCloudProvider);
+    expect((provider as InstanceType<typeof MockAtlasCloudProvider>).config).toEqual({
+      provider: 'atlascloud',
+      model: 'deepseek-ai/deepseek-v4-pro',
+      apiKey: 'atlas-key',
+      baseUrl: 'https://api.atlascloud.ai/v1',
+    });
   });
 
   it('throws when cursor is configured but agent binary is not available', () => {

--- a/src/llm/atlascloud.ts
+++ b/src/llm/atlascloud.ts
@@ -1,0 +1,26 @@
+import type { LLMConfig } from './types.js';
+import { OpenAICompatProvider } from './openai-compat.js';
+
+export const ATLASCLOUD_DEFAULT_BASE_URL = 'https://api.atlascloud.ai/v1';
+
+export class AtlasCloudProvider extends OpenAICompatProvider {
+  constructor(config: LLMConfig) {
+    super({
+      ...config,
+      apiKey: config.apiKey ?? process.env.ATLASCLOUD_API_KEY ?? process.env.ATLAS_CLOUD_API_KEY,
+      baseUrl:
+        config.baseUrl ??
+        process.env.ATLASCLOUD_BASE_URL ??
+        process.env.ATLAS_CLOUD_BASE_URL ??
+        ATLASCLOUD_DEFAULT_BASE_URL,
+    });
+  }
+
+  override async listModels(): Promise<string[]> {
+    try {
+      return await super.listModels();
+    } catch {
+      return ['deepseek-ai/deepseek-v4-pro', 'deepseek-ai/deepseek-v4-flash', 'qwen/qwen3.5-27b'];
+    }
+  }
+}

--- a/src/llm/config.ts
+++ b/src/llm/config.ts
@@ -11,6 +11,7 @@ export const DEFAULT_MODELS: Record<ProviderType, string> = {
   vertex: 'claude-sonnet-4-6',
   openai: 'gpt-5.4-mini',
   minimax: 'MiniMax-M3',
+  atlascloud: 'deepseek-ai/deepseek-v4-pro',
   cursor: 'auto',
   'claude-cli': 'default',
   opencode: 'default',
@@ -28,6 +29,9 @@ export const MODEL_CONTEXT_WINDOWS: Record<string, number> = {
   'MiniMax-M3': 1_000_000,
   'MiniMax-M2.7': 204_800,
   'MiniMax-M2.7-highspeed': 204_800,
+  'deepseek-ai/deepseek-v4-pro': 1_048_000,
+  'deepseek-ai/deepseek-v4-flash': 1_048_000,
+  'qwen/qwen3.5-27b': 262_000,
 };
 
 const DEFAULT_CONTEXT_WINDOW = 200_000;
@@ -50,6 +54,7 @@ export const DEFAULT_FAST_MODELS: Partial<Record<ProviderType, string>> = {
   vertex: 'claude-haiku-4-5-20251001',
   openai: 'gpt-5.4-mini',
   minimax: 'MiniMax-M2.7-highspeed',
+  atlascloud: 'deepseek-ai/deepseek-v4-flash',
   cursor: 'gpt-5.3-codex-fast',
 };
 
@@ -100,6 +105,24 @@ export function resolveFromEnv(): LLMConfig | null {
     };
   }
 
+  const atlasCloudApiKey = process.env.ATLASCLOUD_API_KEY || process.env.ATLAS_CLOUD_API_KEY;
+  if (atlasCloudApiKey) {
+    return {
+      provider: 'atlascloud',
+      apiKey: atlasCloudApiKey,
+      model:
+        process.env.ATLASCLOUD_MODEL ||
+        process.env.ATLAS_CLOUD_MODEL ||
+        process.env.CALIBER_MODEL ||
+        DEFAULT_MODELS.atlascloud,
+      fastModel: process.env.ATLASCLOUD_FAST_MODEL || process.env.ATLAS_CLOUD_FAST_MODEL,
+      baseUrl:
+        process.env.ATLASCLOUD_BASE_URL ||
+        process.env.ATLAS_CLOUD_BASE_URL ||
+        'https://api.atlascloud.ai/v1',
+    };
+  }
+
   // Prefer Cursor seat when explicitly requested (no API key; uses agent acp + agent login)
   if (
     process.env.CALIBER_USE_CURSOR_SEAT === '1' ||
@@ -137,9 +160,16 @@ export function readConfigFile(): LLMConfig | null {
     const parsed = JSON.parse(raw) as Record<string, unknown>;
     if (
       !parsed.provider ||
-      !['anthropic', 'vertex', 'openai', 'minimax', 'cursor', 'claude-cli', 'opencode'].includes(
-        parsed.provider as string,
-      )
+      ![
+        'anthropic',
+        'vertex',
+        'openai',
+        'minimax',
+        'atlascloud',
+        'cursor',
+        'claude-cli',
+        'opencode',
+      ].includes(parsed.provider as string)
     ) {
       return null;
     }

--- a/src/llm/index.ts
+++ b/src/llm/index.ts
@@ -4,6 +4,7 @@ import { AnthropicProvider } from './anthropic.js';
 import { VertexProvider } from './vertex.js';
 import { OpenAICompatProvider } from './openai-compat.js';
 import { createMiniMaxProvider } from './minimax.js';
+import { AtlasCloudProvider } from './atlascloud.js';
 import { CursorAcpProvider, isCursorAgentAvailable, isCursorLoggedIn } from './cursor-acp.js';
 import { ClaudeCliProvider, isClaudeCliAvailable, isClaudeCliLoggedIn } from './claude-cli.js';
 import { OpenCodeProvider, isOpenCodeAvailable, isOpenCodeLoggedIn } from './opencode.js';
@@ -34,6 +35,8 @@ function createProvider(config: LLMConfig): LLMProvider {
       return new OpenAICompatProvider(config);
     case 'minimax':
       return createMiniMaxProvider(config);
+    case 'atlascloud':
+      return new AtlasCloudProvider(config);
     case 'cursor': {
       if (!isCursorAgentAvailable()) {
         throw new Error(
@@ -85,7 +88,7 @@ export function getProvider(): LLMProvider {
   const config = loadConfig();
   if (!config) {
     throw new Error(
-      `No LLM provider configured. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, MINIMAX_API_KEY, or VERTEX_PROJECT_ID; or run \`${displayCaliberName()} config\` and choose Cursor, Claude Code, or OpenCode; or set CALIBER_USE_CURSOR_SEAT=1 / CALIBER_USE_CLAUDE_CLI=1 / CALIBER_USE_OPENCODE=1.`,
+      `No LLM provider configured. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, MINIMAX_API_KEY, ATLASCLOUD_API_KEY, or VERTEX_PROJECT_ID; or run \`${displayCaliberName()} config\` and choose a provider; or set CALIBER_USE_CURSOR_SEAT=1 / CALIBER_USE_CLAUDE_CLI=1 / CALIBER_USE_OPENCODE=1.`,
     );
   }
 
@@ -100,7 +103,7 @@ export function getConfig(): LLMConfig {
   const config = loadConfig();
   if (!config) {
     throw new Error(
-      `No LLM provider configured. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, MINIMAX_API_KEY, or VERTEX_PROJECT_ID; or run \`${displayCaliberName()} config\` and choose Cursor, Claude Code, or OpenCode; or set CALIBER_USE_CURSOR_SEAT=1 / CALIBER_USE_CLAUDE_CLI=1 / CALIBER_USE_OPENCODE=1.`,
+      `No LLM provider configured. Set ANTHROPIC_API_KEY, OPENAI_API_KEY, MINIMAX_API_KEY, ATLASCLOUD_API_KEY, or VERTEX_PROJECT_ID; or run \`${displayCaliberName()} config\` and choose a provider; or set CALIBER_USE_CURSOR_SEAT=1 / CALIBER_USE_CLAUDE_CLI=1 / CALIBER_USE_OPENCODE=1.`,
     );
   }
 

--- a/src/llm/model-recovery.ts
+++ b/src/llm/model-recovery.ts
@@ -27,6 +27,7 @@ const KNOWN_MODELS: Record<ProviderType, string[]> = {
   ],
   openai: ['gpt-5.4-mini', 'gpt-4o', 'gpt-4o-mini', 'o3-mini'],
   minimax: [...MINIMAX_MODELS],
+  atlascloud: ['deepseek-ai/deepseek-v4-pro', 'deepseek-ai/deepseek-v4-flash', 'qwen/qwen3.5-27b'],
   cursor: ['auto', 'composer-2', 'composer-2-fast', 'claude-4.6-sonnet-medium'],
   'claude-cli': [],
   opencode: [],

--- a/src/llm/types.ts
+++ b/src/llm/types.ts
@@ -1,4 +1,12 @@
-export type ProviderType = 'anthropic' | 'vertex' | 'openai' | 'minimax' | 'cursor' | 'claude-cli' | 'opencode';
+export type ProviderType =
+  | 'anthropic'
+  | 'vertex'
+  | 'openai'
+  | 'minimax'
+  | 'atlascloud'
+  | 'cursor'
+  | 'claude-cli'
+  | 'opencode';
 
 const SEAT_BASED_PROVIDERS: ReadonlySet<ProviderType> = new Set([
   'cursor',


### PR DESCRIPTION
## What

- Adds an Atlas Cloud LLM provider backed by the existing OpenAI-compatible runtime.
- Supports `ATLASCLOUD_API_KEY` / `ATLAS_CLOUD_API_KEY`, Atlas base URL aliases, default/fast models, model recovery fallbacks, and the interactive `caliber config` provider list.
- Adds focused coverage for env resolution, provider factory wiring, provider client options, model fallback, and interactive setup.

## Why

Atlas Cloud exposes an OpenAI-compatible chat completions API. A dedicated provider lets users configure it directly without reusing or overriding their OpenAI settings.

## Testing

- [x] `npm ci --ignore-scripts`
- [x] `npm test` passes (`1108 passed | 1 skipped`)
- [x] `npx tsc --noEmit` passes
- [x] `npm run build` passes
- [x] Changed-file ESLint passes
- [x] Changed-file Prettier check passes
- [x] `git diff --cached --check` passes
- [ ] Tested manually with `caliber init` / `caliber score` (not run locally; `node dist/bin.js refresh` exits before work because no local LLM provider is configured)

Note: full `npm run format:check` currently reports formatting drift in existing, unmodified source files; the files changed in this PR pass Prettier check.