### PR TITLE
feat(hooks): allow opting out of pre-commit auto-staging

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,12 @@ caliber hooks --remove     # Disable refresh hooks
 
 The `refresh` command analyzes your git diff (committed, staged, and unstaged changes) and updates config files to reflect what changed.
 
+By default the pre-commit hook stages refreshed doc files into the commit in flight. If you prefer to review refreshed docs before committing them (e.g. signed-commit or minimal-diff workflows), disable auto-staging — the refresh still runs, but updated files stay in your working tree:
+
+```bash
+git config caliber.autostage false
+```
+
 </details>
 
 <details>

--- a/src/lib/__tests__/hooks-autostage.test.ts
+++ b/src/lib/__tests__/hooks-autostage.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { execFileSync } from 'child_process';
+
+// Force the generated hook to invoke our fake caliber binary (below) instead
+// of resolving a real install. Everything else in resolve-caliber stays real.
+let FAKE_CALIBER = '';
+vi.mock('../resolve-caliber.js', async (importActual) => {
+  const actual = await importActual<typeof import('../resolve-caliber.js')>();
+  return { ...actual, resolveCaliber: () => FAKE_CALIBER };
+});
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf-8' }).trim();
+}
+
+/**
+ * Execution-level coverage for #225: the generated pre-commit block must NOT
+ * stage refreshed managed docs when `git config caliber.autostage false` is
+ * set. Content-level assertions live in hooks.test.ts; this actually runs the
+ * hook with a real git repo + /bin/sh and inspects the index.
+ */
+describe.skipIf(process.platform === 'win32')('pre-commit autostage execution (#225)', () => {
+  let tmpDir: string;
+  let origCwd: string;
+
+  beforeEach(() => {
+    origCwd = process.cwd();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'autostage-exec-'));
+
+    git(tmpDir, 'init', '-q');
+    git(tmpDir, 'config', 'user.email', 'test@example.com');
+    git(tmpDir, 'config', 'user.name', 'Test');
+    git(tmpDir, 'config', 'commit.gpgsign', 'false');
+
+    // A fake caliber that mutates a managed doc on `refresh` and no-ops on
+    // `learn finalize` — mimics what a real refresh does to CLAUDE.md.
+    FAKE_CALIBER = path.join(tmpDir, 'fake-caliber');
+    fs.writeFileSync(
+      FAKE_CALIBER,
+      '#!/bin/sh\nif [ "$1" = "refresh" ]; then echo refreshed >> CLAUDE.md; fi\nexit 0\n',
+    );
+    fs.chmodSync(FAKE_CALIBER, 0o755);
+
+    // Track CLAUDE.md so `git diff --name-only` surfaces the refresh mutation.
+    fs.writeFileSync(path.join(tmpDir, 'CLAUDE.md'), 'v1\n');
+    git(tmpDir, 'add', 'CLAUDE.md');
+    git(tmpDir, 'commit', '-q', '-m', 'init');
+
+    process.chdir(tmpDir);
+  });
+
+  afterEach(() => {
+    process.chdir(origCwd);
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.restoreAllMocks();
+    vi.resetModules();
+  });
+
+  async function installAndRunHook(): Promise<void> {
+    const { resetResolvedCaliber } = await import('../resolve-caliber.js');
+    resetResolvedCaliber();
+    const { installPreCommitHook } = await import('../hooks.js');
+    installPreCommitHook();
+    execFileSync('sh', [path.join(tmpDir, '.git', 'hooks', 'pre-commit')], { cwd: tmpDir });
+  }
+
+  function stagedFiles(): string[] {
+    return git(tmpDir, 'diff', '--cached', '--name-only').split('\n').filter(Boolean);
+  }
+
+  it('leaves refreshed docs unstaged when caliber.autostage=false', async () => {
+    git(tmpDir, 'config', 'caliber.autostage', 'false');
+
+    await installAndRunHook();
+
+    // The refresh ran (working tree changed) but the doc must not be staged.
+    expect(fs.readFileSync(path.join(tmpDir, 'CLAUDE.md'), 'utf-8')).toContain('refreshed');
+    expect(stagedFiles()).not.toContain('CLAUDE.md');
+  });
+
+  it('stages refreshed docs by default (no opt-out configured)', async () => {
+    await installAndRunHook();
+
+    expect(fs.readFileSync(path.join(tmpDir, 'CLAUDE.md'), 'utf-8')).toContain('refreshed');
+    expect(stagedFiles()).toContain('CLAUDE.md');
+  });
+});

--- a/src/lib/__tests__/hooks.test.ts
+++ b/src/lib/__tests__/hooks.test.ts
@@ -647,7 +647,7 @@ describe('pre-commit hook version marker (F-P0-4)', () => {
       expect(result.upgraded).toBe(false);
       expect(isPreCommitHookCurrent()).toBe(true);
       const content = fs.readFileSync(path.join(hooksDir, 'pre-commit'), 'utf-8');
-      expect(content).toContain('# caliber:pre-commit:v2:start');
+      expect(content).toContain('# caliber:pre-commit:v3:start');
     } finally {
       process.chdir(origCwd);
       fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -707,7 +707,7 @@ describe('pre-commit hook version marker (F-P0-4)', () => {
       expect(result.alreadyInstalled).toBe(false);
 
       const newContent = fs.readFileSync(hookPath, 'utf-8');
-      expect(newContent).toContain('# caliber:pre-commit:v2:start');
+      expect(newContent).toContain('# caliber:pre-commit:v3:start');
       expect(newContent).not.toContain('old body that uses old refresh flags');
     } finally {
       process.chdir(origCwd);
@@ -729,7 +729,7 @@ describe('pre-commit hook version marker (F-P0-4)', () => {
       installPreCommitHook();
       const newContent = fs.readFileSync(hookPath, 'utf-8');
       expect(newContent).toContain('gitleaks detect --no-banner');
-      expect(newContent).toContain('# caliber:pre-commit:v2:start');
+      expect(newContent).toContain('# caliber:pre-commit:v3:start');
     } finally {
       process.chdir(origCwd);
       fs.rmSync(tmpDir, { recursive: true, force: true });
@@ -784,6 +784,49 @@ describe('pre-commit hook version marker (F-P0-4)', () => {
       // Must redirect to stderr so it survives normal stdout suppression in
       // git output. The previous '|| true' silenced everything.
       expect(content).toMatch(/>&2/);
+    } finally {
+      process.chdir(origCwd);
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('guards staging behind the caliber.autostage config key (#225)', async () => {
+    const { installPreCommitHook } = await import('../hooks.js');
+    const { tmpDir, hooksDir } = setupTmpRepo();
+    const origCwd = process.cwd();
+    process.chdir(tmpDir);
+    try {
+      installPreCommitHook();
+      const content = fs.readFileSync(path.join(hooksDir, 'pre-commit'), 'utf-8');
+      // The git add must only run when caliber.autostage is not "false"
+      const guardIdx = content.indexOf('git config --get caliber.autostage');
+      const addIdx = content.indexOf('xargs git add');
+      expect(guardIdx).toBeGreaterThan(-1);
+      expect(addIdx).toBeGreaterThan(guardIdx);
+      expect(content).toContain('autostage disabled');
+    } finally {
+      process.chdir(origCwd);
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('upgrades a v2 hook to v3 with the autostage guard', async () => {
+    const { installPreCommitHook } = await import('../hooks.js');
+    const { tmpDir, hooksDir } = setupTmpRepo();
+    const hookPath = path.join(hooksDir, 'pre-commit');
+    fs.writeFileSync(
+      hookPath,
+      '#!/bin/sh\n\n# caliber:pre-commit:v2:start\nunconditional git add body\n# caliber:pre-commit:v2:end\n',
+    );
+    const origCwd = process.cwd();
+    process.chdir(tmpDir);
+    try {
+      const result = installPreCommitHook();
+      expect(result.upgraded).toBe(true);
+      const content = fs.readFileSync(hookPath, 'utf-8');
+      expect(content).toContain('# caliber:pre-commit:v3:start');
+      expect(content).toContain('git config --get caliber.autostage');
+      expect(content).not.toContain('unconditional git add body');
     } finally {
       process.chdir(origCwd);
       fs.rmSync(tmpDir, { recursive: true, force: true });

--- a/src/lib/hooks.ts
+++ b/src/lib/hooks.ts
@@ -312,7 +312,10 @@ export const removeNotificationHook = notificationHook.remove;
 //
 // Audit finding: F-P0-4 in
 // docs/superpowers/specs/2026-04-29-caliber-install-audit-findings.md
-const HOOK_BLOCK_VERSION = 'v2';
+//
+// v3: staging of refreshed docs is now skippable via
+// `git config caliber.autostage false` (#225).
+const HOOK_BLOCK_VERSION = 'v3';
 const PRECOMMIT_START = `# caliber:pre-commit:${HOOK_BLOCK_VERSION}:start`;
 const PRECOMMIT_END = `# caliber:pre-commit:${HOOK_BLOCK_VERSION}:end`;
 const PRECOMMIT_ANY_VERSION_START_RE = /^#\s*caliber:pre-commit:(?:[a-zA-Z0-9_.-]+:)?start\s*$/m;
@@ -425,7 +428,14 @@ if ${guard}; then
   echo "\\033[2mcaliber: refreshing docs...\\033[0m"
   ${invoke} refresh --quiet 2>.caliber/refresh-hook.log || echo "\\033[33mcaliber: refresh skipped — see .caliber/refresh-hook.log\\033[0m" >&2
   ${invoke} learn finalize 2>>.caliber/refresh-hook.log || true
-  git diff --name-only -- CLAUDE.md .claude/ .cursor/ AGENTS.md CALIBER_LEARNINGS.md .github/ .agents/ .opencode/ 2>/dev/null | xargs git add 2>/dev/null || true
+  # Opt out of auto-staging refreshed docs into the in-flight commit with:
+  #   git config caliber.autostage false
+  # Refreshed files then stay in the working tree for deliberate review/commit.
+  if [ "$(git config --get caliber.autostage 2>/dev/null)" != "false" ]; then
+    git diff --name-only -- CLAUDE.md .claude/ .cursor/ AGENTS.md CALIBER_LEARNINGS.md .github/ .agents/ .opencode/ 2>/dev/null | xargs git add 2>/dev/null || true
+  else
+    echo "\\033[2mcaliber: autostage disabled — refreshed docs left unstaged\\033[0m"
+  fi
 fi
 ${PRECOMMIT_END}`;
 }


### PR DESCRIPTION
## Summary

Fixes #225. The pre-commit hook block unconditionally staged Caliber-managed doc files into the in-flight commit — expanding commit scope beyond what the author staged, which breaks GPG-signed-commit and minimal-diff workflows.

- New opt-out: `git config caliber.autostage false` — the refresh and `learn finalize` still run, but refreshed files stay in the working tree for deliberate review and commit
- Checked at commit time inside the hook script, so the preference survives hook auto-upgrades and reinstalls with no extra state
- Hook block bumped to v3 → existing users get the guard automatically via the version-upgrade path
- Documented in the README Auto-Refresh section

## Test plan

- [x] New tests: generated block guards `git add` behind the config key; v2 → v3 upgrade replaces the old unconditional block
- [x] All 31 hooks tests pass (unit + shell)
- [x] Lint clean (2 pre-existing warnings untouched)

Made with [Cursor](https://cursor.com)