### PR TITLE
fix(scoring): ground project_grounding on dirs and notable files

### DIFF
--- a/src/ai/prompts.ts
+++ b/src/ai/prompts.ts
@@ -113,7 +113,7 @@ Quality (25 pts):
 - Structured with headings (2 pts) — use at least 3 ## sections and bullet lists
 
 Grounding (20 pts) — CRITICAL:
-- Project grounding (12 pts) — reference the project's actual directories and files by name. The scoring checks which project dirs/files from the file tree appear in your config. Mention key directories and files. (50%+ coverage = full points, 35% = 9pts, 20% = 6pts, 10% = 3pts)
+- Project grounding (12 pts) — reference key project directories and notable files (entry points, manifests, config files) by name. Scoring covers dirs + notable files only — not every leaf file. Do NOT add directory tree listings. (50%+ coverage = full points, 35% = 9pts, 20% = 6pts, 10% = 3pts)
 - Reference density (8 pts) — use backticks and inline code extensively. Every file path, command, or identifier should be in backticks. Higher density of backtick references per line = higher score. (40%+ = full, 25% = 6pts, 15% = 4pts)
 
 Accuracy (15 pts) — CRITICAL:
@@ -122,7 +122,7 @@ Accuracy (15 pts) — CRITICAL:
 
 Safety: Never include API keys, tokens, or credentials in config files.
 
-PRIORITY WHEN CONSTRAINTS CONFLICT: Grounding and reference density matter more than raw token count. A 2500-token config that references 50%+ of the project's directories scores higher than a 1500-token config that only mentions 3 paths. Pack references densely using the inline path style shown in OUTPUT SIZE CONSTRAINTS.
+PRIORITY WHEN CONSTRAINTS CONFLICT: Grounding and reference density matter more than raw token count. A 2500-token config that references 50%+ of key dirs and notable files scores higher than a 1500-token config that only mentions 3 paths. Pack references densely using the inline path style shown in OUTPUT SIZE CONSTRAINTS — never pad with directory tree listings.
 
 Note: Permissions, hooks, freshness tracking, and OpenSkills frontmatter are scored automatically by caliber — do not optimize for them.
 README.md is provided for context only — do NOT include a readmeMd field in your output.`;

--- a/src/ai/score-refine.ts
+++ b/src/ai/score-refine.ts
@@ -11,6 +11,8 @@ import {
   extractReferences,
   calculateDuplicatePercent,
   calculateDensityPoints,
+  computeGroundingCoverage,
+  isNotableGroundingFile,
   type ProjectStructure,
 } from '../scoring/utils.js';
 import {
@@ -23,7 +25,6 @@ import {
   POINTS_PROJECT_GROUNDING,
   POINTS_REFERENCE_DENSITY,
   POINTS_NO_DUPLICATES,
-  GROUNDING_THRESHOLDS,
 } from '../scoring/constants.js';
 import { llmCall } from '../llm/index.js';
 import { stripMarkdownFences } from '../llm/utils.js';
@@ -94,7 +95,10 @@ function buildGroundingFixInstruction(
       (d) => d.startsWith(`${dir}/`) && !d.includes('/', dir.length + 1),
     );
     const files = projectStructure.files.filter(
-      (f) => f.startsWith(`${dir}/`) && !f.includes('/', dir.length + 1),
+      (f) =>
+        f.startsWith(`${dir}/`) &&
+        !f.includes('/', dir.length + 1) &&
+        isNotableGroundingFile(f),
     );
     const children = [...subdirs.slice(0, 4), ...files.slice(0, 2)];
     const childList = children.map((c) => c.split('/').pop()).join(', ');
@@ -221,25 +225,35 @@ export function validateSetup(
 
   // 7. Project grounding
   const structure = projectStructure ?? collectProjectStructure(dir);
-  const allEntries = [...structure.dirs, ...structure.files].filter((e) => e.length > 2);
+  const contentLower = primaryContent.toLowerCase();
+  const {
+    entries,
+    mentioned: mentionedEntries,
+    notMentioned,
+    ratio: groundingRatio,
+    points: groundingPoints,
+  } = computeGroundingCoverage(contentLower, structure);
 
-  if (allEntries.length > 0) {
-    const contentLower = primaryContent.toLowerCase();
-    const mentionedEntries = allEntries.filter((e) => isEntryMentioned(e, contentLower));
-    const groundingRatio = mentionedEntries.length / allEntries.length;
-    const groundingThreshold = GROUNDING_THRESHOLDS.find((t) => groundingRatio >= t.minRatio);
-    const groundingPoints = groundingThreshold?.points ?? 0;
+  if (entries.length > 0) {
     const groundingLost = POINTS_PROJECT_GROUNDING - groundingPoints;
 
     if (groundingLost > 0) {
       const topDirs = structure.dirs.filter((d) => !d.includes('/') && d.length > 2);
       const unmentionedTopDirs = topDirs.filter((d) => !isEntryMentioned(d, contentLower));
+      const missingHints =
+        unmentionedTopDirs.length > 0 ? unmentionedTopDirs : notMentioned;
 
-      if (unmentionedTopDirs.length > 0) {
+      if (missingHints.length > 0) {
         issues.push({
           check: 'Project grounding',
-          detail: `${mentionedEntries.length}/${allEntries.length} project entries referenced (${Math.round(groundingRatio * 100)}%)`,
-          fixInstruction: buildGroundingFixInstruction(unmentionedTopDirs, structure),
+          detail: `${mentionedEntries.length}/${entries.length} notable project entries referenced (${Math.round(groundingRatio * 100)}%)`,
+          fixInstruction:
+            unmentionedTopDirs.length > 0
+              ? buildGroundingFixInstruction(unmentionedTopDirs, structure)
+              : `Reference these notable project paths: ${missingHints
+                  .slice(0, 8)
+                  .map((p) => `\`${p}\``)
+                  .join(', ')}. Mention them naturally using dense inline references.`,
           pointsLost: groundingLost,
         });
       }

--- a/src/scoring/__tests__/grounding.test.ts
+++ b/src/scoring/__tests__/grounding.test.ts
@@ -4,7 +4,43 @@ import { execSync } from 'child_process';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { checkGrounding } from '../checks/grounding.js';
-import { collectProjectStructure } from '../utils.js';
+import {
+  collectProjectStructure,
+  isNotableGroundingFile,
+  selectGroundingEntries,
+} from '../utils.js';
+import { POINTS_PROJECT_GROUNDING } from '../constants.js';
+
+describe('isNotableGroundingFile', () => {
+  it('includes entry points and config/manifests', () => {
+    expect(isNotableGroundingFile('package.json')).toBe(true);
+    expect(isNotableGroundingFile('src/index.ts')).toBe(true);
+    expect(isNotableGroundingFile('tsconfig.json')).toBe(true);
+    expect(isNotableGroundingFile('Dockerfile')).toBe(true);
+    expect(isNotableGroundingFile('config/app.yaml')).toBe(true);
+  });
+
+  it('excludes ordinary leaf source files', () => {
+    expect(isNotableGroundingFile('src/util/foo.ts')).toBe(false);
+    expect(isNotableGroundingFile('src/commands/init.ts')).toBe(false);
+    expect(isNotableGroundingFile('README.md')).toBe(false);
+  });
+});
+
+describe('selectGroundingEntries', () => {
+  it('keeps dirs and notable files only', () => {
+    const entries = selectGroundingEntries({
+      dirs: ['src', 'src/util'],
+      files: ['package.json', 'src/index.ts', 'src/util/foo.ts', 'README.md'],
+    });
+    expect(entries).toContain('src');
+    expect(entries).toContain('src/util');
+    expect(entries).toContain('package.json');
+    expect(entries).toContain('src/index.ts');
+    expect(entries).not.toContain('src/util/foo.ts');
+    expect(entries).not.toContain('README.md');
+  });
+});
 
 describe('checkGrounding', () => {
   let dir: string;
@@ -80,6 +116,60 @@ describe('checkGrounding', () => {
     const groundingCheck = checks.find((c) => c.id === 'project_grounding');
     expect(groundingCheck).toBeDefined();
     expect(groundingCheck?.earnedPoints).toBe(0);
+  });
+
+  it('ignores non-notable leaf files in the grounding denominator', () => {
+    mkdirSync(join(dir, 'src'));
+    mkdirSync(join(dir, 'scripts'));
+    mkdirSync(join(dir, 'tests'));
+    writeFileSync(join(dir, 'package.json'), '{}');
+    writeFileSync(join(dir, 'src', 'index.ts'), 'export {}');
+    // Many ordinary leaves that must NOT force tree-style enumeration
+    for (let i = 0; i < 40; i++) {
+      writeFileSync(join(dir, 'src', `leaf-${i}.ts`), `export const x${i} = ${i};`);
+    }
+
+    writeFileSync(
+      join(dir, 'CLAUDE.md'),
+      [
+        '# Project',
+        '',
+        'Code in `src/` · scripts in `scripts/` · tests in `tests/`.',
+        'Entry: `src/index.ts`. Manifest: `package.json`.',
+      ].join('\n'),
+    );
+
+    const structure = collectProjectStructure(dir);
+    expect(structure.files.length).toBeGreaterThan(30);
+    const groundingEntries = selectGroundingEntries(structure);
+    expect(groundingEntries.every((e) => !e.includes('leaf-'))).toBe(true);
+
+    const checks = checkGrounding(dir);
+    const groundingCheck = checks.find((c) => c.id === 'project_grounding');
+    expect(groundingCheck?.earnedPoints).toBe(POINTS_PROJECT_GROUNDING);
+    expect(groundingCheck?.detail).toMatch(/notable project entries/);
+  });
+
+  it('suggests unmentioned notable files when top-level dirs are already covered', () => {
+    mkdirSync(join(dir, 'src'));
+    mkdirSync(join(dir, 'tests'));
+    writeFileSync(join(dir, 'package.json'), '{}');
+    writeFileSync(join(dir, 'tsconfig.json'), '{}');
+    writeFileSync(join(dir, 'Dockerfile'), 'FROM node');
+    writeFileSync(join(dir, 'src', 'index.ts'), 'export {}');
+    writeFileSync(
+      join(dir, 'CLAUDE.md'),
+      '# Project\n\nCode in `src/`. Tests in `tests/`.',
+    );
+
+    const checks = checkGrounding(dir);
+    const groundingCheck = checks.find((c) => c.id === 'project_grounding');
+    // 2 dirs mentioned of 6 notable entries (~33%) — below full marks
+    expect(groundingCheck?.earnedPoints).toBeLessThan(POINTS_PROJECT_GROUNDING);
+    expect(groundingCheck?.fix?.data.missing).toEqual(
+      expect.arrayContaining(['package.json', 'tsconfig.json']),
+    );
+    expect(groundingCheck?.suggestion).toMatch(/package\.json|tsconfig\.json/);
   });
 });
 

--- a/src/scoring/checks/grounding.ts
+++ b/src/scoring/checks/grounding.ts
@@ -2,7 +2,6 @@ import type { Check } from '../index.js';
 import {
   POINTS_PROJECT_GROUNDING,
   POINTS_REFERENCE_DENSITY,
-  GROUNDING_THRESHOLDS,
 } from '../constants.js';
 import {
   collectAllConfigContent,
@@ -11,6 +10,7 @@ import {
   extractReferences,
   analyzeMarkdownStructure,
   calculateDensityPoints,
+  computeGroundingCoverage,
 } from '../utils.js';
 
 export function checkGrounding(dir: string): Check[] {
@@ -20,40 +20,23 @@ export function checkGrounding(dir: string): Check[] {
   const configLower = configContent.toLowerCase();
   const projectStructure = collectProjectStructure(dir);
 
-  // 1. Project grounding — does the config reference real project dirs/files?
-  const allProjectEntries = [
-    ...projectStructure.dirs,
-    ...projectStructure.files,
-  ];
-
-  const meaningfulEntries = allProjectEntries.filter(e => e.length > 2);
-
-  const mentioned: string[] = [];
-  const notMentioned: string[] = [];
-
-  for (const entry of meaningfulEntries) {
-    if (isEntryMentioned(entry, configLower)) {
-      mentioned.push(entry);
-    } else {
-      notMentioned.push(entry);
-    }
-  }
-
-  const groundingRatio = meaningfulEntries.length > 0
-    ? mentioned.length / meaningfulEntries.length
-    : 0;
-
-  const groundingThreshold = GROUNDING_THRESHOLDS.find(t => groundingRatio >= t.minRatio);
-  const groundingPoints = meaningfulEntries.length === 0
-    ? 0
-    : groundingThreshold?.points ?? 0;
+  // 1. Project grounding — does the config reference real project dirs/notable files?
+  const {
+    entries,
+    mentioned,
+    notMentioned,
+    ratio: groundingRatio,
+    points: groundingPoints,
+  } = computeGroundingCoverage(configLower, projectStructure);
 
   const topDirs = projectStructure.dirs
-    .filter(d => !d.includes('/'))
-    .filter(d => d.length > 2);
+    .filter((d) => !d.includes('/'))
+    .filter((d) => d.length > 2);
 
-  const unmentionedTopDirs = topDirs.filter(d => !isEntryMentioned(d, configLower));
-  const mentionedTopDirs = topDirs.filter(d => isEntryMentioned(d, configLower));
+  const unmentionedTopDirs = topDirs.filter((d) => !isEntryMentioned(d, configLower));
+  const mentionedTopDirs = topDirs.filter((d) => isEntryMentioned(d, configLower));
+  const missingHints =
+    unmentionedTopDirs.length > 0 ? unmentionedTopDirs : notMentioned;
 
   checks.push({
     id: 'project_grounding',
@@ -62,24 +45,27 @@ export function checkGrounding(dir: string): Check[] {
     maxPoints: POINTS_PROJECT_GROUNDING,
     earnedPoints: groundingPoints,
     passed: groundingRatio >= 0.2,
-    detail: meaningfulEntries.length === 0
-      ? 'No project structure detected'
-      : `${mentioned.length}/${meaningfulEntries.length} project entries referenced in config (${Math.round(groundingRatio * 100)}%)`,
-    suggestion: unmentionedTopDirs.length > 0
-      ? `Config doesn't mention: ${unmentionedTopDirs.slice(0, 5).join(', ')}${unmentionedTopDirs.length > 5 ? ` (+${unmentionedTopDirs.length - 5} more)` : ''}`
-      : undefined,
-    fix: groundingPoints < POINTS_PROJECT_GROUNDING
-      ? {
-          action: 'add_references',
-          data: {
-            missing: unmentionedTopDirs.slice(0, 10),
-            mentioned: mentionedTopDirs.slice(0, 10),
-            totalEntries: meaningfulEntries.length,
-            coverage: Math.round(groundingRatio * 100),
-          },
-          instruction: `Reference these project directories in your config: ${unmentionedTopDirs.slice(0, 5).join(', ')}`,
-        }
-      : undefined,
+    detail:
+      entries.length === 0
+        ? 'No project structure detected'
+        : `${mentioned.length}/${entries.length} notable project entries referenced in config (${Math.round(groundingRatio * 100)}%)`,
+    suggestion:
+      missingHints.length > 0
+        ? `Config doesn't mention: ${missingHints.slice(0, 5).join(', ')}${missingHints.length > 5 ? ` (+${missingHints.length - 5} more)` : ''}`
+        : undefined,
+    fix:
+      groundingPoints < POINTS_PROJECT_GROUNDING
+        ? {
+            action: 'add_references',
+            data: {
+              missing: missingHints.slice(0, 10),
+              mentioned: mentionedTopDirs.slice(0, 10),
+              totalEntries: entries.length,
+              coverage: Math.round(groundingRatio * 100),
+            },
+            instruction: `Reference these project paths in your config: ${missingHints.slice(0, 5).join(', ')}`,
+          }
+        : undefined,
   });
 
   // 2. Reference density — how many specific references (backticks, paths) does the config have?
@@ -87,13 +73,13 @@ export function checkGrounding(dir: string): Check[] {
   const mdStructure = analyzeMarkdownStructure(configContent);
   const totalSpecificRefs = refs.length + mdStructure.inlineCodeCount;
 
-  const density = mdStructure.nonEmptyLines > 0
-    ? (totalSpecificRefs / mdStructure.nonEmptyLines) * 100
-    : 0;
+  const density =
+    mdStructure.nonEmptyLines > 0
+      ? (totalSpecificRefs / mdStructure.nonEmptyLines) * 100
+      : 0;
 
-  const densityPoints = configContent.length === 0
-    ? 0
-    : calculateDensityPoints(density, POINTS_REFERENCE_DENSITY);
+  const densityPoints =
+    configContent.length === 0 ? 0 : calculateDensityPoints(density, POINTS_REFERENCE_DENSITY);
 
   checks.push({
     id: 'reference_density',
@@ -102,19 +88,27 @@ export function checkGrounding(dir: string): Check[] {
     maxPoints: POINTS_REFERENCE_DENSITY,
     earnedPoints: densityPoints,
     passed: densityPoints >= Math.round(POINTS_REFERENCE_DENSITY * 0.5),
-    detail: configContent.length === 0
-      ? 'No config content'
-      : `${totalSpecificRefs} specific references across ${mdStructure.nonEmptyLines} lines (${Math.round(density)}%)`,
-    suggestion: densityPoints < Math.round(POINTS_REFERENCE_DENSITY * 0.5) && configContent.length > 0
-      ? 'Use backticks and paths to reference specific files, commands, and identifiers'
-      : undefined,
-    fix: densityPoints < Math.round(POINTS_REFERENCE_DENSITY * 0.5) && configContent.length > 0
-      ? {
-          action: 'add_inline_refs',
-          data: { currentDensity: Math.round(density), currentRefs: totalSpecificRefs, lines: mdStructure.nonEmptyLines },
-          instruction: 'Add more inline code references (backticks) for file paths, commands, and identifiers.',
-        }
-      : undefined,
+    detail:
+      configContent.length === 0
+        ? 'No config content'
+        : `${totalSpecificRefs} specific references across ${mdStructure.nonEmptyLines} lines (${Math.round(density)}%)`,
+    suggestion:
+      densityPoints < Math.round(POINTS_REFERENCE_DENSITY * 0.5) && configContent.length > 0
+        ? 'Use backticks and paths to reference specific files, commands, and identifiers'
+        : undefined,
+    fix:
+      densityPoints < Math.round(POINTS_REFERENCE_DENSITY * 0.5) && configContent.length > 0
+        ? {
+            action: 'add_inline_refs',
+            data: {
+              currentDensity: Math.round(density),
+              currentRefs: totalSpecificRefs,
+              lines: mdStructure.nonEmptyLines,
+            },
+            instruction:
+              'Add more inline code references (backticks) for file paths, commands, and identifiers.',
+          }
+        : undefined,
   });
 
   return checks;

--- a/src/scoring/constants.ts
+++ b/src/scoring/constants.ts
@@ -42,7 +42,7 @@ export const POINTS_NO_DUPLICATES = 2;
 export const POINTS_HAS_STRUCTURE = 2;
 
 // ── Grounding checks (20 pts) ────────────────────────────────────────
-/** Does the config reference the project's actual directories and files? */
+/** Does the config reference the project's directories and notable files? */
 export const POINTS_PROJECT_GROUNDING = 12;
 /** How many specific references (backticks, paths) does the config have? */
 export const POINTS_REFERENCE_DENSITY = 8;

--- a/src/scoring/utils.ts
+++ b/src/scoring/utils.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, readdirSync } from 'fs';
 import { execFileSync } from 'child_process';
-import { join, relative } from 'path';
+import { basename, join, relative } from 'path';
+import { GROUNDING_THRESHOLDS } from './constants.js';
 
 export function readFileOrNull(filePath: string): string | null {
   try {
@@ -477,6 +478,82 @@ export function isEntryMentioned(entry: string, contentLower: string): boolean {
       contentLower,
     );
   });
+}
+
+/**
+ * Entry-point basenames that match fingerprint filePriority ≥ 40.
+ * Keep in sync with `filePriority` in src/fingerprint/code-analysis.ts.
+ */
+const GROUNDING_ENTRY_POINTS = new Set([
+  'index.ts',
+  'index.js',
+  'index.tsx',
+  'index.jsx',
+  'main.ts',
+  'main.py',
+  'main.go',
+  'main.rs',
+  'app.ts',
+  'app.js',
+  'app.py',
+  'server.ts',
+  'server.js',
+  'mod.rs',
+  'lib.rs',
+]);
+
+/** Config/manifest paths that match fingerprint filePriority ≥ 35. */
+const GROUNDING_CONFIG_OR_MANIFEST_RE =
+  /\.(json|ya?ml|toml|ini|cfg)$|config\.|Makefile|Dockerfile/i;
+
+/**
+ * Whether a surveyed file is notable enough to count toward project grounding.
+ * Mirrors fingerprint `filePriority ≥ 35` (entry points + config/manifests).
+ */
+export function isNotableGroundingFile(relPath: string): boolean {
+  const base = basename(relPath);
+  return GROUNDING_ENTRY_POINTS.has(base) || GROUNDING_CONFIG_OR_MANIFEST_RE.test(relPath);
+}
+
+/**
+ * Grounding denominator: all directories plus notable files only (not every leaf file).
+ */
+export function selectGroundingEntries(structure: ProjectStructure): string[] {
+  return [
+    ...structure.dirs.filter((e) => e.length > 2),
+    ...structure.files.filter((e) => e.length > 2 && isNotableGroundingFile(e)),
+  ];
+}
+
+export interface GroundingCoverage {
+  entries: string[];
+  mentioned: string[];
+  notMentioned: string[];
+  ratio: number;
+  points: number;
+}
+
+/**
+ * Compute project-grounding coverage of config content against notable structure entries.
+ */
+export function computeGroundingCoverage(
+  contentLower: string,
+  structure: ProjectStructure,
+): GroundingCoverage {
+  const entries = selectGroundingEntries(structure);
+  const mentioned: string[] = [];
+  const notMentioned: string[] = [];
+  for (const entry of entries) {
+    if (isEntryMentioned(entry, contentLower)) {
+      mentioned.push(entry);
+    } else {
+      notMentioned.push(entry);
+    }
+  }
+  const ratio = entries.length > 0 ? mentioned.length / entries.length : 0;
+  const threshold = GROUNDING_THRESHOLDS.find((t) => ratio >= t.minRatio);
+  const points = entries.length === 0 ? 0 : (threshold?.points ?? 0);
+  return { entries, mentioned, notMentioned, ratio, points };
 }
 
 /**


### PR DESCRIPTION
## Summary
- `project_grounding` now scores against **directories + notable files** (entry points, manifests, config files — mirroring fingerprint `filePriority ≥ 35`) instead of every surveyed file, resolving the conflict with the no-tree-listings quality check.
- Shared `computeGroundingCoverage` helper used by both the scoring check and score-refine; fix hints now surface missing notable files when top-level dirs are already covered.
- Generation prompts updated to target key dirs + notable files, never tree listings.

Cherry-picked from #238 (which landed on the stale `next` branch); re-applied cleanly on `master`.

## Test plan
- [x] `npx vitest run src/scoring/__tests__/grounding.test.ts src/ai/__tests__/score-refine.test.ts` — 33 passing on master base
- [x] ESLint + `tsc --noEmit` clean
- [x] Spot-check on this repo: denominator 219 → 83, dense inline-ref config keeps full points

Closes #237

Made with [Cursor](https://cursor.com)