### PR TITLE
ci: serialize npm publishes and fix PR size labelling on forks

### DIFF
--- a/.github/workflows/pr-size.yml
+++ b/.github/workflows/pr-size.yml
@@ -1,7 +1,10 @@
 name: PR Size Label
 
+# pull_request_target so fork PRs get a writable token — `pull_request` runs from
+# a fork are read-only and the labelling API call 403s. Safe here: this workflow
+# never checks out PR code, it only calls the API.
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize]
 
 permissions:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,13 @@ on:
     types: [completed]
     branches: [master]
 
+# Serialize releases. Two merges landing close together each trigger a publish;
+# without this the second run races the first and its push is rejected after the
+# package is already on npm.
+concurrency:
+  group: publish-npm
+  cancel-in-progress: false
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -174,10 +181,13 @@ jobs:
           git config user.email "github-actions@github.com"
           git add package.json package-lock.json CHANGELOG.md
           git diff --cached --quiet && echo "No version changes to commit" || git commit -m "chore: release v${VERSION} [skip ci]"
+          # Rebase before tagging: if master moved since checkout, tagging first
+          # would leave the tag on a commit the rebase orphans.
+          git pull --rebase origin master
           git tag "v${VERSION}"
           MAJOR=$(echo "${VERSION}" | cut -d. -f1)
           git tag -f "v${MAJOR}"
-          git push && git push origin "v${VERSION}" && git push -f origin "v${MAJOR}"
+          git push origin HEAD:master && git push origin "v${VERSION}" && git push -f origin "v${MAJOR}"
 
       - name: Create GitHub release
         if: steps.version.outputs.skip != 'true'


### PR DESCRIPTION
## Why

Two problems surfaced while merging the recent batch of PRs.

**1. The publish workflow races itself.** #222 and #227 merged about two minutes apart, so each triggered a `Publish to npm` run. The second race lost: #222's run got as far as publishing `1.53.1` to npm, then failed on the version-bump push because #227's merge had already moved master.

```
! [rejected]  master -> master (fetch first)
##[error]Process completed with exit code 1
```

The net effect was a package on npm with no matching git tag and no GitHub release. Users were unaffected — #227's run then shipped `v1.53.2`, which contains everything — but this recurs on any back-to-back merge.

**2. PR size labelling 403s on every fork PR.** `pull_request` gives fork-originated runs a read-only token, so `issues.addLabels` fails with `Resource not accessible by integration` no matter what `permissions:` declares. This is what made #229 initially look unmergeable. Confirmed by the run history: every fork branch fails, every internal branch passes.

## What changed

- `publish.yml` gets a `concurrency: publish-npm` group with `cancel-in-progress: false`, so a queued release waits for the in-flight one and then checks out a master that already has the previous release commit.
- `publish.yml` rebases onto `origin/master` **before** tagging. Tagging first would leave the tag pointing at a commit the rebase orphans. The bare `git push` is now an explicit `git push origin HEAD:master`.
- `pr-size.yml` switches to `pull_request_target`. This is safe here specifically because the workflow never checks out PR code — it only reads the file list and applies a label through the API.

`caliber-score.yml` also runs on `pull_request` with `pull-requests: write`, but its run history shows it succeeding on fork PRs, so it is deliberately left alone. It checks out code, which would make `pull_request_target` unsafe.

## Test plan

- [x] All seven workflow files parse as valid YAML
- [ ] Merge, then confirm the next release tags and pushes cleanly
- [ ] Confirm the next fork PR receives a `size/*` label instead of a red check

Made with [Cursor](https://cursor.com)