### PR TITLE
fix: community skill installer drops references, scripts, and assets

### DIFF
--- a/src/commands/__tests__/skill-install.test.ts
+++ b/src/commands/__tests__/skill-install.test.ts
@@ -65,6 +65,17 @@ describe('fetchSkillFiles', () => {
     vi.unstubAllGlobals();
   });
 
+  it('fetches only SKILL.md by default (no GitHub API calls at search time)', async () => {
+    const impl = stubFetch({
+      [`${RAW_BASE}/${DIR}/SKILL.md`]: { ok: true, body: SKILL_MD },
+    });
+
+    const files = await fetchSkillFiles(REC);
+    expect([...(files as Map<string, Buffer>).keys()]).toEqual(['SKILL.md']);
+    const calledUrls = impl.mock.calls.map((c) => String(c[0]));
+    expect(calledUrls.some((u) => u.startsWith('https://api.github.com'))).toBe(false);
+  });
+
   it('fetches SKILL.md plus supporting files recursively', async () => {
     stubFetch({
       [`${RAW_BASE}/${DIR}/SKILL.md`]: { ok: true, body: SKILL_MD },
@@ -93,7 +104,7 @@ describe('fetchSkillFiles', () => {
       [`${RAW_BASE}/${DIR}/references/chapter_01.md`]: { ok: true, body: 'chapter one' },
     });
 
-    const files = await fetchSkillFiles(REC);
+    const files = await fetchSkillFiles(REC, { includeSupporting: true });
     expect(files).not.toBeNull();
     expect([...(files as Map<string, Buffer>).keys()].sort()).toEqual([
       'SKILL.md',
@@ -110,14 +121,14 @@ describe('fetchSkillFiles', () => {
       // API listing route missing → 404
     });
 
-    const files = await fetchSkillFiles(REC);
+    const files = await fetchSkillFiles(REC, { includeSupporting: true });
     expect(files).not.toBeNull();
     expect([...(files as Map<string, Buffer>).keys()]).toEqual(['SKILL.md']);
   });
 
   it('returns null when SKILL.md is not found anywhere', async () => {
     stubFetch({});
-    expect(await fetchSkillFiles(REC)).toBeNull();
+    expect(await fetchSkillFiles(REC, { includeSupporting: true })).toBeNull();
   });
 
   it('skips symlinks, submodules, unsafe paths, and oversized files', async () => {
@@ -140,7 +151,7 @@ describe('fetchSkillFiles', () => {
       [`${RAW_BASE}/${DIR}/ok.md`]: { ok: true, body: 'fine' },
     });
 
-    const files = await fetchSkillFiles(REC);
+    const files = await fetchSkillFiles(REC, { includeSupporting: true });
     expect([...(files as Map<string, Buffer>).keys()].sort()).toEqual(['SKILL.md', 'ok.md'].sort());
   });
 
@@ -159,7 +170,7 @@ describe('fetchSkillFiles', () => {
     for (const e of many) routes[e.download_url as string] = { ok: true, body: 'x' };
     stubFetch(routes);
 
-    const files = await fetchSkillFiles(REC);
+    const files = await fetchSkillFiles(REC, { includeSupporting: true });
     expect((files as Map<string, Buffer>).size).toBeLessThanOrEqual(50);
   });
 });
@@ -187,10 +198,18 @@ describe('installSkills', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.unstubAllGlobals();
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it('writes SKILL.md and supporting files for each platform', async () => {
+  it('writes SKILL.md and supporting files for each platform (cached fallback when fetch fails)', async () => {
+    // Install-time full fetch fails (offline / rate limit) → falls back to the
+    // content cached at search time, which must still be written in full.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({ ok: false, status: 403 })),
+    );
+
     const files = new Map<string, Buffer>([
       ['SKILL.md', Buffer.from(SKILL_MD)],
       ['references/chapter_01.md', Buffer.from('chapter one')],

--- a/src/commands/__tests__/skill-install.test.ts
+++ b/src/commands/__tests__/skill-install.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, readFileSync, existsSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { fetchSkillFiles, getSkillPath, installSkills } from '../recommend.js';
-import type { SkillResult } from '../recommend.js';
+import type { SkillResult, SkillFileMap } from '../recommend.js';
 
 const SKILL_MD = '# Rust Best Practices\n\nRead references/chapter_01.md for details.';
 
@@ -16,25 +16,35 @@ const REC: SkillResult = {
   detected_technology: 'rust',
 };
 
-type RouteMap = Record<string, { ok: boolean; body?: string | object }>;
+type RouteMap = Record<string, { ok: boolean; status?: number; body?: string | object }>;
 
 function stubFetch(routes: RouteMap) {
   const impl = vi.fn(async (url: string) => {
     const route = routes[url];
     if (!route) return { ok: false, status: 404 };
+    const body = route.body;
+    const bytes =
+      typeof body === 'string'
+        ? (() => {
+            const b = Buffer.from(body, 'utf-8');
+            return b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength);
+          })()
+        : new ArrayBuffer(0);
     return {
       ok: route.ok,
-      text: async () => route.body as string,
-      json: async () => route.body,
-      arrayBuffer: async () => {
-        // Slice out of the shared Buffer pool so we return only this string's bytes
-        const b = Buffer.from(route.body as string, 'utf-8');
-        return b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength);
-      },
+      status: route.status ?? (route.ok ? 200 : 404),
+      text: async () => (typeof body === 'string' ? body : ''),
+      json: async () => body,
+      arrayBuffer: async () => bytes,
     };
   });
   vi.stubGlobal('fetch', impl);
   return impl;
+}
+
+function expectFiles(files: SkillFileMap | null): SkillFileMap {
+  expect(files).not.toBeNull();
+  return files as SkillFileMap;
 }
 
 const RAW_BASE = 'https://raw.githubusercontent.com/apollographql/skills/HEAD';
@@ -70,8 +80,8 @@ describe('fetchSkillFiles', () => {
       [`${RAW_BASE}/${DIR}/SKILL.md`]: { ok: true, body: SKILL_MD },
     });
 
-    const files = await fetchSkillFiles(REC);
-    expect([...(files as Map<string, Buffer>).keys()]).toEqual(['SKILL.md']);
+    const files = expectFiles(await fetchSkillFiles(REC));
+    expect([...files.keys()]).toEqual(['SKILL.md']);
     const calledUrls = impl.mock.calls.map((c) => String(c[0]));
     expect(calledUrls.some((u) => u.startsWith('https://api.github.com'))).toBe(false);
   });
@@ -104,26 +114,27 @@ describe('fetchSkillFiles', () => {
       [`${RAW_BASE}/${DIR}/references/chapter_01.md`]: { ok: true, body: 'chapter one' },
     });
 
-    const files = await fetchSkillFiles(REC, { includeSupporting: true });
-    expect(files).not.toBeNull();
-    expect([...(files as Map<string, Buffer>).keys()].sort()).toEqual([
-      'SKILL.md',
-      'references/chapter_01.md',
-    ]);
-    expect((files as Map<string, Buffer>).get('references/chapter_01.md')?.toString()).toBe(
-      'chapter one',
-    );
+    const files = expectFiles(await fetchSkillFiles(REC, { includeSupporting: true }));
+    expect([...files.keys()].sort()).toEqual(['SKILL.md', 'references/chapter_01.md']);
+    expect(files.get('references/chapter_01.md')?.toString()).toBe('chapter one');
   });
 
-  it('falls back to SKILL.md only when directory listing fails', async () => {
+  it('keeps SKILL.md when directory listing 404s', async () => {
     stubFetch({
       [`${RAW_BASE}/${DIR}/SKILL.md`]: { ok: true, body: SKILL_MD },
-      // API listing route missing → 404
     });
 
-    const files = await fetchSkillFiles(REC, { includeSupporting: true });
-    expect(files).not.toBeNull();
-    expect([...(files as Map<string, Buffer>).keys()]).toEqual(['SKILL.md']);
+    const files = expectFiles(await fetchSkillFiles(REC, { includeSupporting: true }));
+    expect([...files.keys()]).toEqual(['SKILL.md']);
+  });
+
+  it('returns null on GitHub API rate limit so install can fall back', async () => {
+    stubFetch({
+      [`${RAW_BASE}/${DIR}/SKILL.md`]: { ok: true, body: SKILL_MD },
+      [`${API_BASE}/${DIR}`]: { ok: false, status: 403, body: 'rate limited' },
+    });
+
+    expect(await fetchSkillFiles(REC, { includeSupporting: true })).toBeNull();
   });
 
   it('returns null when SKILL.md is not found anywhere', async () => {
@@ -151,8 +162,8 @@ describe('fetchSkillFiles', () => {
       [`${RAW_BASE}/${DIR}/ok.md`]: { ok: true, body: 'fine' },
     });
 
-    const files = await fetchSkillFiles(REC, { includeSupporting: true });
-    expect([...(files as Map<string, Buffer>).keys()].sort()).toEqual(['SKILL.md', 'ok.md'].sort());
+    const files = expectFiles(await fetchSkillFiles(REC, { includeSupporting: true }));
+    expect([...files.keys()].sort()).toEqual(['SKILL.md', 'ok.md'].sort());
   });
 
   it('caps the number of collected files', async () => {
@@ -170,8 +181,8 @@ describe('fetchSkillFiles', () => {
     for (const e of many) routes[e.download_url as string] = { ok: true, body: 'x' };
     stubFetch(routes);
 
-    const files = await fetchSkillFiles(REC, { includeSupporting: true });
-    expect((files as Map<string, Buffer>).size).toBeLessThanOrEqual(50);
+    const files = expectFiles(await fetchSkillFiles(REC, { includeSupporting: true }));
+    expect(files.size).toBeLessThanOrEqual(50);
   });
 });
 
@@ -202,29 +213,54 @@ describe('installSkills', () => {
     rmSync(dir, { recursive: true, force: true });
   });
 
-  it('writes SKILL.md and supporting files for each platform (cached fallback when fetch fails)', async () => {
-    // Install-time full fetch fails (offline / rate limit) → falls back to the
-    // content cached at search time, which must still be written in full.
+  it('writes nested supporting files from a successful install-time fetch', async () => {
+    stubFetch({
+      [`${RAW_BASE}/${DIR}/SKILL.md`]: { ok: true, body: SKILL_MD },
+      [`${API_BASE}/${DIR}`]: {
+        ok: true,
+        body: [
+          dirEntry({
+            name: 'references',
+            path: `${DIR}/references`,
+            type: 'dir',
+            download_url: null,
+          }),
+        ],
+      },
+      [`${API_BASE}/${DIR}/references`]: {
+        ok: true,
+        body: [
+          dirEntry({
+            name: 'chapter_01.md',
+            path: `${DIR}/references/chapter_01.md`,
+            download_url: `${RAW_BASE}/${DIR}/references/chapter_01.md`,
+          }),
+        ],
+      },
+      [`${RAW_BASE}/${DIR}/references/chapter_01.md`]: { ok: true, body: 'chapter one' },
+    });
+
+    await installSkills([REC], ['claude'], new Map());
+
+    const skillDir = join(dir, '.claude', 'skills', REC.slug);
+    expect(readFileSync(join(skillDir, 'SKILL.md'), 'utf-8')).toBe(SKILL_MD);
+    expect(readFileSync(join(skillDir, 'references', 'chapter_01.md'), 'utf-8')).toBe(
+      'chapter one',
+    );
+  });
+
+  it('falls back to search-time SKILL.md cache when install-time fetch fails', async () => {
     vi.stubGlobal(
       'fetch',
       vi.fn(async () => ({ ok: false, status: 403 })),
     );
 
-    const files = new Map<string, Buffer>([
-      ['SKILL.md', Buffer.from(SKILL_MD)],
-      ['references/chapter_01.md', Buffer.from('chapter one')],
-      ['scripts/run.sh', Buffer.from('#!/bin/sh\necho ok')],
-    ]);
-
-    await installSkills([REC], ['claude', 'codex'], new Map([[REC.slug, files]]));
+    const cache = new Map([['SKILL.md', Buffer.from(SKILL_MD)]]);
+    await installSkills([REC], ['claude', 'codex'], new Map([[REC.slug, cache]]));
 
     for (const base of [join('.claude', 'skills'), join('.agents', 'skills')]) {
-      const skillDir = join(dir, base, REC.slug);
-      expect(readFileSync(join(skillDir, 'SKILL.md'), 'utf-8')).toBe(SKILL_MD);
-      expect(readFileSync(join(skillDir, 'references', 'chapter_01.md'), 'utf-8')).toBe(
-        'chapter one',
-      );
-      expect(existsSync(join(skillDir, 'scripts', 'run.sh'))).toBe(true);
+      expect(readFileSync(join(dir, base, REC.slug, 'SKILL.md'), 'utf-8')).toBe(SKILL_MD);
+      expect(existsSync(join(dir, base, REC.slug, 'references'))).toBe(false);
     }
   });
 });

--- a/src/commands/__tests__/skill-install.test.ts
+++ b/src/commands/__tests__/skill-install.test.ts
@@ -16,26 +16,28 @@ const REC: SkillResult = {
   detected_technology: 'rust',
 };
 
-type RouteMap = Record<string, { ok: boolean; status?: number; body?: string | object }>;
+type RouteMap = Record<string, { ok: boolean; status?: number; body?: string | object | Buffer }>;
+
+function toArrayBuffer(buf: Buffer): ArrayBuffer {
+  return buf.buffer.slice(buf.byteOffset, buf.byteOffset + buf.byteLength) as ArrayBuffer;
+}
 
 function stubFetch(routes: RouteMap) {
   const impl = vi.fn(async (url: string) => {
     const route = routes[url];
     if (!route) return { ok: false, status: 404 };
     const body = route.body;
-    const bytes =
-      typeof body === 'string'
-        ? (() => {
-            const b = Buffer.from(body, 'utf-8');
-            return b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength);
-          })()
-        : new ArrayBuffer(0);
+    const buf = Buffer.isBuffer(body)
+      ? body
+      : typeof body === 'string'
+        ? Buffer.from(body, 'utf-8')
+        : Buffer.alloc(0);
     return {
       ok: route.ok,
       status: route.status ?? (route.ok ? 200 : 404),
       text: async () => (typeof body === 'string' ? body : ''),
       json: async () => body,
-      arrayBuffer: async () => bytes,
+      arrayBuffer: async () => toArrayBuffer(buf),
     };
   });
   vi.stubGlobal('fetch', impl);
@@ -82,8 +84,8 @@ describe('fetchSkillFiles', () => {
 
     const files = expectFiles(await fetchSkillFiles(REC));
     expect([...files.keys()]).toEqual(['SKILL.md']);
-    const calledUrls = impl.mock.calls.map((c) => String(c[0]));
-    expect(calledUrls.some((u) => u.startsWith('https://api.github.com'))).toBe(false);
+    const calledHosts = impl.mock.calls.map((c) => new URL(String(c[0])).host);
+    expect(calledHosts).not.toContain('api.github.com');
   });
 
   it('fetches SKILL.md plus supporting files recursively', async () => {
@@ -247,6 +249,75 @@ describe('installSkills', () => {
     expect(readFileSync(join(skillDir, 'references', 'chapter_01.md'), 'utf-8')).toBe(
       'chapter one',
     );
+  });
+
+  it('installs references/, scripts/, and binary assets/ across multiple platforms', async () => {
+    const pngBytes = Buffer.from([0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0x00, 0xff]);
+    stubFetch({
+      [`${RAW_BASE}/${DIR}/SKILL.md`]: { ok: true, body: SKILL_MD },
+      [`${API_BASE}/${DIR}`]: {
+        ok: true,
+        body: [
+          dirEntry({ name: 'SKILL.md', path: `${DIR}/SKILL.md` }),
+          dirEntry({
+            name: 'references',
+            path: `${DIR}/references`,
+            type: 'dir',
+            download_url: null,
+          }),
+          dirEntry({ name: 'scripts', path: `${DIR}/scripts`, type: 'dir', download_url: null }),
+          dirEntry({ name: 'assets', path: `${DIR}/assets`, type: 'dir', download_url: null }),
+        ],
+      },
+      [`${API_BASE}/${DIR}/references`]: {
+        ok: true,
+        body: [
+          dirEntry({
+            name: 'chapter_01.md',
+            path: `${DIR}/references/chapter_01.md`,
+            download_url: `${RAW_BASE}/${DIR}/references/chapter_01.md`,
+          }),
+        ],
+      },
+      [`${API_BASE}/${DIR}/scripts`]: {
+        ok: true,
+        body: [
+          dirEntry({
+            name: 'setup.sh',
+            path: `${DIR}/scripts/setup.sh`,
+            download_url: `${RAW_BASE}/${DIR}/scripts/setup.sh`,
+          }),
+        ],
+      },
+      [`${API_BASE}/${DIR}/assets`]: {
+        ok: true,
+        body: [
+          dirEntry({
+            name: 'logo.png',
+            path: `${DIR}/assets/logo.png`,
+            download_url: `${RAW_BASE}/${DIR}/assets/logo.png`,
+          }),
+        ],
+      },
+      [`${RAW_BASE}/${DIR}/references/chapter_01.md`]: { ok: true, body: 'chapter one' },
+      [`${RAW_BASE}/${DIR}/scripts/setup.sh`]: { ok: true, body: '#!/bin/sh\necho hi\n' },
+      [`${RAW_BASE}/${DIR}/assets/logo.png`]: { ok: true, body: pngBytes },
+    });
+
+    await installSkills([REC], ['claude', 'codex'], new Map());
+
+    for (const base of [join('.claude', 'skills'), join('.agents', 'skills')]) {
+      const skillDir = join(dir, base, REC.slug);
+      expect(readFileSync(join(skillDir, 'SKILL.md'), 'utf-8')).toBe(SKILL_MD);
+      expect(readFileSync(join(skillDir, 'references', 'chapter_01.md'), 'utf-8')).toBe(
+        'chapter one',
+      );
+      expect(readFileSync(join(skillDir, 'scripts', 'setup.sh'), 'utf-8')).toBe(
+        '#!/bin/sh\necho hi\n',
+      );
+      const png = readFileSync(join(skillDir, 'assets', 'logo.png'));
+      expect(Buffer.compare(png, pngBytes)).toBe(0);
+    }
   });
 
   it('falls back to search-time SKILL.md cache when install-time fetch fails', async () => {

--- a/src/commands/__tests__/skill-install.test.ts
+++ b/src/commands/__tests__/skill-install.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { fetchSkillFiles, getSkillPath, installSkills } from '../recommend.js';
+import type { SkillResult } from '../recommend.js';
+
+const SKILL_MD = '# Rust Best Practices\n\nRead references/chapter_01.md for details.';
+
+const REC: SkillResult = {
+  name: 'Rust Best Practices',
+  slug: 'rust-best-practices',
+  source_url: 'https://github.com/apollographql/skills',
+  score: 90,
+  reason: 'test',
+  detected_technology: 'rust',
+};
+
+type RouteMap = Record<string, { ok: boolean; body?: string | object }>;
+
+function stubFetch(routes: RouteMap) {
+  const impl = vi.fn(async (url: string) => {
+    const route = routes[url];
+    if (!route) return { ok: false, status: 404 };
+    return {
+      ok: route.ok,
+      text: async () => route.body as string,
+      json: async () => route.body,
+      arrayBuffer: async () => {
+        // Slice out of the shared Buffer pool so we return only this string's bytes
+        const b = Buffer.from(route.body as string, 'utf-8');
+        return b.buffer.slice(b.byteOffset, b.byteOffset + b.byteLength);
+      },
+    };
+  });
+  vi.stubGlobal('fetch', impl);
+  return impl;
+}
+
+const RAW_BASE = 'https://raw.githubusercontent.com/apollographql/skills/HEAD';
+const API_BASE = 'https://api.github.com/repos/apollographql/skills/contents';
+const DIR = 'skills/rust-best-practices';
+
+function dirEntry(
+  overrides: Partial<{
+    name: string;
+    path: string;
+    type: string;
+    size: number;
+    download_url: string | null;
+  }>,
+) {
+  return {
+    name: 'file.md',
+    path: `${DIR}/file.md`,
+    type: 'file',
+    size: 100,
+    download_url: `${RAW_BASE}/${DIR}/file.md`,
+    ...overrides,
+  };
+}
+
+describe('fetchSkillFiles', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('fetches SKILL.md plus supporting files recursively', async () => {
+    stubFetch({
+      [`${RAW_BASE}/${DIR}/SKILL.md`]: { ok: true, body: SKILL_MD },
+      [`${API_BASE}/${DIR}`]: {
+        ok: true,
+        body: [
+          dirEntry({ name: 'SKILL.md', path: `${DIR}/SKILL.md` }),
+          dirEntry({
+            name: 'references',
+            path: `${DIR}/references`,
+            type: 'dir',
+            download_url: null,
+          }),
+        ],
+      },
+      [`${API_BASE}/${DIR}/references`]: {
+        ok: true,
+        body: [
+          dirEntry({
+            name: 'chapter_01.md',
+            path: `${DIR}/references/chapter_01.md`,
+            download_url: `${RAW_BASE}/${DIR}/references/chapter_01.md`,
+          }),
+        ],
+      },
+      [`${RAW_BASE}/${DIR}/references/chapter_01.md`]: { ok: true, body: 'chapter one' },
+    });
+
+    const files = await fetchSkillFiles(REC);
+    expect(files).not.toBeNull();
+    expect([...(files as Map<string, Buffer>).keys()].sort()).toEqual([
+      'SKILL.md',
+      'references/chapter_01.md',
+    ]);
+    expect((files as Map<string, Buffer>).get('references/chapter_01.md')?.toString()).toBe(
+      'chapter one',
+    );
+  });
+
+  it('falls back to SKILL.md only when directory listing fails', async () => {
+    stubFetch({
+      [`${RAW_BASE}/${DIR}/SKILL.md`]: { ok: true, body: SKILL_MD },
+      // API listing route missing → 404
+    });
+
+    const files = await fetchSkillFiles(REC);
+    expect(files).not.toBeNull();
+    expect([...(files as Map<string, Buffer>).keys()]).toEqual(['SKILL.md']);
+  });
+
+  it('returns null when SKILL.md is not found anywhere', async () => {
+    stubFetch({});
+    expect(await fetchSkillFiles(REC)).toBeNull();
+  });
+
+  it('skips symlinks, submodules, unsafe paths, and oversized files', async () => {
+    stubFetch({
+      [`${RAW_BASE}/${DIR}/SKILL.md`]: { ok: true, body: SKILL_MD },
+      [`${API_BASE}/${DIR}`]: {
+        ok: true,
+        body: [
+          dirEntry({ name: 'link.md', path: `${DIR}/link.md`, type: 'symlink' }),
+          dirEntry({ name: 'sub', path: `${DIR}/sub`, type: 'submodule' }),
+          dirEntry({ name: '../escape.md', path: 'elsewhere/escape.md' }),
+          dirEntry({ name: 'big.bin', path: `${DIR}/big.bin`, size: 10 * 1024 * 1024 }),
+          dirEntry({
+            name: 'ok.md',
+            path: `${DIR}/ok.md`,
+            download_url: `${RAW_BASE}/${DIR}/ok.md`,
+          }),
+        ],
+      },
+      [`${RAW_BASE}/${DIR}/ok.md`]: { ok: true, body: 'fine' },
+    });
+
+    const files = await fetchSkillFiles(REC);
+    expect([...(files as Map<string, Buffer>).keys()].sort()).toEqual(['SKILL.md', 'ok.md'].sort());
+  });
+
+  it('caps the number of collected files', async () => {
+    const many = Array.from({ length: 80 }, (_, i) =>
+      dirEntry({
+        name: `f${i}.md`,
+        path: `${DIR}/f${i}.md`,
+        download_url: `${RAW_BASE}/${DIR}/f${i}.md`,
+      }),
+    );
+    const routes: RouteMap = {
+      [`${RAW_BASE}/${DIR}/SKILL.md`]: { ok: true, body: SKILL_MD },
+      [`${API_BASE}/${DIR}`]: { ok: true, body: many },
+    };
+    for (const e of many) routes[e.download_url as string] = { ok: true, body: 'x' };
+    stubFetch(routes);
+
+    const files = await fetchSkillFiles(REC);
+    expect((files as Map<string, Buffer>).size).toBeLessThanOrEqual(50);
+  });
+});
+
+describe('getSkillPath', () => {
+  it('builds nested paths inside the skill directory', () => {
+    expect(getSkillPath('claude', 'my-skill', 'references/ch1.md')).toBe(
+      join('.claude', 'skills', 'my-skill', 'references', 'ch1.md'),
+    );
+  });
+
+  it('throws when a relative path escapes the skill directory', () => {
+    expect(() => getSkillPath('claude', 'my-skill', '../../evil.md')).toThrow(/escapes/);
+  });
+});
+
+describe('installSkills', () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'caliber-skill-test-'));
+    vi.spyOn(process, 'cwd').mockReturnValue(dir);
+    process.env.CALIBER_TELEMETRY_DISABLED = '1';
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('writes SKILL.md and supporting files for each platform', async () => {
+    const files = new Map<string, Buffer>([
+      ['SKILL.md', Buffer.from(SKILL_MD)],
+      ['references/chapter_01.md', Buffer.from('chapter one')],
+      ['scripts/run.sh', Buffer.from('#!/bin/sh\necho ok')],
+    ]);
+
+    await installSkills([REC], ['claude', 'codex'], new Map([[REC.slug, files]]));
+
+    for (const base of [join('.claude', 'skills'), join('.agents', 'skills')]) {
+      const skillDir = join(dir, base, REC.slug);
+      expect(readFileSync(join(skillDir, 'SKILL.md'), 'utf-8')).toBe(SKILL_MD);
+      expect(readFileSync(join(skillDir, 'references', 'chapter_01.md'), 'utf-8')).toBe(
+        'chapter one',
+      );
+      expect(existsSync(join(skillDir, 'scripts', 'run.sh'))).toBe(true);
+    }
+  });
+});

--- a/src/commands/recommend.ts
+++ b/src/commands/recommend.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import ora from 'ora';
 import select from '@inquirer/select';
 import { mkdirSync, readFileSync, readdirSync, existsSync, writeFileSync } from 'fs';
-import { join, dirname, resolve, sep } from 'path';
+import { join, dirname, resolve } from 'path';
 import { collectFingerprint, Fingerprint } from '../fingerprint/index.js';
 import { scanLocalState } from '../scanner/index.js';
 import { llmJsonCall } from '../llm/index.js';
@@ -10,6 +10,7 @@ import { loadConfig, getFastModel } from '../llm/config.js';
 import { trackSkillsInstalled } from '../telemetry/events.js';
 import { readState } from '../lib/state.js';
 import { displayCaliberName } from '../lib/resolve-caliber.js';
+import { assertPathWithinDir } from '../lib/sanitize.js';
 
 type Platform = 'claude' | 'cursor' | 'codex' | 'opencode' | 'github-copilot';
 
@@ -55,13 +56,8 @@ export function getSkillPath(platform: Platform, slug: string, relPath = 'SKILL.
           ? join('.opencode', 'skills')
           : join('.claude', 'skills');
 
-  const cwd = process.cwd();
-  const skillDir = resolve(cwd, baseDir, safe);
-  const fullPath = resolve(skillDir, relPath);
-  if (!fullPath.startsWith(skillDir + sep)) {
-    throw new Error(`Skill file path escapes skill directory: "${slug}/${relPath}"`);
-  }
-
+  const skillDir = resolve(process.cwd(), baseDir, safe);
+  assertPathWithinDir(relPath, skillDir);
   return join(baseDir, safe, relPath);
 }
 
@@ -441,15 +437,7 @@ export async function searchSkills(
   }
 
   onStatus?.('Fetching skill content...');
-  const contentMap = new Map<string, SkillFileMap>();
-  await Promise.all(
-    results.map(async (rec) => {
-      const content = await fetchSkillFiles(rec);
-      if (content) contentMap.set(rec.slug, content);
-    }),
-  );
-
-  const available = results.filter((r) => contentMap.has(r.slug));
+  const { available, contentMap } = await fetchAvailable(results);
   return { results: available, contentMap };
 }
 
@@ -507,14 +495,7 @@ export async function querySkills(query: string): Promise<void> {
 
   // Verify content is available
   const fetchSpinner = ora('Verifying availability...').start();
-  const contentMap = new Map<string, SkillFileMap>();
-  await Promise.all(
-    top.map(async (rec) => {
-      const content = await fetchSkillFiles(rec);
-      if (content) contentMap.set(rec.slug, content);
-    }),
-  );
-  const available = top.filter((r) => contentMap.has(r.slug));
+  const { available } = await fetchAvailable(top);
   fetchSpinner.succeed(`${available.length} available`);
 
   if (!available.length) {
@@ -569,15 +550,7 @@ export async function installBySlug(slugStr: string): Promise<void> {
   }
 
   // Fetch content
-  const contentMap = new Map<string, SkillFileMap>();
-  await Promise.all(
-    matched.map(async (rec) => {
-      const content = await fetchSkillFiles(rec);
-      if (content) contentMap.set(rec.slug, content);
-    }),
-  );
-
-  const installable = matched.filter((r) => contentMap.has(r.slug));
+  const { available: installable, contentMap } = await fetchAvailable(matched);
   if (!installable.length) {
     spinner.fail('Could not fetch skill content.');
     return;
@@ -695,15 +668,7 @@ export async function searchAndInstallSkills(targetPlatforms?: Platform[]): Prom
 
   // Step 4: Pre-fetch content — only show skills that are actually installable
   const fetchSpinner = ora('Verifying skill availability...').start();
-  const contentMap = new Map<string, SkillFileMap>();
-  await Promise.all(
-    results.map(async (rec) => {
-      const content = await fetchSkillFiles(rec);
-      if (content) contentMap.set(rec.slug, content);
-    }),
-  );
-
-  const available = results.filter((r) => contentMap.has(r.slug));
+  const { available, contentMap } = await fetchAvailable(results);
   if (!available.length) {
     fetchSpinner.fail('No installable skills found — content could not be fetched.');
     return;
@@ -886,11 +851,19 @@ function isSafeRelPath(rel: string): boolean {
   );
 }
 
+/** Thrown when the GitHub contents API rate-limits us — callers should fall back. */
+class SkillFetchRateLimited extends Error {
+  constructor() {
+    super('GitHub API rate limited');
+    this.name = 'SkillFetchRateLimited';
+  }
+}
+
 /**
  * Recursively collect supporting files (references/, scripts/, assets/, ...)
- * that live next to SKILL.md upstream (#228). Best-effort: any listing or
- * download failure is skipped so it never blocks the SKILL.md install.
- * Symlinks and submodules are skipped; caps bound depth, count, and file size.
+ * next to SKILL.md (#228). Non-rate-limit listing/download failures are skipped
+ * so SKILL.md still installs. Symlinks/submodules skipped; depth/count/size capped.
+ * Sibling files and subdirs are fetched in parallel.
  */
 async function collectSupportingFiles(
   repoPath: string,
@@ -904,23 +877,27 @@ async function collectSupportingFiles(
   let entries: GitHubDirEntry[];
   try {
     const headers: Record<string, string> = { Accept: 'application/vnd.github+json' };
-    // Unauthenticated GitHub API allows only 60 req/hr — honor a token when available
     const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
     if (token) headers.Authorization = `Bearer ${token}`;
     const resp = await fetch(`https://api.github.com/repos/${repoPath}/contents/${dirPath}`, {
       signal: AbortSignal.timeout(FETCH_TIMEOUT),
       headers,
     });
+    if (resp.status === 403 || resp.status === 429) throw new SkillFetchRateLimited();
     if (!resp.ok) return;
     const data = (await resp.json()) as unknown;
     if (!Array.isArray(data)) return;
     entries = data as GitHubDirEntry[];
-  } catch {
+  } catch (err) {
+    if (err instanceof SkillFetchRateLimited) throw err;
     return;
   }
 
+  const subdirs: string[] = [];
+  const downloads: Array<{ rel: string; url: string }> = [];
+
   for (const entry of entries) {
-    if (files.size >= MAX_SKILL_FILES) return;
+    if (files.size + downloads.length >= MAX_SKILL_FILES) break;
 
     const rel = entry.path.startsWith(skillDirPath + '/')
       ? entry.path.slice(skillDirPath.length + 1)
@@ -928,16 +905,24 @@ async function collectSupportingFiles(
     if (!isSafeRelPath(rel) || files.has(rel)) continue;
 
     if (entry.type === 'dir') {
-      await collectSupportingFiles(repoPath, entry.path, skillDirPath, depth + 1, files);
+      subdirs.push(entry.path);
     } else if (entry.type === 'file' && entry.download_url && entry.size <= MAX_SKILL_FILE_SIZE) {
-      try {
-        const resp = await fetch(entry.download_url, {
-          signal: AbortSignal.timeout(FETCH_TIMEOUT),
-        });
-        if (resp.ok) files.set(rel, Buffer.from(await resp.arrayBuffer()));
-      } catch {}
+      downloads.push({ rel, url: entry.download_url });
     }
   }
+
+  await Promise.all([
+    ...downloads.map(async ({ rel, url }) => {
+      if (files.size >= MAX_SKILL_FILES) return;
+      try {
+        const resp = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT) });
+        if (resp.ok) files.set(rel, Buffer.from(await resp.arrayBuffer()));
+      } catch {
+        /* skip individual download failures */
+      }
+    }),
+    ...subdirs.map((sub) => collectSupportingFiles(repoPath, sub, skillDirPath, depth + 1, files)),
+  ]);
 }
 
 /**
@@ -974,10 +959,28 @@ export async function fetchSkillFiles(
         await collectSupportingFiles(repoPath, dir, dir, 0, files);
       }
       return files;
-    } catch {}
+    } catch (err) {
+      // Rate limit during supporting-file fetch → null so install falls back to
+      // the search-time SKILL.md cache instead of silently installing a partial tree.
+      if (err instanceof SkillFetchRateLimited) return null;
+    }
   }
 
   return null;
+}
+
+/** Search-time: fetch SKILL.md for each candidate and drop unreachable ones. */
+async function fetchAvailable(
+  recs: SkillResult[],
+): Promise<{ available: SkillResult[]; contentMap: Map<string, SkillFileMap> }> {
+  const contentMap = new Map<string, SkillFileMap>();
+  await Promise.all(
+    recs.map(async (rec) => {
+      const content = await fetchSkillFiles(rec);
+      if (content) contentMap.set(rec.slug, content);
+    }),
+  );
+  return { available: recs.filter((r) => contentMap.has(r.slug)), contentMap };
 }
 
 async function installSkills(
@@ -988,13 +991,16 @@ async function installSkills(
   const spinner = ora(`Installing ${recs.length} skill${recs.length > 1 ? 's' : ''}...`).start();
   const installed: string[] = [];
 
-  for (const rec of recs) {
-    // Supporting files (references/, scripts/, assets/) are fetched only now,
-    // for the handful of skills actually selected — search-time fetches stay
-    // cheap and off the rate-limited GitHub API. Falls back to the cached
-    // SKILL.md-only content when the full fetch fails (offline, rate limit).
-    const files =
-      (await fetchSkillFiles(rec, { includeSupporting: true })) ?? contentMap.get(rec.slug);
+  // Supporting files fetched only for selected skills (search stays off the API).
+  // Falls back to search-time SKILL.md cache on offline/rate-limit.
+  const fetched = await Promise.all(
+    recs.map(async (rec) => ({
+      rec,
+      files: (await fetchSkillFiles(rec, { includeSupporting: true })) ?? contentMap.get(rec.slug),
+    })),
+  );
+
+  for (const { rec, files } of fetched) {
     if (!files) continue;
 
     for (const platform of platforms) {

--- a/src/commands/recommend.ts
+++ b/src/commands/recommend.ts
@@ -903,9 +903,13 @@ async function collectSupportingFiles(
 
   let entries: GitHubDirEntry[];
   try {
+    const headers: Record<string, string> = { Accept: 'application/vnd.github+json' };
+    // Unauthenticated GitHub API allows only 60 req/hr — honor a token when available
+    const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
+    if (token) headers.Authorization = `Bearer ${token}`;
     const resp = await fetch(`https://api.github.com/repos/${repoPath}/contents/${dirPath}`, {
       signal: AbortSignal.timeout(FETCH_TIMEOUT),
-      headers: { Accept: 'application/vnd.github+json' },
+      headers,
     });
     if (!resp.ok) return;
     const data = (await resp.json()) as unknown;
@@ -936,7 +940,16 @@ async function collectSupportingFiles(
   }
 }
 
-export async function fetchSkillFiles(rec: SkillResult): Promise<SkillFileMap | null> {
+/**
+ * Fetch a skill's files. By default only SKILL.md is fetched (cheap raw
+ * request, no API quota) — used at search/preview time for many candidates.
+ * Pass `includeSupporting: true` at install time to also pull references/,
+ * scripts/, assets/ etc. via the GitHub contents API (rate-limited).
+ */
+export async function fetchSkillFiles(
+  rec: SkillResult,
+  options?: { includeSupporting?: boolean },
+): Promise<SkillFileMap | null> {
   if (!rec.source_url) return null;
 
   const repoPath = rec.source_url.replace('https://github.com/', '');
@@ -957,7 +970,9 @@ export async function fetchSkillFiles(rec: SkillResult): Promise<SkillFileMap | 
       if (text.length <= 20) continue;
 
       const files: SkillFileMap = new Map([['SKILL.md', Buffer.from(text, 'utf-8')]]);
-      await collectSupportingFiles(repoPath, dir, dir, 0, files);
+      if (options?.includeSupporting) {
+        await collectSupportingFiles(repoPath, dir, dir, 0, files);
+      }
       return files;
     } catch {}
   }
@@ -974,7 +989,12 @@ async function installSkills(
   const installed: string[] = [];
 
   for (const rec of recs) {
-    const files = contentMap.get(rec.slug);
+    // Supporting files (references/, scripts/, assets/) are fetched only now,
+    // for the handful of skills actually selected — search-time fetches stay
+    // cheap and off the rate-limited GitHub API. Falls back to the cached
+    // SKILL.md-only content when the full fetch fails (offline, rate limit).
+    const files =
+      (await fetchSkillFiles(rec, { includeSupporting: true })) ?? contentMap.get(rec.slug);
     if (!files) continue;
 
     for (const platform of platforms) {

--- a/src/commands/recommend.ts
+++ b/src/commands/recommend.ts
@@ -2,7 +2,7 @@ import chalk from 'chalk';
 import ora from 'ora';
 import select from '@inquirer/select';
 import { mkdirSync, readFileSync, readdirSync, existsSync, writeFileSync } from 'fs';
-import { join, dirname, resolve } from 'path';
+import { join, dirname, resolve, sep } from 'path';
 import { collectFingerprint, Fingerprint } from '../fingerprint/index.js';
 import { scanLocalState } from '../scanner/index.js';
 import { llmJsonCall } from '../llm/index.js';
@@ -42,7 +42,7 @@ function sanitizeSlug(slug: string): string {
   return slug.replace(/[^a-zA-Z0-9_-]/g, '-').replace(/^-+|-+$/g, '');
 }
 
-function getSkillPath(platform: Platform, slug: string): string {
+export function getSkillPath(platform: Platform, slug: string, relPath = 'SKILL.md'): string {
   const safe = sanitizeSlug(slug);
   if (!safe) throw new Error(`Invalid skill slug: "${slug}"`);
 
@@ -56,12 +56,13 @@ function getSkillPath(platform: Platform, slug: string): string {
           : join('.claude', 'skills');
 
   const cwd = process.cwd();
-  const fullPath = resolve(cwd, baseDir, safe, 'SKILL.md');
-  if (!fullPath.startsWith(resolve(cwd, baseDir) + '/')) {
-    throw new Error(`Skill path escapes base directory: "${slug}"`);
+  const skillDir = resolve(cwd, baseDir, safe);
+  const fullPath = resolve(skillDir, relPath);
+  if (!fullPath.startsWith(skillDir + sep)) {
+    throw new Error(`Skill file path escapes skill directory: "${slug}/${relPath}"`);
   }
 
-  return join(baseDir, safe, 'SKILL.md');
+  return join(baseDir, safe, relPath);
 }
 
 function getSkillDir(platform: Platform): string {
@@ -383,7 +384,7 @@ function extractTopDeps(): string[] {
 
 export interface SkillSearchResult {
   results: SkillResult[];
-  contentMap: Map<string, string>;
+  contentMap: Map<string, SkillFileMap>;
 }
 
 export async function searchSkills(
@@ -440,10 +441,10 @@ export async function searchSkills(
   }
 
   onStatus?.('Fetching skill content...');
-  const contentMap = new Map<string, string>();
+  const contentMap = new Map<string, SkillFileMap>();
   await Promise.all(
     results.map(async (rec) => {
-      const content = await fetchSkillContent(rec);
+      const content = await fetchSkillFiles(rec);
       if (content) contentMap.set(rec.slug, content);
     }),
   );
@@ -506,10 +507,10 @@ export async function querySkills(query: string): Promise<void> {
 
   // Verify content is available
   const fetchSpinner = ora('Verifying availability...').start();
-  const contentMap = new Map<string, string>();
+  const contentMap = new Map<string, SkillFileMap>();
   await Promise.all(
     top.map(async (rec) => {
-      const content = await fetchSkillContent(rec);
+      const content = await fetchSkillFiles(rec);
       if (content) contentMap.set(rec.slug, content);
     }),
   );
@@ -568,10 +569,10 @@ export async function installBySlug(slugStr: string): Promise<void> {
   }
 
   // Fetch content
-  const contentMap = new Map<string, string>();
+  const contentMap = new Map<string, SkillFileMap>();
   await Promise.all(
     matched.map(async (rec) => {
-      const content = await fetchSkillContent(rec);
+      const content = await fetchSkillFiles(rec);
       if (content) contentMap.set(rec.slug, content);
     }),
   );
@@ -694,10 +695,10 @@ export async function searchAndInstallSkills(targetPlatforms?: Platform[]): Prom
 
   // Step 4: Pre-fetch content — only show skills that are actually installable
   const fetchSpinner = ora('Verifying skill availability...').start();
-  const contentMap = new Map<string, string>();
+  const contentMap = new Map<string, SkillFileMap>();
   await Promise.all(
     results.map(async (rec) => {
-      const content = await fetchSkillContent(rec);
+      const content = await fetchSkillFiles(rec);
       if (content) contentMap.set(rec.slug, content);
     }),
   );
@@ -861,27 +862,103 @@ async function interactiveSelect(recs: SkillResult[]): Promise<SkillResult[] | n
 
 // --- Content fetching & install ---
 
-async function fetchSkillContent(rec: SkillResult): Promise<string | null> {
+const FETCH_TIMEOUT = 5_000;
+const MAX_SKILL_FILES = 50;
+const MAX_SKILL_FILE_SIZE = 1024 * 1024; // 1 MB
+const MAX_SKILL_DIR_DEPTH = 3;
+
+/** Files belonging to one skill, keyed by path relative to the skill directory. */
+export type SkillFileMap = Map<string, Buffer>;
+
+interface GitHubDirEntry {
+  name: string;
+  path: string;
+  type: string;
+  size: number;
+  download_url: string | null;
+}
+
+function isSafeRelPath(rel: string): boolean {
+  return (
+    !rel.startsWith('/') &&
+    !rel.includes('\\') &&
+    rel.split('/').every((seg) => seg !== '' && seg !== '.' && seg !== '..')
+  );
+}
+
+/**
+ * Recursively collect supporting files (references/, scripts/, assets/, ...)
+ * that live next to SKILL.md upstream (#228). Best-effort: any listing or
+ * download failure is skipped so it never blocks the SKILL.md install.
+ * Symlinks and submodules are skipped; caps bound depth, count, and file size.
+ */
+async function collectSupportingFiles(
+  repoPath: string,
+  dirPath: string,
+  skillDirPath: string,
+  depth: number,
+  files: SkillFileMap,
+): Promise<void> {
+  if (depth > MAX_SKILL_DIR_DEPTH || files.size >= MAX_SKILL_FILES) return;
+
+  let entries: GitHubDirEntry[];
+  try {
+    const resp = await fetch(`https://api.github.com/repos/${repoPath}/contents/${dirPath}`, {
+      signal: AbortSignal.timeout(FETCH_TIMEOUT),
+      headers: { Accept: 'application/vnd.github+json' },
+    });
+    if (!resp.ok) return;
+    const data = (await resp.json()) as unknown;
+    if (!Array.isArray(data)) return;
+    entries = data as GitHubDirEntry[];
+  } catch {
+    return;
+  }
+
+  for (const entry of entries) {
+    if (files.size >= MAX_SKILL_FILES) return;
+
+    const rel = entry.path.startsWith(skillDirPath + '/')
+      ? entry.path.slice(skillDirPath.length + 1)
+      : entry.name;
+    if (!isSafeRelPath(rel) || files.has(rel)) continue;
+
+    if (entry.type === 'dir') {
+      await collectSupportingFiles(repoPath, entry.path, skillDirPath, depth + 1, files);
+    } else if (entry.type === 'file' && entry.download_url && entry.size <= MAX_SKILL_FILE_SIZE) {
+      try {
+        const resp = await fetch(entry.download_url, {
+          signal: AbortSignal.timeout(FETCH_TIMEOUT),
+        });
+        if (resp.ok) files.set(rel, Buffer.from(await resp.arrayBuffer()));
+      } catch {}
+    }
+  }
+}
+
+export async function fetchSkillFiles(rec: SkillResult): Promise<SkillFileMap | null> {
   if (!rec.source_url) return null;
 
   const repoPath = rec.source_url.replace('https://github.com/', '');
 
-  const FETCH_TIMEOUT = 5_000;
+  // Try common skill directory locations in the source repo
+  const dirCandidates = [`skills/${rec.slug}`, `.claude/skills/${rec.slug}`, rec.slug];
 
-  // Try common skill file locations in the source repo
-  const candidates = [
-    `https://raw.githubusercontent.com/${repoPath}/HEAD/skills/${rec.slug}/SKILL.md`,
-    `https://raw.githubusercontent.com/${repoPath}/HEAD/.claude/skills/${rec.slug}/SKILL.md`,
-    `https://raw.githubusercontent.com/${repoPath}/HEAD/${rec.slug}/SKILL.md`,
-  ];
-
-  for (const url of candidates) {
+  for (const dir of dirCandidates) {
     try {
-      const resp = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT) });
-      if (resp.ok) {
-        const text = await resp.text();
-        if (text.length > 20) return text;
-      }
+      const resp = await fetch(
+        `https://raw.githubusercontent.com/${repoPath}/HEAD/${dir}/SKILL.md`,
+        {
+          signal: AbortSignal.timeout(FETCH_TIMEOUT),
+        },
+      );
+      if (!resp.ok) continue;
+      const text = await resp.text();
+      if (text.length <= 20) continue;
+
+      const files: SkillFileMap = new Map([['SKILL.md', Buffer.from(text, 'utf-8')]]);
+      await collectSupportingFiles(repoPath, dir, dir, 0, files);
+      return files;
     } catch {}
   }
 
@@ -891,21 +968,24 @@ async function fetchSkillContent(rec: SkillResult): Promise<string | null> {
 async function installSkills(
   recs: SkillResult[],
   platforms: Platform[],
-  contentMap: Map<string, string>,
+  contentMap: Map<string, SkillFileMap>,
 ): Promise<void> {
   const spinner = ora(`Installing ${recs.length} skill${recs.length > 1 ? 's' : ''}...`).start();
   const installed: string[] = [];
 
   for (const rec of recs) {
-    const content = contentMap.get(rec.slug);
-    if (!content) continue;
+    const files = contentMap.get(rec.slug);
+    if (!files) continue;
 
     for (const platform of platforms) {
-      const skillPath = getSkillPath(platform, rec.slug);
-      const fullPath = join(process.cwd(), skillPath);
-      mkdirSync(dirname(fullPath), { recursive: true });
-      writeFileSync(fullPath, content, 'utf-8');
-      installed.push(`[${platform}] ${skillPath}`);
+      for (const [relPath, content] of files) {
+        const skillPath = getSkillPath(platform, rec.slug, relPath);
+        const fullPath = join(process.cwd(), skillPath);
+        mkdirSync(dirname(fullPath), { recursive: true });
+        writeFileSync(fullPath, content);
+      }
+      const extra = files.size > 1 ? ` (+${files.size - 1} supporting files)` : '';
+      installed.push(`[${platform}] ${getSkillPath(platform, rec.slug)}${extra}`);
     }
   }
 


### PR DESCRIPTION
## Summary

Fixes #228. The installer fetched only `SKILL.md` for community skills, silently dropping supporting files in `references/`, `scripts/`, and `assets/` — agents were then instructed to read files that don't exist locally.

- After locating `SKILL.md`, list the upstream skill directory via the GitHub contents API and recursively download all sibling files (binary-safe via `arrayBuffer`)
- Safety: per-file path-escape rejection at write time (`getSkillPath` now validates any relative path against the skill dir), symlink/submodule entries skipped, caps on depth (3), file count (50), and file size (1 MB)
- Graceful degradation: if directory listing fails (rate limit, offline), installs `SKILL.md` only — current behavior preserved
- `getSkillPath` containment check now uses `path.sep` (was hardcoded `/`, broken on Windows)

## Test plan

- [x] 8 new unit tests: recursive fetch, listing-failure fallback, symlink/unsafe-path/oversize skipping, file cap, nested path building, escape rejection, multi-platform install with supporting files
- [x] Existing recommend tests pass (22/22 total)
- [x] Type-check and lint clean

Made with [Cursor](https://cursor.com)