### PR TITLE
fix(opencode): detect login from credential counts, not output length

### DIFF
--- a/src/llm/__tests__/opencode.test.ts
+++ b/src/llm/__tests__/opencode.test.ts
@@ -3,6 +3,7 @@ import {
   OpenCodeProvider,
   isOpenCodeAvailable,
   isOpenCodeLoggedIn,
+  parseOpenCodeAuthList,
   resetOpenCodeLoginCache,
 } from '../opencode.js';
 import type { LLMConfig } from '../types.js';
@@ -671,12 +672,63 @@ describe('isOpenCodeLoggedIn', () => {
     expect(isOpenCodeLoggedIn()).toBe(true);
   });
 
+  // `opencode auth list` always prints its section headers, so a logged-out
+  // machine still produces ~150 bytes of output (#115).
+  it('returns false for real CLI output with nothing authenticated', () => {
+    execSync.mockReturnValue(
+      Buffer.from(
+        '┌  Credentials \u001b[90m~/.local/share/opencode/auth.json\n│\n└  0 credentials\n\n' +
+          '┌  Environment\n│\n└  0 environment variables\n\n',
+      ),
+    );
+    expect(isOpenCodeLoggedIn()).toBe(false);
+  });
+
+  it('returns true when only an environment variable supplies the credential', () => {
+    execSync.mockReturnValue(
+      Buffer.from(
+        '┌  Credentials \u001b[90m~/.local/share/opencode/auth.json\n│\n└  0 credentials\n\n' +
+          '┌  Environment\n│\n●  Google \u001b[90mGEMINI_API_KEY\n│\n└  1 environment variable\n\n',
+      ),
+    );
+    expect(isOpenCodeLoggedIn()).toBe(true);
+  });
+
+  it('returns true when credentials are stored even with no environment variables', () => {
+    execSync.mockReturnValue(
+      Buffer.from(
+        '┌  Credentials\n│\n●  Anthropic\n│\n└  2 credentials\n\n' +
+          '┌  Environment\n│\n└  0 environment variables\n\n',
+      ),
+    );
+    expect(isOpenCodeLoggedIn()).toBe(true);
+  });
+
   it('caches the result across calls', () => {
     execSync.mockReturnValue(Buffer.from('user@example.com\n'));
     expect(isOpenCodeLoggedIn()).toBe(true);
     execSync.mockReset(); // clear mock but cache should still have value
     expect(isOpenCodeLoggedIn()).toBe(true);
     expect(execSync).not.toHaveBeenCalled();
+  });
+});
+
+describe('parseOpenCodeAuthList', () => {
+  it('returns null when no counts are present so the caller can fail open', () => {
+    expect(parseOpenCodeAuthList('some future format with no counts')).toBeNull();
+    expect(parseOpenCodeAuthList('')).toBeNull();
+  });
+
+  it('reads counts through ANSI colour codes', () => {
+    expect(parseOpenCodeAuthList('\u001b[90m0 credentials\u001b[0m')).toBe(false);
+    expect(parseOpenCodeAuthList('\u001b[32m3 credentials\u001b[0m')).toBe(true);
+  });
+
+  it('handles singular and plural forms', () => {
+    expect(parseOpenCodeAuthList('1 credential')).toBe(true);
+    expect(parseOpenCodeAuthList('0 credential')).toBe(false);
+    expect(parseOpenCodeAuthList('1 environment variable')).toBe(true);
+    expect(parseOpenCodeAuthList('0 environment variables')).toBe(false);
   });
 });
 

--- a/src/llm/opencode.ts
+++ b/src/llm/opencode.ts
@@ -30,11 +30,29 @@ export function resetOpenCodeLoginCache(): void {
 export function isOpenCodeAvailable(): boolean {
   try {
     const cmd = IS_WINDOWS ? `where ${OPENCODE_BIN}` : `which ${OPENCODE_BIN}`;
-    execSync(cmd,{ stdio: 'ignore', windowsHide: true });
+    execSync(cmd, { stdio: 'ignore', windowsHide: true });
     return true;
   } catch {
     return false;
   }
+}
+
+/**
+ * Reads the credential and environment-variable counts out of `opencode auth list`.
+ *
+ * The command always prints its section headers, so output length says nothing
+ * about whether anything is actually authenticated — a machine with nothing
+ * configured still emits "0 credentials". Only the counts are meaningful.
+ *
+ * Returns null when neither count can be found, which means the CLI changed its
+ * output format and the caller should not draw a conclusion from it.
+ */
+export function parseOpenCodeAuthList(output: string): boolean | null {
+  const plain = output.replace(/\u001b\[[0-9;]*m/g, '');
+  const credentials = plain.match(/(\d+)\s+credentials?\b/i);
+  const envVars = plain.match(/(\d+)\s+environment variables?\b/i);
+  if (!credentials && !envVars) return null;
+  return Number(credentials?.[1] ?? 0) > 0 || Number(envVars?.[1] ?? 0) > 0;
 }
 
 /** Whether the user is logged in to OpenCode CLI. Uses `opencode auth list` for a zero-cost check. Result is cached for the process lifetime. */
@@ -46,8 +64,11 @@ export function isOpenCodeLoggedIn(): boolean {
       stdio: ['pipe', 'pipe', 'pipe'],
       windowsHide: true,
     });
-    // If command succeeds and returns non-empty output, user is logged in
-    cachedLoggedIn = result.toString().trim().length > 0;
+    const parsed = parseOpenCodeAuthList(result.toString());
+    // Unrecognised output means a CLI format change. Assume logged in rather
+    // than locking out users who are authenticated (see #115) — a genuine auth
+    // failure still surfaces later with the provider's own error message.
+    cachedLoggedIn = parsed ?? result.toString().trim().length > 0;
   } catch {
     // Command failed or not found - treat as not logged in
     cachedLoggedIn = false;
@@ -62,7 +83,7 @@ function spawnOpenCode(args: string[]): ChildProcess {
   // Same subprocess sentinel pattern as spawnClaude — see src/lib/subprocess-sentinel.ts.
   const env = withCaliberSubprocessEnv({ ...process.env, OPENCODE_DISABLE_AUTOCOMPACT: 'TRUE' });
   if (IS_WINDOWS) {
-    return spawn([OPENCODE_BIN, ...args].join(' '),{
+    return spawn([OPENCODE_BIN, ...args].join(' '), {
       cwd: process.cwd(),
       stdio: ['pipe', 'pipe', 'pipe'] as const,
       env,
@@ -70,7 +91,7 @@ function spawnOpenCode(args: string[]): ChildProcess {
       windowsHide: true,
     });
   } else {
-    return spawn(OPENCODE_BIN, args,{
+    return spawn(OPENCODE_BIN, args, {
       cwd: process.cwd(),
       stdio: ['pipe', 'pipe', 'pipe'] as const,
       env,


### PR DESCRIPTION
Closes #115.

## The bug

`isOpenCodeLoggedIn()` decided whether the user was authenticated by checking whether `opencode auth list` produced any output at all:

```ts
cachedLoggedIn = result.toString().trim().length > 0;
```

But that command always prints its section headers. On a machine with nothing configured it still emits about 150 bytes:

```
┌  Credentials ~/.local/share/opencode/auth.json
│
└  0 credentials

┌  Environment
│
└  0 environment variables
```

So the check returned `true` for anyone with the CLI on their PATH, authenticated or not. The guard only ever caught the case where the binary was missing — which `isOpenCodeAvailable()` already covers — making it effectively dead code. A genuinely logged-out user sailed past it and hit an opaque failure inside the LLM call instead of the intended "run `opencode auth login`" message.

Verified against opencode 1.17.13:

```
$ node -e "... execSync('opencode auth list') ..."
trimmed length: 148
caliber verdict loggedIn = true     # with 0 credentials
```

## The fix

Parse the credential and environment-variable counts, which are the only meaningful signal in that output. Environment variables count as authenticated because OpenCode picks up provider keys from the environment as well as from `auth.json`.

When neither count can be found the CLI has changed its format, so we fall back to assuming the user is logged in. That direction matters: #115 was originally reported as a *false negative* (the code used `opencode auth status`, which does not exist, locking out authenticated users). Failing open keeps a future format change from reintroducing that, and a real auth failure still surfaces with the provider's own error message.

## Why it went unnoticed

The existing tests only fed the check bare strings like `'user@example.com\n'` and `''`, so they exercised the length heuristic rather than anything resembling CLI output. They now use captured real output for the logged-out, credential-authenticated, and env-var-authenticated cases, plus direct coverage of the parser for ANSI codes, singular/plural forms, and the unrecognised-format path.

## Notes on #115

The rest of the issue is already shipped — OpenCode is registered as a provider (`ProviderType`, `createProvider`, `DEFAULT_MODELS`, model recovery, interactive setup) and as a write target (`src/writers/opencode/`). @thejohnlin's report was the last open thread on it; the `auth status` call they identified was replaced with `auth list` earlier, and this change fixes the remaining half of the same guard.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] Full suite: 1204 passed, 0 failed
- [x] `eslint` clean on both changed files
- [x] Behaviour confirmed against a real opencode 1.17.13 install

Made with [Cursor](https://cursor.com)